### PR TITLE
Add Perlin gradient noise

### DIFF
--- a/Examples/AMReX_Shapes/README.md
+++ b/Examples/AMReX_Shapes/README.md
@@ -43,3 +43,4 @@ To select different geometries, set which_geom to one of the below.
 * `which_geom = 10` Spherical shell
 * `which_geom = 11` Death star
 * `which_geom = 12` Rounded box
+* `which_geom = 13` Kern Perlin's gradient noise SDF

--- a/Examples/AMReX_Shapes/main.cpp
+++ b/Examples/AMReX_Shapes/main.cpp
@@ -163,6 +163,11 @@ main(int argc, char* argv[])
 
     func = std::make_shared<EBGeometry::RoundedBoxSDF<T>>(1.0 * Vec3::one(), 0.1);
   }
+  else if (whichGeom == 13) { // Perlin Random noise function
+    rb = RealBox({-1, -1, -1}, {1, 1, 1});
+
+    func = std::make_shared<EBGeometry::PerlinSDF<T>>(0.5, 2.0 * Vec3::one(), 0.5, 4);
+  }
 
   // AMReX uses the opposite sign.
   func = EBGeometry::Complement<T>(func);

--- a/Examples/EBGeometry_Shapes/main.cpp
+++ b/Examples/EBGeometry_Shapes/main.cpp
@@ -21,4 +21,6 @@ main()
   const EBGeometry::CapsuleSDF<T>          capsule(Vec3::zero(), Vec3::one(), 0.1);
   const EBGeometry::InfiniteConeSDF<T>     infiniteCone(Vec3::zero(), 45.0);
   const EBGeometry::ConeSDF<T>             cone(Vec3::zero(), 1.0, 45.0);
+  const EBGeometry::PerlinSDF<T>           perlin(1.0, Vec3::one(), 0.5, 10);
+  const EBGeometry::RoundedBoxSDF<T>       roundBox(Vec3::one(), 0.1);
 }

--- a/Source/EBGeometry_AnalyticDistanceFunctions.hpp
+++ b/Source/EBGeometry_AnalyticDistanceFunctions.hpp
@@ -1032,7 +1032,7 @@ protected:
 
   /*!
     @brief Ken Perlins grad function
-    @param[in] has Input parameter
+    @param[in] hash Input parameter
     @param[in] x Input parameter
     @param[in] y Input parameter
     @param[in] z Input parameter
@@ -1048,7 +1048,7 @@ protected:
 
   /*!
     @brief Octave noise function
-    @param[in] a_Input point
+    @param[in] a_point Input point
   */
   T
   noise(const Vec3T<T>& a_point) const noexcept


### PR DESCRIPTION
This PR adds Ken Perlins gradient noise function. The default permutation table is equal to the one in the original publication, but users can shuffle it by supplying an RNG.