### PR TITLE
Add SFC-based bottom-up construction of BVHs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run clang-format
         uses: jidicula/clang-format-action@v4.10.1
         with:
-          clang-format-version: '10'
+          clang-format-version: '18'
           check-path: ${{ matrix.directory }}
 
   Linux-GNU:

--- a/Docs/Sphinx/source/Concepts.rst
+++ b/Docs/Sphinx/source/Concepts.rst
@@ -50,7 +50,7 @@ An example of an implicit function for the same sphere is
    I_{\textrm{sph}}\left(\mathbf{x}\right) = \left|\mathbf{x} - \mathbf{x}_0\right|^2 - R^2.
 
 An important difference between these is the Eikonal property in :eq:`Eikonal`, ensuring that the signed distance function always returns the exact distance to the object.
-Signed distance functions are usually the more useful object, but many operations (e.g. CSG unions) do not preserve the signed distance property.
+Signed distance functions are more useful objects, but many operations (e.g. CSG unions) do not preserve the signed distance property (but still provide *bounds* for the signed distance).
 
 .. _Chap:DCEL:
 
@@ -69,7 +69,7 @@ The DCEL structures consist of the following objects:
 
 As shown in :numref:`Fig:DCEL`, half-edges circulate the inside of the facet, with pointer access to the next half-edge.
 A half-edge also stores a reference to its starting vertex, as well as a reference to its pair-edge.
-From the DCEL structure we can easily obtain all edges or vertices belonging to a single facet, and also jump to a neighboring facet by fetching the pair edge. 
+From the DCEL structure we can obtain all edges or vertices belonging to a single facet by iterating through the half-edges, and also jump to a neighboring facet by fetching the pair edge. 
 
 .. _Fig:DCEL:
 .. figure:: /_static/DCEL.png
@@ -111,7 +111,7 @@ Three cases can be distinguished:
 
    .. tip::
    
-      ``EBGeometry`` uses the crossing number algorithm by default.
+      ``EBGeometry`` uses the crossing number algorithm by default. 
       
    If the point projects to the inside of the face, the signed distance is just :math:`\mathbf{n}_f\cdot\left(\mathbf{x} - \mathbf{x}_f\right)` where :math:`\mathbf{n}_f` is the face normal and :math:`\mathbf{x}_f` is a point on the face plane (e.g., a vertex).
    If the point projects to *outside* the polygon face, the closest feature is either an edge or a vertex.
@@ -163,7 +163,7 @@ Bounding volume hierarchies
 Bounding volume hierarchies (BVHs) are tree structures where the regular nodes are bounding volumes that enclose all geometric primitives (e.g. polygon faces or implicit functions) further down in the hierarchy.
 This means that every node in a BVH is associated with a *bounding volume*.
 The bounding volume can, in principle, be any type of volume. 
-Moreover, there are two types of nodes in a BVH:
+There are two types of nodes in a BVH:
 
 * **Regular/interior nodes.** These do not contain any of the primitives/objects, but store references to subtrees (aka child nodes).
 * **Leaf nodes.** These lie at the bottom of the BVH tree and each of them contains a subset of the geometric primitives.
@@ -186,7 +186,7 @@ Note that the bounding volume for :math:`P` encloses the bounding volumes of :ma
 There is no fundamental limitation to what type of primitives/objects can be enclosed in BVHs, which makes BVHs useful beyond triangulated data sets.
 For example, analytic signed distance functions can also be embedded in BVHs, provided that we can construct bounding volumes that enclose them.
 
-.. note::
+.. important::
    
    ``EBGeometry`` is not limited to binary trees, but supports :math:`k` -ary trees where each regular node has :math:`k` child nodes. 
 
@@ -226,7 +226,10 @@ Top-down construction can thus be illustrated as a recursive procedure:
 	 if(enoughPrimitives(child)):
 	    child.topDownConstruction(child.objects)
 
-In practice, the above procedure is supplemented by more sophisticated criteria for terminating the recursion, as well as routines for creating the bounding volumes around the newly inserted nodes. 
+In practice, the above procedure is supplemented by more sophisticated criteria for terminating the recursion, as well as routines for creating the bounding volumes around the newly inserted nodes.
+
+Bottom-up construction is also possible, in which case one constructs the leaf nodes first, and then merge the nodes upward until one reaches a root node.
+In ``EBGeometry``, bottom-up construction is done by means of space-filling curves (e.g., Morton codes).
 
 Tree traversal
 --------------
@@ -237,9 +240,9 @@ For the traversal algorithm we consider the following steps:
 
 * When descending from node :math:`P` we determine that we first investigate the left subtree (node :math:`A`) since its bounding volume is closer than the bounding volumes for the other subtree.
   The other subtree will is investigated after we have recursed to the bottom of the :math:`A` subtree. 
-* Since :math:`A` is a leaf node, we find the signed distance from :math:`\mathbf{x}` to the primitives in :math:`A`.
+* Since :math:`A` is a leaf node, we compute the signed distance from :math:`\mathbf{x}` to the primitives in :math:`A`.
   This requires us to iterate over all the triangles in :math:`A`. 
-* When moving back to :math:`P`, we find that the distance to the primitives in :math:`A` is shorter than the distance from :math:`\mathbf{x}` to the bounding volume that encloses nodes :math:`B` and :math:`C`.
+* When investigating the other child node of :math:`P`, we find that the distance to the primitives in :math:`A` is shorter than the distance from :math:`\mathbf{x}` to the bounding volume that encloses nodes :math:`B` and :math:`C`.
   This immediately permits us to prune the entire subtree containing :math:`B` and :math:`C`.
 
 .. _Fig:TreePruning:
@@ -251,17 +254,19 @@ For the traversal algorithm we consider the following steps:
 
 .. warning::
    
-   Note that all BVH traversal algorithms have linear complexity when the primitives are all at approximately the same distance from the query point.
-   For example, it is necessary to traverse almost the entire tree when one tries to compute the signed distance at the origin of a tessellated sphere.
+   BVH traversal has :math:`\log N` complexity on average.
+   However in the worst case the traversal algorithm may have linear complexity if the primitives are all at approximately the same distance from the query point.
+   For example, it is necessary to traverse almost the entire tree when one tries to compute the signed distance at the origin of a tessellated sphere since all triangles and their bounding volumes are approximately at the same distance from the center.
 
-Note that types of tree traversal (that do not compute the signed distance) are also possible, e.g. we may want to compute the union :math:`I\left(\mathbf{x}\right) = \min\left(I_1\left(\mathbf{x}\right), I_2\left(\mathbf{x}\right), .\ldots\right)`.
-``EBGeometry`` supports a fairly flexible approach to the tree traversal and update algorithms.
+Other types of tree traversal (that do not compute the signed distance) are also possible.
+``EBGeometry`` supports a fairly flexible approach to the tree traversal and update algorithms such that the user is permitted to use the hierarhical traversal algorithm also for other types of operations (e.g., for finding all facets within a specified distance from a point).
 
 Octree
 ======
 
 Octrees are tree-structures where each interior node has exactly eight children.
-Such trees are usually used for spatial partitioning (and in this case the eight children have no spatial overlap), and the leaf nodes may also contain actual data. 
+Such trees are usually used for spatial partitioning.
+Unlike BVH trees, the eight child nodes have no spatial overlap.
 
 Octree construction can be done in (at least) two ways:
 
@@ -301,4 +306,6 @@ Combining objects
 * Difference.
 
 Some of these CSG operations also have smooth equivalents, i.e. for smoothing the transition between combined objects.
-Fast CSG operations are also supported by ``EBGeometry``, e.g. the BVH-accelerated CSG union where one uses the BVH when searching for the relevant geometric primitive(s). 
+Fast CSG operations are also supported by ``EBGeometry``, e.g. the BVH-accelerated CSG union where one uses the BVH when searching for the relevant geometric primitive(s).
+This functionality is motivated by the fact that a CSG union is normally implemented as :math:`\min\left(I_1, I_2, I_3, \ldots,I_N\right)`, which has :math:`\mathcal{O}\left(N\right)` complexity when there are :math:`N` objects.
+BVH trees can reduce this to :math:`\mathcal{O}\left(\log N\right)` complexity.

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -52,12 +52,13 @@ Constructing a BVH is done by
 *  Partitioning the BVH by providing a partitioning function. 
 
 The first step is usually a matter of simply constructing the root node using the full constructor, which takes a list of primitives and their associated bounding volumes. 
-The second step is to recursively build the BVH, which is done through the function ``topDownSortAndPartition()``, see the code below:
+The second step is to recursively build the BVH.
+We currently support top-down and bottom-up construction (using space-filling curves).
 
-.. literalinclude:: ../../../Source/EBGeometry_BVH.hpp
-   :language: c++
-   :lines: 29, 62-94, 217-227, 248-257, 263-268, 274-285, 404, 643,644
-   :caption: Header section of the BVH implementation.
+Top-down construction
+_____________________
+
+Top-down construction is done through the function ``topDownSortAndPartition()``, `see the doxygen API for the BVH implementation <doxygen/html/doxygen/html/classBVH_1_1NodeT.html`.
 
 The optional input arguments to ``topDownSortAndPartition`` are polymorphic functions of type indicated above, and have the following responsibilities:
 
@@ -67,6 +68,11 @@ The optional input arguments to ``topDownSortAndPartition`` are polymorphic func
 *  ``StopFunctionT`` simply takes a ``NodeT`` as input argument and determines if the node should be partitioned further.
 
 Default arguments for these are provided, bubt users are free to partition their BVHs in their own way should they choose.
+
+Bottom-up construction
+______________________
+
+TODO.
 
 .. _Chap:LinearBVH:
 

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -14,7 +14,7 @@ The full BVH is encapsulated by a class
 
 .. code-block:: c++
 
-   template <class T, class P, class BV, int K>
+   template <class T, class P, class BV, size_t K>
    class NodeT;
 
 The above template parameters are:
@@ -40,25 +40,31 @@ Bounding volumes
 *  **Axis-aligned bounding box**, which is templated as ``EBGeometry::BoundingVolumes::AABBT<T>``.
 
 For full API details, see `the doxygen API <doxygen/html/namespaceBoundingVolumes.html>`_.
+Other types of bounding volumes can in principle be added, with the only requirement being that they conform to the same interface as the ``AABB`` and ``BoundingSphere`` volumes.
 
 .. _Chap:BVHConstruction:
 
 Construction
 ------------
 
-Constructing a BVH is done by
+Constructing a BVH is done by:
 
-*  Creating a root node and providing it with the geometric primitives and their bounding volumes.
-*  Partitioning the BVH by providing a partitioning function. 
+#.  Creating a root node and providing it with the geometric primitives and their bounding volumes.
+#.  Partitioning the BVH by providing a partitioning function. 
 
 The first step is usually a matter of simply constructing the root node using the full constructor, which takes a list of primitives and their associated bounding volumes. 
 The second step is to recursively build the BVH.
 We currently support top-down and bottom-up construction (using space-filling curves).
 
+.. tip::
+
+   The default construction methods performs the hierarchical subdivision by only considering the *bounding volumes*.
+   Consequently, the build process is identical regardless of what type of primitives (e.g., triangles or analytic spheres) are contained in the BVH.
+
 Top-down construction
 _____________________
 
-Top-down construction is done through the function ``topDownSortAndPartition()``, `see the doxygen API for the BVH implementation <doxygen/html/doxygen/html/classBVH_1_1NodeT.html`.
+Top-down construction is done through the function ``topDownSortAndPartition()``, `see the doxygen API for the BVH implementation <doxygen/html/doxygen/html/classBVH_1_1NodeT.html>`_.
 
 The optional input arguments to ``topDownSortAndPartition`` are polymorphic functions of type indicated above, and have the following responsibilities:
 
@@ -72,7 +78,19 @@ Default arguments for these are provided, bubt users are free to partition their
 Bottom-up construction
 ______________________
 
-TODO.
+The bottom-up construction uses a space-filling curve (e.g., a Morton curve) for first building the leaf nodes.
+This construction is done such that each leaf node contains approximately the number of primitives, and all leaf nodes exist on the same level.
+To use bottom-up construction, one may use the member function
+
+.. literalinclude:: ../../../Source/EBGeometry_BVH.hpp
+   :language: c++
+   :lines: 298-309
+
+The template argument is the space-filling curve that the user wants to apply.
+Currently, we support Morton codes and nested indices.
+For Morton curves, one would e.g. call ``bottomUpSortAndPartition<SFC::Morton>`` while for nested indices (which are not recommended) the signature is likewise ``bottomUpSortAndPartition<SFC::Nested``.
+
+Build times for SFC-based bottom-up construction are generally speaking faster than top-down construction, but tends to produce worse trees such that traversal becomes slower. 
 
 .. _Chap:LinearBVH:
 
@@ -196,7 +214,7 @@ This function has a signature
   using Visiter = std::function<bool(const NodeType& a_node, const Meta a_meta)>;
 
 where ``NodeType`` is the type of node (which is different for full/flat BVHs), and the ``Meta`` template parameter is discussed below.
-If this function returns true, the node will be visisted and if the function returns false then the node will be pruned from the tree traversal.
+If this function returns true, the node will be visisted and if the function returns false then the node will be pruned from the tree traversal. Typically, the ``Meta`` parameter will contain the necessary information that determines whether or not to visit the subtree.
 
 Traversal pattern
 _________________
@@ -212,6 +230,9 @@ This function has the signature:
   template <class NodeType, class Meta, size_t K>
   using Sorter = std::function<void(std::array<std::pair<std::shared_ptr<const NodeType>, Meta>, K>& a_children)>;
 
+Sorting the child nodes is completely optional.
+The user can leave this function empty if it does not matter which subtrees are visited first. 
+
 Update rule
 ___________
 
@@ -222,6 +243,8 @@ These are done by a user-supplied update-rule:
 		
   template <class P>
   using Updater = std::function<void(const PrimitiveListT<P>& a_primitives)>;
+
+Typically, the ``Updater`` will modify parameters that appear in a local scope outside of the tree traversal (e.g. updating the minimum distance to a DCEL mesh).
 
 Meta-data
 _________
@@ -235,8 +258,25 @@ The signature for meta-data construction is
   template <class NodeType, class Meta>
   using MetaUpdater = std::function<Meta(const NodeType& a_node)>;
 
-Traversal example
-_________________
+The biggest difference between ``Updater`` and ``MetaUpdater`` is that ``Updater`` is *only* called on leaf nodes whereas ``MetaUpdater`` is also called for internal nodes.
+One typical example for DCEL meshes is that ``Updater`` computes the distance from an input point to the triangles in a leaf node, whereas ``MetaUpdater`` computes the distance from the input point to the bounding volumes of a child nodes.
+This information is then used in ``Sorter`` in order to determine a preferred child visit pattern when descending along subtrees. 
+
+Traversal algorithm
+___________________
+
+The code-block below shows the implementation of the BVH traversal.
+The implementation uses a non-recursive queue-based formulation when descending along subtrees.
+Observe that each entry in the stack contains both the node itself *and* any meta-data we want to attach to the node.
+If the traversal decides to visit a node, it immediately computes the specified meta-data of the node, and the user can then sort the children based on that data.
+
+.. literalinclude:: ../../../Source/EBGeometry_BVHImplem.hpp
+   :language: c++
+   :lines: 284-322
+   :caption: Tree traversal algorithm for the BVH tree.
+
+Traversal examples
+__________________
 
 The DCEL mesh distance fields use a traversal pattern based on
 
@@ -248,6 +288,6 @@ These rules are given below.
 
 .. literalinclude:: ../../../Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
    :language: c++
-   :lines: 127-161
+   :lines: 97-132
    :caption: Tree traversal criterion for computing the signed distance to a DCEL mesh using the BVH accelerator.
 	     See :file:`Source/EBGeometry_MeshDistanceFunctionsImplem.hpp` for details.

--- a/Docs/Sphinx/source/ImplemCSG.rst
+++ b/Docs/Sphinx/source/ImplemCSG.rst
@@ -37,7 +37,7 @@ These are also available through functions that automatically cast the resulting
 
 .. literalinclude:: ../../../Source/EBGeometry_Transform.hpp   
    :language: c++
-   :lines: 20-90
+   :lines: 20-111
 
 CSG operations
 --------------

--- a/Docs/Sphinx/source/ImplemDCEL.rst
+++ b/Docs/Sphinx/source/ImplemDCEL.rst
@@ -10,7 +10,7 @@ The DCEL functionality exists under the namespace ``EBGeometry::DCEL`` and conta
 
 .. important::
 
-   The DCEL functionality is *not* restricted to triangles, but supports N-sided polygons, including *meta-data* attached to the vertices, edges, and facets. 
+   The DCEL functionality is *not* restricted to triangles, but supports N-sided polygons, including *meta-data* attached to the vertices, edges, and facets. The latter is particularly useful in case on wants to associate e.g. boundary conditions to specific triangles. 
 
 Main types
 ----------
@@ -77,7 +77,7 @@ The above DCEL classes have member functions of the type:
 
 which can be used to compute the distance to the various features on the mesh.
 
-Meta-data can be attached to the DCEL primitives by selecting an appropriate type for ``Meta`` above (which defaults to ``short``). 
+Meta-data can be attached to the DCEL primitives by selecting an appropriate type for ``Meta`` above.
 
 
 .. _Chap:BVHIntegration:

--- a/Docs/Sphinx/source/ImplemOctree.rst
+++ b/Docs/Sphinx/source/ImplemOctree.rst
@@ -5,7 +5,7 @@ Octree
 
 The octree functionality is encapsulated in the namespace ``EBGeometry::Octree``.
 For the full API, see `the doxygen API <doxygen/html/namespaceOctree.html>`__.
-Currently, only full octrees are supported (i.e. pointer-based representation).
+Currently, only full octrees are supported (i.e., using a pointer-based representation).
 
 Octrees are encapsulated by a class
 

--- a/Docs/Sphinx/source/Introduction.rst
+++ b/Docs/Sphinx/source/Introduction.rst
@@ -20,13 +20,13 @@ To obtain ``EBGeometry``, clone the code from `github <https://github.com/rmrsk/
 To compile the ``EBGeometry`` example codes, navigate to the :file:`EBGeometry/Examples` folder.
 Folders that are named :file:`EBGeometry_<something>` are pure ``EBGeometry`` examples and can be compiled without any third-party dependencies.
 
-To run the ``EBGeometry`` examples, navigate to one of the folders and execute
+To run the ``EBGeometry`` examples, navigate to one of the folders in :file:`EBGeometry/Examples/EBGeometry_*` and execute
 
 .. code-block:: bash
 
-   g++ -O3 -std=c++17 main.cpp && ./a.out
+   g++ -O3 main.cpp && ./a.out
 
-All ``EBGeometry`` examples should run using this command.
+All ``EBGeometry`` examples can be run using this command.
 README files present in each folder provide more information regarding the functionality and usage of each example code.
 
 Third-party examples

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -43,10 +43,12 @@ To read one or multiple STL files and turn it into DCEL meshes, use
    :language: c++
    :lines: 53-67
 
+Note that this will only expose the DCEL mesh, but not include any signed distance functionality.
+
 DCEL mesh SDF
 _____________
 
-To read one or multiple STL files and turn it into signed distance representations, use
+To read one or multiple STL files and also turn it into signed distance representations, use
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
@@ -59,7 +61,7 @@ To read one or multiple STL files and turn it into signed distance representatio
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 85-99
+   :lines: 85-105
 
 .. _Chap:LinearSTL:
 
@@ -70,7 +72,7 @@ To read one or multiple STL files and turn it into signed distance representatio
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 101-115
+   :lines: 107-127
 
 .. _Chap:PolySoups:
 
@@ -91,11 +93,12 @@ To turn this into a DCEL mesh, one should compress the triangle soup (get rid of
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 136-165
+   :lines: 146-165
 
 The ``compress`` function will discard duplicate vertices from the soup, while the ``soupToDCEL`` will simply turn the remaining polygon soup into a DCEL mesh.
+This function will also compute the vertex and edge normal vectors.
 
-.. tip::
+.. warning::
    
    ``soupToDCEL`` will issue plenty of warnings if the polygon soup is not watertight and orientable. 
 

--- a/Docs/doxyfile
+++ b/Docs/doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../ ../Source
+INPUT                  = ./ ../ ../Source
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -873,7 +873,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                = ./README.md
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -982,7 +982,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = ../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/EBGeometry.hpp
+++ b/EBGeometry.hpp
@@ -12,6 +12,7 @@
 #include "Source/EBGeometry_Parser.hpp"
 #include "Source/EBGeometry_SFC.hpp"
 #include "Source/EBGeometry_SignedDistanceFunction.hpp"
+#include "Source/EBGeometry_SimpleTimer.hpp"
 #include "Source/EBGeometry_Transform.hpp"
 
 /*!

--- a/EBGeometry.hpp
+++ b/EBGeometry.hpp
@@ -10,6 +10,7 @@
 #include "Source/EBGeometry_MeshDistanceFunctions.hpp"
 #include "Source/EBGeometry_Octree.hpp"
 #include "Source/EBGeometry_Parser.hpp"
+#include "Source/EBGeometry_SFC.hpp"
 #include "Source/EBGeometry_SignedDistanceFunction.hpp"
 #include "Source/EBGeometry_Transform.hpp"
 

--- a/Examples/AMReX_DCEL/main.cpp
+++ b/Examples/AMReX_DCEL/main.cpp
@@ -50,7 +50,8 @@ public:
   /*!
     @brief AMReX's implicit function definition.
   */
-  Real operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+  Real
+  operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     using Vec3 = EBGeometry::Vec3T<T>;
 

--- a/Examples/AMReX_F18/main.cpp
+++ b/Examples/AMReX_F18/main.cpp
@@ -67,7 +67,8 @@ public:
     this->m_implicitFunction = a_other.m_implicitFunction;
   }
 
-  Real operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+  Real
+  operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     return Real(m_implicitFunction->value(EBGeometry::Vec3T(x, y, z)));
   };

--- a/Examples/AMReX_PackedSpheres/main.cpp
+++ b/Examples/AMReX_PackedSpheres/main.cpp
@@ -77,7 +77,8 @@ public:
     this->m_fastUnion = a_other.m_fastUnion;
   }
 
-  Real operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+  Real
+  operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     if (m_useBVH) {
       return Real(m_fastUnion->value(EBGeometry::Vec3T(x, y, z)));

--- a/Examples/AMReX_PaintEB/main.cpp
+++ b/Examples/AMReX_PaintEB/main.cpp
@@ -58,7 +58,8 @@ public:
   /*!
     @brief AMReX's implicit function definition.
   */
-  Real operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+  Real
+  operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     return m_sdf->value(EBGeometry::Vec3T<T>(x, y, z));
   };
@@ -76,7 +77,7 @@ public:
     @brief Get the face(s) that are closest to the input point. 
   */
   inline std::vector<std::pair<std::shared_ptr<const Face>, T>>
-    getClosestFaces(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+  getClosestFaces(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     return m_sdf->getClosestFaces(EBGeometry::Vec3T<T>(x, y, z), true);
   }

--- a/Examples/AMReX_RandomCity/main.cpp
+++ b/Examples/AMReX_RandomCity/main.cpp
@@ -90,7 +90,8 @@ public:
     this->m_fastUnion = a_other.m_fastUnion;
   }
 
-  Real operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+  Real
+  operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     if (m_useBVH) {
       return Real(m_fastUnion->value(EBGeometry::Vec3T(x, y, z)));

--- a/Examples/AMReX_Shapes/main.cpp
+++ b/Examples/AMReX_Shapes/main.cpp
@@ -48,7 +48,8 @@ public:
   /*!
     @brief AMReX's implicit function definition. EBGeometry sign is opposite to AMReX'
   */
-  Real operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+  Real
+  operator()(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     return -m_impFunc->value(Vec3(x, y, z));
   };

--- a/Examples/EBGeometry_DCEL/README.md
+++ b/Examples/EBGeometry_DCEL/README.md
@@ -24,4 +24,4 @@ Run it with
 
     ./a.out 'filename'
 
-where 'filename' is one of the STL files in ../Scenes/STL/.
+where 'filename' is one of the STL files in ../Resources

--- a/Source/EBGeometry_AnalyticDistanceFunctions.hpp
+++ b/Source/EBGeometry_AnalyticDistanceFunctions.hpp
@@ -905,7 +905,7 @@ public:
     m_noiseAmplitude   = a_noiseAmplitude;
     m_noiseFrequency   = a_noiseFrequency;
     m_noisePersistence = std::min(1.0, a_noisePersistence);
-    m_noiseOctaves     = std::max((unsigned int)1, a_noiseOctaves);
+    m_noiseOctaves     = std::max(static_cast<unsigned int>(1), a_noiseOctaves);
 
     // By default, use Ken Perlin's original permutation table
     for (int i = 0; i < 256; i++) {
@@ -1055,9 +1055,9 @@ protected:
   noise(const Vec3T<T>& a_point) const noexcept
   {
     // Lower cube corner
-    const int X = (int)std::floor(a_point[0]) & 255;
-    const int Y = (int)std::floor(a_point[1]) & 255;
-    const int Z = (int)std::floor(a_point[2]) & 255;
+    const int X = static_cast<int>(std::floor(a_point[0])) & 255;
+    const int Y = static_cast<int>(std::floor(a_point[1])) & 255;
+    const int Z = static_cast<int>(std::floor(a_point[2])) & 255;
 
     // Relative distance wrt lower cube corner
     const double x = a_point[0] - std::floor(a_point[0]);

--- a/Source/EBGeometry_AnalyticDistanceFunctions.hpp
+++ b/Source/EBGeometry_AnalyticDistanceFunctions.hpp
@@ -86,7 +86,7 @@ public:
     @param[in] a_point      Point on the plane
     @param[in] a_normal     Plane normal vector.
   */
-  PlaneSDF(const Vec3T<T>& a_point, const Vec3T<T>& a_normal)
+  PlaneSDF(const Vec3T<T>& a_point, const Vec3T<T>& a_normal) noexcept
   {
     m_point  = a_point;
     m_normal = a_normal / a_normal.length();
@@ -131,7 +131,7 @@ public:
     @param[in] a_center Sphere center
     @param[in] a_radius Sphere radius
   */
-  SphereSDF(const Vec3T<T>& a_center, const T& a_radius)
+  SphereSDF(const Vec3T<T>& a_center, const T& a_radius) noexcept
   {
     this->m_center = a_center;
     this->m_radius = a_radius;
@@ -140,7 +140,7 @@ public:
   /*!
     @brief Copy constructor
   */
-  SphereSDF(const SphereSDF& a_other)
+  SphereSDF(const SphereSDF& a_other) noexcept
   {
     this->m_center = a_other.m_center;
     this->m_radius = a_other.m_radius;
@@ -149,7 +149,7 @@ public:
   /*!
     @brief Destructor
   */
-  virtual ~SphereSDF() = default;
+  virtual ~SphereSDF() noexcept = default;
 
   /*!
     @brief Get center
@@ -226,7 +226,7 @@ public:
     @param[in] a_loCorner   Lower left corner
     @param[in] a_hiCorner   Upper right corner
   */
-  BoxSDF(const Vec3T<T>& a_loCorner, const Vec3T<T>& a_hiCorner)
+  BoxSDF(const Vec3T<T>& a_loCorner, const Vec3T<T>& a_hiCorner) noexcept
   {
     this->m_loCorner = a_loCorner;
     this->m_hiCorner = a_hiCorner;
@@ -235,7 +235,7 @@ public:
   /*!
     @brief Destructor (does nothing).
   */
-  virtual ~BoxSDF()
+  virtual ~BoxSDF() noexcept
   {}
 
   /*!
@@ -334,7 +334,7 @@ public:
     @param[in] a_majorRadius Major torus radius.
     @param[in] a_minorRadius Minor torus radius.
   */
-  TorusSDF(const Vec3T<T>& a_center, const T& a_majorRadius, const T& a_minorRadius)
+  TorusSDF(const Vec3T<T>& a_center, const T& a_majorRadius, const T& a_minorRadius) noexcept
   {
     this->m_center      = a_center;
     this->m_majorRadius = a_majorRadius;
@@ -344,7 +344,7 @@ public:
   /*!
     @brief Destructor (does nothing).
   */
-  virtual ~TorusSDF()
+  virtual ~TorusSDF() noexcept
   {}
 
   /*!
@@ -455,7 +455,7 @@ public:
     @param[in] a_center2    Other endpoint.
     @param[in] a_radius     Cylinder radius.
   */
-  CylinderSDF(const Vec3T<T>& a_center1, const Vec3T<T>& a_center2, const T& a_radius)
+  CylinderSDF(const Vec3T<T>& a_center1, const Vec3T<T>& a_center2, const T& a_radius) noexcept
   {
     this->m_center1 = a_center1;
     this->m_center2 = a_center2;
@@ -470,7 +470,7 @@ public:
   /*!
     @brief Destructor (does nothing).
   */
-  virtual ~CylinderSDF()
+  virtual ~CylinderSDF() noexcept
   {}
 
   /*!
@@ -592,7 +592,7 @@ public:
     @param[in] a_radius     Cylinder radius.
     @param[in] a_axis       Cylinder axis.
   */
-  InfiniteCylinderSDF(const Vec3T<T>& a_center, const T& a_radius, const size_t a_axis)
+  InfiniteCylinderSDF(const Vec3T<T>& a_center, const T& a_radius, const size_t a_axis) noexcept
   {
     m_center = a_center;
     m_radius = a_radius;
@@ -650,7 +650,7 @@ public:
     @param[in] a_tip2       Other center point.
     @param[in] a_radius     Radius.
   */
-  CapsuleSDF(const Vec3T<T>& a_tip1, const Vec3T<T> a_tip2, const T& a_radius)
+  CapsuleSDF(const Vec3T<T>& a_tip1, const Vec3T<T> a_tip2, const T& a_radius) noexcept
   {
     const Vec3T<T> axis = (a_tip2 - a_tip1) / length(a_tip2 - a_tip1);
     m_center1           = a_tip1 + a_radius * axis;
@@ -708,7 +708,7 @@ public:
     @param[in] a_tip        Cone tip position
     @param[in] a_angle      Cone opening angle.
   */
-  InfiniteConeSDF(const Vec3T<T>& a_tip, const T& a_angle)
+  InfiniteConeSDF(const Vec3T<T>& a_tip, const T& a_angle) noexcept
   {
     constexpr T pi = 3.14159265358979323846;
 
@@ -769,7 +769,7 @@ public:
     @param[in] a_height     Cone height, measured from top to bottom.
     @param[in] a_angle      Cone opening angle.
   */
-  ConeSDF(const Vec3T<T>& a_tip, const T& a_height, const T& a_angle)
+  ConeSDF(const Vec3T<T>& a_tip, const T& a_height, const T& a_angle) noexcept
   {
     constexpr T pi = 3.14159265358979323846;
 
@@ -849,7 +849,7 @@ public:
     @param[in] a_curvature Corner curvature. 
     @note Curvature must be > 0.0
   */
-  RoundedBoxSDF(const Vec3T<T>& a_dimensions, const T a_curvature)
+  RoundedBoxSDF(const Vec3T<T>& a_dimensions, const T a_curvature) noexcept
   {
     this->m_dimensions = 0.5 * a_dimensions;
 

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -297,7 +297,6 @@ namespace BVH {
     inline void
     bottomUpSortAndPartition() noexcept;
 #endif
-    
 
     /*!
       @brief Get node type

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -21,6 +21,7 @@
 
 // Our includes
 #include "EBGeometry_Vec.hpp"
+#include "EBGeometry_SFC.hpp"
 #include "EBGeometry_NamespaceHeader.hpp"
 
 /*!
@@ -283,6 +284,20 @@ namespace BVH {
     inline void
     topDownSortAndPartition(const Partitioner&  a_partitioner = BVCentroidPartitioner<T, P, BV, K>,
                             const StopFunction& a_stopCrit    = DefaultStopFunction<T, P, BV, K>) noexcept;
+
+#if __cplusplus >= 202002L
+    /*!
+      @brief Function for doing bottom-up construction using a specified space-filling curve.
+      @details The template parameter is the space-filling curve type. This function will partition the BVH
+      by first sorting the bounding volume centroids along the space-filling curve. The tree is then constructed
+      by placing at least K primitives in each leaf, and the leaves are then merged upwards until we reach the
+      root node.
+    */
+    template <SFC::Encodable S>
+    inline void
+    bottomUpSortAndPartition() noexcept;
+#endif
+    
 
     /*!
       @brief Get node type

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -140,7 +140,7 @@ namespace BVH {
     @brief Function for splitting a vector of some size into K almost-equal chunks. This is a utility function.
   */
   template <class X, size_t K>
-  auto equalCounts = [](const std::vector<X>& a_primitives) -> std::array<std::vector<X>, K> {
+  auto equalCounts = [](const std::vector<X>& a_primitives) noexcept -> std::array<std::vector<X>, K> {
     int length = a_primitives.size() / K;
     int remain = a_primitives.size() % K;
 
@@ -167,7 +167,7 @@ namespace BVH {
   */
   template <class T, class P, class BV, size_t K>
   auto PrimitiveCentroidPartitioner =
-    [](const PrimAndBVListT<P, BV>& a_primsAndBVs) -> std::array<PrimAndBVListT<P, BV>, K> {
+    [](const PrimAndBVListT<P, BV>& a_primsAndBVs) noexcept -> std::array<PrimAndBVListT<P, BV>, K> {
     Vec3T<T> lo = Vec3T<T>::max();
     Vec3T<T> hi = -Vec3T<T>::max();
 
@@ -224,7 +224,7 @@ namespace BVH {
   */
   template <class T, class P, class BV, size_t K>
   auto DefaultStopFunction =
-    [](const BVH::NodeT<T, P, BV, K>& a_node) -> bool { return (a_node.getPrimitives()).size() < K; };
+    [](const BVH::NodeT<T, P, BV, K>& a_node) noexcept -> bool { return (a_node.getPrimitives()).size() < K; };
 
   /*!
     @brief Class which encapsulates a node in a bounding volume hierarchy.

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -365,11 +365,22 @@ namespace BVH {
     inline std::shared_ptr<LinearBVH<T, P, BV, K>>
     flattenTree() const noexcept;
 
+    /*!
+      @brief Check if BVH is already partitioned
+    */
+    inline bool
+    isPartitioned() const noexcept;
+
   protected:
     /*!
       @brief Bounding volume object for enclosing everything in this node. 
     */
     BV m_boundingVolume;
+
+    /*!
+      @brief Determines whether or not the partitioning function has already been called
+    */
+    bool m_partitioned;
 
     /*!
       @brief Primitives list. This will be empty for regular nodes

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -285,24 +285,30 @@ namespace BVH {
     topDownSortAndPartition(const Partitioner&  a_partitioner = BVCentroidPartitioner<T, P, BV, K>,
                             const StopFunction& a_stopCrit    = DefaultStopFunction<T, P, BV, K>) noexcept;
 
-#if __cplusplus >= 202002L
     /*!
       @brief Function for doing bottom-up construction using a specified space-filling curve.
       @details The template parameter is the space-filling curve type. This function will partition the BVH
       by first sorting the bounding volume centroids along the space-filling curve. The tree is then constructed
       by placing at least K primitives in each leaf, and the leaves are then merged upwards until we reach the
       root node.
+      @note S must have an encode and decode function which returns an SFC index. See the SFC namespace for
+      examples for Morton and Nested indices. 
     */
-    template <SFC::Encodable S>
+    template <typename S>
     inline void
     bottomUpSortAndPartition() noexcept;
-#endif
 
     /*!
       @brief Get node type
     */
     inline bool
     isLeaf() const noexcept;
+
+    /*!
+      @brief Check if BVH is already partitioned
+    */
+    inline bool
+    isPartitioned() const noexcept;
 
     /*!
       @brief Get bounding volume
@@ -364,12 +370,6 @@ namespace BVH {
     */
     inline std::shared_ptr<LinearBVH<T, P, BV, K>>
     flattenTree() const noexcept;
-
-    /*!
-      @brief Check if BVH is already partitioned
-    */
-    inline bool
-    isPartitioned() const noexcept;
 
   protected:
     /*!
@@ -541,6 +541,12 @@ namespace BVH {
     isLeaf() const noexcept;
 
     /*!
+      @brief Check if BVH is already partitioned
+    */
+    inline bool
+    isPartitioned() const noexcept;
+
+    /*!
       @brief Get the distance from a 3D point to the bounding volume
       @param[in] a_point 3D point
       @return Returns distance to bounding volume. A zero distance implies that
@@ -563,6 +569,11 @@ namespace BVH {
       @brief Bounding volume.
     */
     BV m_boundingVolume;
+
+    /*!
+      @brief Determines whether or not the partitioning function has already been called
+    */
+    bool m_partitioned;
 
     /*!
       @brief Offset into primitives array

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -412,6 +412,14 @@ namespace BVH {
     getBoundingVolumes() noexcept;
 
     /*!
+      @brief Explicitly set this node's children.
+      @details This will turn this node into the parent node of the input children, i.e. a regular node.
+      @return m_children.
+    */
+    inline void
+    setChildren(const std::array<std::shared_ptr<NodeT<T, P, BV, K>>, K>& a_children) noexcept;        
+
+    /*!
       @brief Flatten tree method.
       @details This function will flatten everything beneath the current node and
       linearize all the nodes and primitives beneath it to a_linearNodes and

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -424,7 +424,7 @@ namespace BVH {
     /*!
       @brief Explicitly set this node's children.
       @details This will turn this node into the parent node of the input children, i.e. a regular node.
-      @return m_children.
+      @param[in] a_children Child nodes.
     */
     inline void
     setChildren(const std::array<std::shared_ptr<NodeT<T, P, BV, K>>, K>& a_children) noexcept;

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -30,6 +30,16 @@
 namespace BVH {
 
   /*!
+    @brief Enum for specifying whether or not the construction is top-down or bottom-up
+  */
+  enum class Build
+  {
+    TopDown,
+    Morton,
+    Nested
+  };
+
+  /*!
     @brief Forward declare the BVH node since it is needed for the polymorphic
     lambdas.
     @details T is the precision used in the BVH computations, P is the enclosing

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -417,7 +417,7 @@ namespace BVH {
       @return m_children.
     */
     inline void
-    setChildren(const std::array<std::shared_ptr<NodeT<T, P, BV, K>>, K>& a_children) noexcept;        
+    setChildren(const std::array<std::shared_ptr<NodeT<T, P, BV, K>>, K>& a_children) noexcept;
 
     /*!
       @brief Flatten tree method.

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -231,17 +231,16 @@ namespace BVH {
 
       // Starting at the bottom of the tree, merge the nodes upward in clusters of K.
       for (int lvl = treeDepth - 1; lvl >= 0; lvl--) {
-        const size_t numNodes = std::pow(K, lvl);
+        nodes[lvl].resize(0);
 
-        for (int inode = 0; inode < numNodes; inode++) {
+        for (int inode = 0; inode < std::pow(K, lvl); inode++) {
 
           std::array<std::shared_ptr<NodeT<T, P, BV, K>>, K> children;
 
           for (int child = 0; child < K; child++) {
-            children[child] = nodes[lvl - 1][inode * K + child];
+            children[child] = nodes[lvl + 1][inode * K + child];
           }
 
-          // The root node (i.e., this node) already exists so don't reset it.
           if (lvl > 0) {
             nodes[lvl].emplace_back(std::make_shared<NodeT<T, P, BV, K>>());
           }
@@ -270,7 +269,7 @@ namespace BVH {
     m_primitives.resize(0);
     m_boundingVolumes.resize(0);
 
-    m_boundingVolume = BV(m_boundingVolumes);
+    m_boundingVolume = BV(boundingVolumes);
     m_children       = a_children;
     m_partitioned    = true;
   }

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -198,13 +198,43 @@ namespace BVH {
     const size_t treeDepth     = std::floor(log(numPrimitives) / log(K));
     const size_t numLeaves     = std::pow(K, treeDepth);
     const size_t primsPerLeaf  = numPrimitives / numLeaves;
-    const size_t remainder     = numPrimitives % numLeaves;
 
-    std::cout << numPrimitives << "\t" << treeDepth << "\t" << numLeaves << "\t" << primsPerLeaf << "\t" << remainder
-              << "\t" << std::endl;
+    if (treeDepth > 0) {
 
-    // Build the leaves -- this node will always be the root node.
-    std::vector<std::shared_ptr<NodeT<T, P, BV, K>>> leaves;
+      // Build the leaves by partitioning the primitives along the SFC.
+      std::vector<std::vector<std::shared_ptr<NodeT<T, P, BV, K>>>> nodes(treeDepth + 1);
+
+      size_t startIndex = 0;
+      size_t endIndex   = 0;
+      size_t remainder  = numPrimitives % numLeaves;
+
+      for (size_t ileaf = 0; ileaf < numLeaves; ileaf++) {
+        endIndex = startIndex + primsPerLeaf - 1;
+
+        if (remainder > 0) {
+          endIndex  = endIndex + 1;
+          remainder = remainder - 1;
+        }
+
+        std::vector<BVH::PrimAndBV<P, BV>> primsAndBVs;
+
+        for (size_t i = startIndex; i <= endIndex; i++) {
+          const auto& cur = sortedPrimitives[i];
+
+          primsAndBVs.emplace_back(std::get<0>(cur), std::get<1>(cur));
+        }
+
+        nodes[treeDepth].emplace_back(std::make_shared<NodeT<T, P, BV, K>>(primsAndBVs));
+
+        startIndex = endIndex + 1;
+      }
+
+      // Starting at the bottom of the tree, merge the nodes.
+      for (int lvl = treeDepth - 1; lvl > 0; lvl--) {
+      }
+
+      // This node is the root node of the tree.
+    }
 
     m_partitioned = true;
   }

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -172,8 +172,9 @@ namespace BVH {
     for (const auto& bv : m_boundingVolumes) {
       const Vec3 curBin = (bv.getCentroid() - minCoord) / delta;
 
-      bins.emplace_back(SFC::Index{
-        (unsigned int)std::floor(curBin[0]), (unsigned int)std::floor(curBin[1]), (unsigned int)std::floor(curBin[2])});
+      bins.emplace_back(SFC::Index{static_cast<unsigned int>(std::floor(curBin[0])),
+                                   static_cast<unsigned int>(std::floor(curBin[1])),
+                                   static_cast<unsigned int>(std::floor(curBin[2]))});
     }
 
     // Sort the primitives, their BVs, and their spatial bins along the space-filling curves.
@@ -181,7 +182,7 @@ namespace BVH {
 
     std::vector<PrimBvAndCode> sortedPrimitives;
 
-    for (int i = 0; i < m_primitives.size(); i++) {
+    for (size_t i = 0; i < m_primitives.size(); i++) {
       sortedPrimitives.emplace_back(std::make_tuple(m_primitives[i], m_boundingVolumes[i], S::encode(bins[i])));
     }
 
@@ -230,25 +231,25 @@ namespace BVH {
       }
 
       // Starting at the bottom of the tree, merge the nodes upward in clusters of K.
-      for (int lvl = treeDepth - 1; lvl >= 0; lvl--) {
-        nodes[lvl].resize(0);
+      for (int lvl = static_cast<int>(treeDepth) - 1; lvl >= 0; lvl--) {
+        nodes[static_cast<size_t>(lvl)].resize(0);
 
-        for (int inode = 0; inode < std::pow(K, lvl); inode++) {
+        for (size_t inode = 0; inode < std::pow(K, lvl); inode++) {
 
           std::array<std::shared_ptr<NodeT<T, P, BV, K>>, K> children;
 
-          for (int child = 0; child < K; child++) {
-            children[child] = nodes[lvl + 1][inode * K + child];
+          for (size_t child = 0; child < K; child++) {
+            children[child] = nodes[static_cast<size_t>(lvl + 1)][inode * K + child];
           }
 
           if (lvl > 0) {
-            nodes[lvl].emplace_back(std::make_shared<NodeT<T, P, BV, K>>());
+            nodes[static_cast<size_t>(lvl)].emplace_back(std::make_shared<NodeT<T, P, BV, K>>());
           }
           else {
-            nodes[lvl].emplace_back(this->shared_from_this());
+            nodes[static_cast<size_t>(lvl)].emplace_back(this->shared_from_this());
           }
 
-          nodes[lvl].back()->setChildren(children);
+          nodes[static_cast<size_t>(lvl)].back()->setChildren(children);
         }
       }
     }
@@ -552,8 +553,8 @@ namespace BVH {
           const size_t& offset  = node->getPrimitivesOffset();
           const size_t& numPrim = node->getNumPrimitives();
 
-          const auto first = m_primitives.begin() + offset;
-          const auto last  = first + numPrim;
+          const auto first = m_primitives.begin() + static_cast<long int>(offset);
+          const auto last  = first + static_cast<long int>(numPrim);
 
           // User-based update rule.
           a_updater(PrimitiveList(first, last));

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -140,7 +140,16 @@ namespace BVH {
   inline void
   NodeT<T, P, BV, K>::bottomUpSortAndPartition() noexcept
   {
-#error "NodeT<T, P, BV, K>::bottomUpSortAndPartition not implemented yet"
+    // Get the centroids for all the primitives.
+    std::vector<Vec3> bvCentroids;
+
+    Vec3 min = +Vec3::infinity();
+    Vec3 max = -Vec3::infinity();
+
+    for (const auto& bv : m_boundingVolumes) {
+      bvCentroids.emplace_back(bv.getCentroid());
+    }
+#warning "NodeT<T, P, BV, K>::bottomUpSortAndPartition not implemented yet"
   }
 #endif
 

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -230,8 +230,7 @@ namespace BVH {
       }
 
       // Starting at the bottom of the tree, merge the nodes upward in clusters of K.
-      for (int lvl = treeDepth - 1; lvl > 0; lvl--) {
-
+      for (int lvl = treeDepth - 1; lvl >= 0; lvl--) {
         const size_t numNodes = std::pow(K, lvl);
 
         for (int inode = 0; inode < numNodes; inode++) {
@@ -242,6 +241,7 @@ namespace BVH {
             children[child] = nodes[lvl - 1][inode * K + child];
           }
 
+          // The root node (i.e., this node) already exists so don't reset it.
           if (lvl > 0) {
             nodes[lvl].emplace_back(std::make_shared<NodeT<T, P, BV, K>>());
           }

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -134,6 +134,16 @@ namespace BVH {
     }
   }
 
+#if __cplusplus >= 202002L
+  template <class T, class P, class BV, size_t K>
+  template <SFC::Encodable S>
+  inline void
+  NodeT<T, P, BV, K>::bottomUpSortAndPartition() noexcept
+  {
+#error "NodeT<T, P, BV, K>::bottomUpSortAndPartition not implemented yet"
+  }
+#endif
+
   template <class T, class P, class BV, size_t K>
   inline T
   NodeT<T, P, BV, K>::getDistanceToBoundingVolume(const Vec3& a_point) const noexcept

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -163,7 +163,8 @@ namespace BVH {
         (unsigned int)std::floor(curBin[0]), (unsigned int)std::floor(curBin[1]), (unsigned int)std::floor(curBin[2])});
     }
 
-    std::cout << bins.size() << std::endl;
+    // Sort the bins along the space-filling curves.
+    SFC::sort<S>(bins);
   }
 #endif
 

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -147,9 +147,8 @@ namespace BVH {
     m_partitioned = true;
   }
 
-#if __cplusplus >= 202002L
   template <class T, class P, class BV, size_t K>
-  template <SFC::Encodable S>
+  template <typename S>
   inline void
   NodeT<T, P, BV, K>::bottomUpSortAndPartition() noexcept
   {
@@ -192,12 +191,23 @@ namespace BVH {
 
     std::sort(std::begin(sortedPrimitives), std::end(sortedPrimitives), sortCrit);
 
-    // Go through the SFC and merge leaves that are nearby. This is done recursively so we end up with
+    // Go through the SFC and merge leaves that are nearby. We are trying to build a _balanced_
+    // tree where all the leaves exist on the same level, so the numb
     // a root node in the end.
+    const size_t numPrimitives = sortedPrimitives.size();
+    const size_t treeDepth     = std::floor(log(numPrimitives) / log(K));
+    const size_t numLeaves     = std::pow(K, treeDepth);
+    const size_t primsPerLeaf  = numPrimitives / numLeaves;
+    const size_t remainder     = numPrimitives % numLeaves;
+
+    std::cout << numPrimitives << "\t" << treeDepth << "\t" << numLeaves << "\t" << primsPerLeaf << "\t" << remainder
+              << "\t" << std::endl;
+
+    // Build the leaves -- this node will always be the root node.
+    std::vector<std::shared_ptr<NodeT<T, P, BV, K>>> leaves;
 
     m_partitioned = true;
   }
-#endif
 
   template <class T, class P, class BV, size_t K>
   inline T
@@ -388,6 +398,12 @@ namespace BVH {
   LinearNodeT<T, P, BV, K>::isLeaf() const noexcept
   {
     return m_numPrimitives > 0;
+  }
+  template <class T, class P, class BV, size_t K>
+  inline bool
+  LinearNodeT<T, P, BV, K>::isPartitioned() const noexcept
+  {
+    return m_partitioned;
   }
 
   template <class T, class P, class BV, size_t K>

--- a/Source/EBGeometry_BoundingVolumes.hpp
+++ b/Source/EBGeometry_BoundingVolumes.hpp
@@ -64,27 +64,27 @@ namespace BoundingVolumes {
     /*!
       @brief Default constructor. Leaves object in undefined state.
     */
-    BoundingSphereT();
+    inline BoundingSphereT() noexcept;
 
     /*!
       @brief Full constructor. Sets the center and radius of the bounding sphere.
       @param[in] a_center Bounding sphere center
       @param[in] a_radius Bounding sphere radius
     */
-    BoundingSphereT(const Vec3T<T>& a_center, const T& a_radius);
+    inline BoundingSphereT(const Vec3T<T>& a_center, const T& a_radius) noexcept;
 
     /*!
       @brief Full constructor. Constructs a bounding sphere that encloses all the
       other bounding spheres
       @param[in] a_otherSpheres Other bounding spheres.
     */
-    BoundingSphereT(const std::vector<BoundingSphereT<T>>& a_otherSpheres);
+    inline BoundingSphereT(const std::vector<BoundingSphereT<T>>& a_otherSpheres) noexcept;
 
     /*!
       @brief Copy constructor. Sets the center and radius from the other sphere.
       @param[in] a_other Other sphere
     */
-    BoundingSphereT(const BoundingSphereT& a_other);
+    inline BoundingSphereT(const BoundingSphereT& a_other) noexcept;
 
     /*!
       @brief Template constructor which takes a set of 3D points (mixed precision
@@ -95,13 +95,13 @@ namespace BoundingVolumes {
       @note This calls the define(...) function.
     */
     template <class P>
-    BoundingSphereT(const std::vector<Vec3T<P>>&   a_points,
-                    const BoundingVolumeAlgorithm& a_alg = BoundingVolumeAlgorithm::Ritter);
+    inline BoundingSphereT(const std::vector<Vec3T<P>>&   a_points,
+                           const BoundingVolumeAlgorithm& a_alg = BoundingVolumeAlgorithm::Ritter) noexcept;
 
     /*!
       @brief Destructor (does nothing).
     */
-    virtual ~BoundingSphereT();
+    virtual ~BoundingSphereT() noexcept;
 
     /*!
       @brief Copy assignment operator
@@ -235,27 +235,27 @@ namespace BoundingVolumes {
     /*!
       @brief Default constructor (does nothing)
     */
-    AABBT();
+    inline AABBT() noexcept;
 
     /*!
       @brief Full constructor taking the low/high corners of the bounding box
       @param[in] a_lo Low corner
       @param[in] a_hi High
     */
-    AABBT(const Vec3T<T>& a_lo, const Vec3T<T>& a_hi);
+    inline AABBT(const Vec3T<T>& a_lo, const Vec3T<T>& a_hi) noexcept;
 
     /*!
       @brief Copy constructor of another bounding box
       @param[in] a_other Other bounding box
     */
-    AABBT(const AABBT& a_other);
+    inline AABBT(const AABBT& a_other) noexcept;
 
     /*!
       @brief Constructor which creates an AABB which encloses a set of other
       AABBs.
       @param[in] a_others Other bounding boxes
     */
-    AABBT(const std::vector<AABBT<T>>& a_others);
+    inline AABBT(const std::vector<AABBT<T>>& a_others) noexcept;
 
     /*!
       @brief Template constructor (since mixed precision allowed) which creates an
@@ -264,12 +264,12 @@ namespace BoundingVolumes {
       @note Calls the define function
     */
     template <class P>
-    AABBT(const std::vector<Vec3T<P>>& a_points);
+    inline AABBT(const std::vector<Vec3T<P>>& a_points) noexcept;
 
     /*!
       @brief Destructor (does nothing)
     */
-    virtual ~AABBT();
+    virtual ~AABBT() noexcept;
 
     /*!
       @brief Copy assignment

--- a/Source/EBGeometry_BoundingVolumesImplem.hpp
+++ b/Source/EBGeometry_BoundingVolumesImplem.hpp
@@ -139,14 +139,15 @@ namespace BoundingVolumes {
 
     constexpr T half = 0.5;
 
-    constexpr size_t DIM = 3;
+    constexpr size_t BoundingVolumeDIM = 3;
 
     // INITIAL PASS
-    std::vector<Vec3> min_coord(DIM, a_points[0]); // [0] = Minimum x, [1] = Minimum y, [2] = Minimum z
-    std::vector<Vec3> max_coord(DIM, a_points[0]);
+    // [0] = Minimum x, [1] = Minimum y, [2] = Minimum z
+    std::vector<Vec3> min_coord(BoundingVolumeDIM, a_points[0]);
+    std::vector<Vec3> max_coord(BoundingVolumeDIM, a_points[0]);
 
     for (size_t i = 1; i < a_points.size(); i++) {
-      for (size_t dir = 0; dir < DIM; dir++) {
+      for (size_t dir = 0; dir < BoundingVolumeDIM; dir++) {
         Vec3& min = min_coord[dir];
         Vec3& max = max_coord[dir];
 
@@ -161,7 +162,7 @@ namespace BoundingVolumes {
 
     T    dist = -1;
     Vec3 v, p1, p2;
-    for (size_t dir = 0; dir < DIM; dir++) {
+    for (size_t dir = 0; dir < BoundingVolumeDIM; dir++) {
       const T len = (max_coord[dir] - min_coord[dir]).length();
       if (len > dist) {
         dist = len;
@@ -399,15 +400,15 @@ namespace BoundingVolumes {
   inline T
   AABBT<T>::getArea() const noexcept
   {
-    constexpr size_t DIM = 3;
+    constexpr size_t BoundingVolumeDIM = 3;
 
     T ret = 0.0;
 
     const auto delta = m_hiCorner - m_loCorner;
 
-    for (size_t dir = 0; dir < DIM; dir++) {
-      const size_t otherDir1 = (dir + 1) % DIM;
-      const size_t otherDir2 = (dir + 2) % DIM;
+    for (size_t dir = 0; dir < BoundingVolumeDIM; dir++) {
+      const size_t otherDir1 = (dir + 1) % BoundingVolumeDIM;
+      const size_t otherDir2 = (dir + 2) % BoundingVolumeDIM;
 
       ret += 2.0 * delta[otherDir1] * delta[otherDir2];
     }

--- a/Source/EBGeometry_BoundingVolumesImplem.hpp
+++ b/Source/EBGeometry_BoundingVolumesImplem.hpp
@@ -22,28 +22,28 @@
 namespace BoundingVolumes {
 
   template <class T>
-  inline BoundingSphereT<T>::BoundingSphereT()
+  inline BoundingSphereT<T>::BoundingSphereT() noexcept
   {
     m_radius = 0.0;
     m_center = Vec3::zero();
   }
 
   template <class T>
-  inline BoundingSphereT<T>::BoundingSphereT(const Vec3T<T>& a_center, const T& a_radius)
+  inline BoundingSphereT<T>::BoundingSphereT(const Vec3T<T>& a_center, const T& a_radius) noexcept
   {
     m_center = a_center;
     m_radius = a_radius;
   }
 
   template <class T>
-  BoundingSphereT<T>::BoundingSphereT(const BoundingSphereT& a_other)
+  BoundingSphereT<T>::BoundingSphereT(const BoundingSphereT& a_other) noexcept
   {
     m_radius = a_other.m_radius;
     m_center = a_other.m_center;
   }
 
   template <class T>
-  BoundingSphereT<T>::BoundingSphereT(const std::vector<BoundingSphereT<T>>& a_otherSpheres)
+  BoundingSphereT<T>::BoundingSphereT(const std::vector<BoundingSphereT<T>>& a_otherSpheres) noexcept
   {
 
     // TLDR: Spheres enclosing other spheres is a difficult problem, but a sphere
@@ -65,13 +65,13 @@ namespace BoundingVolumes {
 
   template <class T>
   template <class P>
-  BoundingSphereT<T>::BoundingSphereT(const std::vector<Vec3T<P>>& a_points, const BoundingVolumeAlgorithm& a_algorithm)
+  BoundingSphereT<T>::BoundingSphereT(const std::vector<Vec3T<P>>& a_points, const BoundingVolumeAlgorithm& a_algorithm) noexcept
   {
     this->define(a_points, a_algorithm);
   }
 
   template <class T>
-  BoundingSphereT<T>::~BoundingSphereT()
+  BoundingSphereT<T>::~BoundingSphereT() noexcept
   {}
 
   template <class T>
@@ -238,28 +238,28 @@ namespace BoundingVolumes {
   }
 
   template <class T>
-  AABBT<T>::AABBT()
+  AABBT<T>::AABBT()noexcept
   {
     m_loCorner = Vec3::zero();
     m_hiCorner = Vec3::zero();
   }
 
   template <class T>
-  AABBT<T>::AABBT(const Vec3T<T>& a_lo, const Vec3T<T>& a_hi)
+  AABBT<T>::AABBT(const Vec3T<T>& a_lo, const Vec3T<T>& a_hi) noexcept
   {
     m_loCorner = a_lo;
     m_hiCorner = a_hi;
   }
 
   template <class T>
-  AABBT<T>::AABBT(const AABBT<T>& a_other)
+  AABBT<T>::AABBT(const AABBT<T>& a_other) noexcept
   {
     m_loCorner = a_other.m_loCorner;
     m_hiCorner = a_other.m_hiCorner;
   }
 
   template <class T>
-  AABBT<T>::AABBT(const std::vector<AABBT<T>>& a_others)
+  AABBT<T>::AABBT(const std::vector<AABBT<T>>& a_others)noexcept
   {
     m_loCorner = a_others.front().getLowCorner();
     m_hiCorner = a_others.front().getHighCorner();
@@ -272,13 +272,13 @@ namespace BoundingVolumes {
 
   template <class T>
   template <class P>
-  AABBT<T>::AABBT(const std::vector<Vec3T<P>>& a_points)
+  AABBT<T>::AABBT(const std::vector<Vec3T<P>>& a_points) noexcept
   {
     this->define(a_points);
   }
 
   template <class T>
-  AABBT<T>::~AABBT()
+  AABBT<T>::~AABBT() noexcept
   {}
 
   template <class T>

--- a/Source/EBGeometry_BoundingVolumesImplem.hpp
+++ b/Source/EBGeometry_BoundingVolumesImplem.hpp
@@ -65,7 +65,8 @@ namespace BoundingVolumes {
 
   template <class T>
   template <class P>
-  BoundingSphereT<T>::BoundingSphereT(const std::vector<Vec3T<P>>& a_points, const BoundingVolumeAlgorithm& a_algorithm) noexcept
+  BoundingSphereT<T>::BoundingSphereT(const std::vector<Vec3T<P>>&   a_points,
+                                      const BoundingVolumeAlgorithm& a_algorithm) noexcept
   {
     this->define(a_points, a_algorithm);
   }
@@ -238,7 +239,7 @@ namespace BoundingVolumes {
   }
 
   template <class T>
-  AABBT<T>::AABBT()noexcept
+  AABBT<T>::AABBT() noexcept
   {
     m_loCorner = Vec3::zero();
     m_hiCorner = Vec3::zero();
@@ -259,7 +260,7 @@ namespace BoundingVolumes {
   }
 
   template <class T>
-  AABBT<T>::AABBT(const std::vector<AABBT<T>>& a_others)noexcept
+  AABBT<T>::AABBT(const std::vector<AABBT<T>>& a_others) noexcept
   {
     m_loCorner = a_others.front().getLowCorner();
     m_hiCorner = a_others.front().getHighCorner();

--- a/Source/EBGeometry_CSG.hpp
+++ b/Source/EBGeometry_CSG.hpp
@@ -358,10 +358,12 @@ protected:
 
   /*!
     @brief Build BVH tree for the input objects. 
-    @param[in] a_primsAndBVs Geometric primitives and their bounding volumes. 
+    @param[in] a_primsAndBVs Geometric primitives and their bounding volumes.
+    @param[in] a_build Build method (see EBGeometry_BVH.hpp)
   */
   inline void
-  buildTree(const std::vector<std::pair<std::shared_ptr<const P>, BV>>& a_primsAndBVs) noexcept;
+  buildTree(const std::vector<std::pair<std::shared_ptr<const P>, BV>>& a_primsAndBVs,
+            const BVH::Build                                            a_build = BVH::Build::TopDown) noexcept;
 };
 
 /*!

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -319,18 +319,18 @@ FastUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
   T minDist = std::numeric_limits<T>::infinity();
 
   BVH::Updater<P> updater = [&minDist,
-                             &a_point](const std::vector<std::shared_ptr<const P>>& a_implicitFunctions) -> void {
+                             &a_point](const std::vector<std::shared_ptr<const P>>& a_implicitFunctions) noexcept -> void {
     for (const auto& implicitFunction : a_implicitFunctions) {
       minDist = std::min(minDist, implicitFunction->value(a_point));
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&minDist](const Node& a_node, const T& a_bvDist) -> bool {
+  BVH::Visiter<Node, T> visiter = [&minDist](const Node& a_node, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= 0.0 || a_bvDist <= minDist;
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) -> void {
+    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(),
       a_leaves.end(),
@@ -338,7 +338,7 @@ FastUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
-  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) -> T {
+  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) noexcept -> T {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
@@ -378,7 +378,7 @@ FastSmoothUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
   T b = std::numeric_limits<T>::infinity();
 
   BVH::Updater<P> updater =
-    [&a, &b, &a_point](const std::vector<std::shared_ptr<const P>>& a_implicitFunctions) -> void {
+    [&a, &b, &a_point](const std::vector<std::shared_ptr<const P>>& a_implicitFunctions) noexcept -> void {
     for (const auto& implicitFunction : a_implicitFunctions) {
       const auto& d = implicitFunction->value(a_point);
 
@@ -392,12 +392,12 @@ FastSmoothUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&a, &b](const Node& a_node, const T& a_bvDist) -> bool {
+  BVH::Visiter<Node, T> visiter = [&a, &b](const Node& a_node, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= 0.0 || a_bvDist <= a || a_bvDist <= b;
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) -> void {
+    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(),
       a_leaves.end(),
@@ -405,7 +405,7 @@ FastSmoothUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
-  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) -> T {
+  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) noexcept -> T {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -281,12 +281,33 @@ FastUnionIF<T, P, BV, K>::FastUnionIF(const std::vector<std::shared_ptr<P>>& a_p
 
 template <class T, class P, class BV, size_t K>
 void
-FastUnionIF<T, P, BV, K>::buildTree(const std::vector<std::pair<std::shared_ptr<const P>, BV>>& a_primsAndBVs) noexcept
+FastUnionIF<T, P, BV, K>::buildTree(const std::vector<std::pair<std::shared_ptr<const P>, BV>>& a_primsAndBVs,
+                                    const BVH::Build                                            a_build) noexcept
 {
   // Init the root node, partition it, and flatten it.
   auto root = std::make_shared<EBGeometry::BVH::NodeT<T, P, BV, K>>(a_primsAndBVs);
 
-  root->topDownSortAndPartition();
+  switch (a_build) {
+  case BVH::Build::TopDown: {
+    root->topDownSortAndPartition();
+
+    break;
+  }
+  case BVH::Build::Morton: {
+    root->template bottomUpSortAndPartition<SFC::Morton>();
+
+    break;
+  }
+  case BVH::Build::Nested: {
+    root->template bottomUpSortAndPartition<SFC::Nested>();
+
+    break;
+  }
+  default: {
+    std::cerr << "EBGeometry_CSGImplem.hpp in FastUnionIF::buildTree - unsupported build method requested" << std::endl;
+    break;
+  }
+  }
 
   m_bvh = root->flattenTree();
 }

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -318,8 +318,8 @@ FastUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
 {
   T minDist = std::numeric_limits<T>::infinity();
 
-  BVH::Updater<P> updater = [&minDist,
-                             &a_point](const std::vector<std::shared_ptr<const P>>& a_implicitFunctions) noexcept -> void {
+  BVH::Updater<P> updater =
+    [&minDist, &a_point](const std::vector<std::shared_ptr<const P>>& a_implicitFunctions) noexcept -> void {
     for (const auto& implicitFunction : a_implicitFunctions) {
       minDist = std::min(minDist, implicitFunction->value(a_point));
     }

--- a/Source/EBGeometry_DCEL_Mesh.hpp
+++ b/Source/EBGeometry_DCEL_Mesh.hpp
@@ -108,7 +108,7 @@ namespace DCEL {
     /*!
       @brief Default constructor. Leaves unobject in an unusable state
     */
-    MeshT();
+    MeshT() noexcept;
 
     /*!
       @brief Disallowed copy construction
@@ -127,12 +127,12 @@ namespace DCEL {
       description. This is usually done through a file parser which reads a mesh
       file format and creates the DCEL mesh structure
     */
-    MeshT(std::vector<FacePtr>& a_faces, std::vector<EdgePtr>& a_edges, std::vector<VertexPtr>& a_vertices);
+    MeshT(std::vector<FacePtr>& a_faces, std::vector<EdgePtr>& a_edges, std::vector<VertexPtr>& a_vertices) noexcept;
 
     /*!
       @brief Destructor (does nothing)
     */
-    virtual ~MeshT();
+    virtual ~MeshT() noexcept;
 
     /*!
       @brief Define function. Puts Mesh in usable state.

--- a/Source/EBGeometry_DCEL_MeshImplem.hpp
+++ b/Source/EBGeometry_DCEL_MeshImplem.hpp
@@ -23,7 +23,7 @@
 namespace DCEL {
 
   template <class T, class Meta>
-  inline MeshT<T, Meta>::MeshT()
+  inline MeshT<T, Meta>::MeshT() noexcept
   {
     m_algorithm = SearchAlgorithm::Direct2;
   }
@@ -31,14 +31,14 @@ namespace DCEL {
   template <class T, class Meta>
   inline MeshT<T, Meta>::MeshT(std::vector<FacePtr>&   a_faces,
                                std::vector<EdgePtr>&   a_edges,
-                               std::vector<VertexPtr>& a_vertices)
+                               std::vector<VertexPtr>& a_vertices) noexcept
     : MeshT()
   {
     this->define(a_faces, a_edges, a_vertices);
   }
 
   template <class T, class Meta>
-  inline MeshT<T, Meta>::~MeshT()
+  inline MeshT<T, Meta>::~MeshT() noexcept
   {}
 
   template <class T, class Meta>

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -23,12 +23,14 @@ namespace DCEL {
 
   /*!
     @brief One-liner for turning a DCEL mesh into a full-tree BVH. 
-    @param[in] a_dcelMesh Input DCEL mesh. 
+    @param[in] a_dcelMesh Input DCEL mesh.
+    @param[in] a_build Build specification for BVH.
     @return Returns a pointer to a full-tree BVH representation of the DCEL faces.
   */
   template <class T, class Meta, class BV, size_t K>
   std::shared_ptr<EBGeometry::BVH::NodeT<T, FaceT<T, Meta>, BV, K>>
-  buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcelMesh);
+  buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcelMesh,
+               const BVH::Build                                         a_build = BVH::Build::TopDown) noexcept;
 } // namespace DCEL
 
 /*!
@@ -114,8 +116,10 @@ public:
 
   /*!
     @brief Full constructor. Takes the input mesh and creates the BVH.
+    @param[in] a_mesh Input mesh
+    @param[in] a_build Specification of build method. Must be TopDown, Morton, or Nested.
   */
-  FastMeshSDF(const std::shared_ptr<Mesh>& a_mesh) noexcept;
+  FastMeshSDF(const std::shared_ptr<Mesh>& a_mesh, const BVH::Build a_build = BVH::Build::TopDown) noexcept;
 
   /*!
     @brief Destructor
@@ -200,8 +204,9 @@ public:
   /*!
     @brief Full constructor. Takes the input mesh and creates the BVH.
     @param[in] a_mesh Input mesh
+    @param[in] a_build Build specification. Either top-down, Morton, or Nested.
   */
-  FastCompactMeshSDF(const std::shared_ptr<Mesh>& a_mesh) noexcept;
+  FastCompactMeshSDF(const std::shared_ptr<Mesh>& a_mesh, const BVH::Build a_build = BVH::Build::TopDown) noexcept;
 
   /*!
     @brief Destructor

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -33,7 +33,7 @@ DCEL::buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dc
   // Partition the BVH using the default input arguments.
   auto bvh = std::make_shared<EBGeometry::BVH::NodeT<T, Prim, BV, K>>(primsAndBVs);
 
-#if 1
+#if 0
 #warning "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
   bvh->template bottomUpSortAndPartition<SFC::Morton>();
 #else

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -100,7 +100,8 @@ FastMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexc
 {
   T minDist = std::numeric_limits<T>::infinity();
 
-  BVH::Updater<Face> updater = [&minDist, &a_point](const std::vector<std::shared_ptr<const Face>>& faces) noexcept -> void {
+  BVH::Updater<Face> updater = [&minDist,
+                                &a_point](const std::vector<std::shared_ptr<const Face>>& faces) noexcept -> void {
     for (const auto& f : faces) {
       const T curDist = f->signedDistance(a_point);
 

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -33,10 +33,12 @@ DCEL::buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dc
   // Partition the BVH using the default input arguments.
   auto bvh = std::make_shared<EBGeometry::BVH::NodeT<T, Prim, BV, K>>(primsAndBVs);
 
+#if 1
 #warning "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
   bvh->template bottomUpSortAndPartition<SFC::Morton>();
-
+#else
   bvh->topDownSortAndPartition();
+#endif
 
   return bvh;
 }

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -34,9 +34,10 @@ DCEL::buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dc
   auto bvh = std::make_shared<EBGeometry::BVH::NodeT<T, Prim, BV, K>>(primsAndBVs);
 
 #if __cplusplus >= 202002L // Development code
-#warning "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
+#warning \
+  "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
   bvh->template bottomUpSortAndPartition<SFC::Morton>();
-#endif        
+#endif
 
   bvh->topDownSortAndPartition();
 

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -33,10 +33,8 @@ DCEL::buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dc
   // Partition the BVH using the default input arguments.
   auto bvh = std::make_shared<EBGeometry::BVH::NodeT<T, Prim, BV, K>>(primsAndBVs);
 
-#if __cplusplus >= 202002L // Development code
 #warning "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
   bvh->template bottomUpSortAndPartition<SFC::Morton>();
-#endif
 
   bvh->topDownSortAndPartition();
 

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -100,7 +100,7 @@ FastMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexc
 {
   T minDist = std::numeric_limits<T>::infinity();
 
-  BVH::Updater<Face> updater = [&minDist, &a_point](const std::vector<std::shared_ptr<const Face>>& faces) -> void {
+  BVH::Updater<Face> updater = [&minDist, &a_point](const std::vector<std::shared_ptr<const Face>>& faces) noexcept -> void {
     for (const auto& f : faces) {
       const T curDist = f->signedDistance(a_point);
 
@@ -108,12 +108,12 @@ FastMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexc
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&minDist, &a_point](const Node& a_node, const T& a_bvDist) -> bool {
+  BVH::Visiter<Node, T> visiter = [&minDist, &a_point](const Node& a_node, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= std::abs(minDist);
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) -> void {
+    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(),
       a_leaves.end(),
@@ -121,7 +121,7 @@ FastMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexc
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
-  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) -> T {
+  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) noexcept -> T {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
@@ -150,13 +150,13 @@ FastMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, const bool
   // Visitation pattern - go into the node if the point is inside or the distance to the BV is shorter than
   // the shortest distance so far.
   EBGeometry::BVH::Visiter<Node, T> visiter = [&shortestDistanceSoFar](const Node&    a_node,
-                                                                       const BVHMeta& a_bvDist) -> bool {
+                                                                       const BVHMeta& a_bvDist) noexcept -> bool {
     return a_bvDist <= 0.0 || a_bvDist <= shortestDistanceSoFar;
   };
 
   // Sorter for BVH nodes, visit closest nodes first
   EBGeometry::BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) -> void {
+    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(),
       a_leaves.end(),
@@ -165,13 +165,13 @@ FastMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, const bool
   };
 
   // Meta-data updater - this meta-data enters into the visitor pattern.
-  EBGeometry::BVH::MetaUpdater<Node, BVHMeta> metaUpdater = [&a_point](const Node& a_node) -> BVHMeta {
+  EBGeometry::BVH::MetaUpdater<Node, BVHMeta> metaUpdater = [&a_point](const Node& a_node) noexcept -> BVHMeta {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
   // Update rule for the BVH. Go through the faces and check
   EBGeometry::BVH::Updater<Face> updater = [&shortestDistanceSoFar, &a_point, &candidateFaces](
-                                             const std::vector<std::shared_ptr<const Face>>& a_faces) -> void {
+                                             const std::vector<std::shared_ptr<const Face>>& a_faces) noexcept -> void {
     // Calculate the distance to each face in the leaf node. If it is shorter than the shortest distance so far, add this face
     // to the list of faces and update the shortest distance.
     for (const auto& f : a_faces) {
@@ -234,7 +234,8 @@ FastCompactMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) cons
 {
   T minDist = std::numeric_limits<T>::infinity();
 
-  BVH::Updater<Face> updater = [&minDist, &a_point](const std::vector<std::shared_ptr<const Face>>& faces) -> void {
+  BVH::Updater<Face> updater = [&minDist,
+                                &a_point](const std::vector<std::shared_ptr<const Face>>& faces) noexcept -> void {
     for (const auto& f : faces) {
       const T curDist = f->signedDistance(a_point);
 
@@ -242,12 +243,12 @@ FastCompactMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) cons
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&minDist, &a_point](const Node& a_node, const T& a_bvDist) -> bool {
+  BVH::Visiter<Node, T> visiter = [&minDist, &a_point](const Node& a_node, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= std::abs(minDist);
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) -> void {
+    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(),
       a_leaves.end(),
@@ -255,7 +256,7 @@ FastCompactMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) cons
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
-  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) -> T {
+  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) noexcept -> T {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
@@ -282,13 +283,13 @@ FastCompactMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, con
   // Visitation pattern - go into the node if the point is inside or the distance to the BV is shorter than
   // the shortest distance so far.
   EBGeometry::BVH::Visiter<Node, T> visiter = [&shortestDistanceSoFar](const Node&    a_node,
-                                                                       const BVHMeta& a_bvDist) -> bool {
+                                                                       const BVHMeta& a_bvDist) noexcept -> bool {
     return a_bvDist <= 0.0 || a_bvDist <= shortestDistanceSoFar;
   };
 
   // Sorter for BVH nodes, visit closest nodes first
   EBGeometry::BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) -> void {
+    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(),
       a_leaves.end(),
@@ -297,13 +298,13 @@ FastCompactMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, con
   };
 
   // Meta-data updater - this meta-data enters into the visitor pattern.
-  EBGeometry::BVH::MetaUpdater<Node, BVHMeta> metaUpdater = [&a_point](const Node& a_node) -> BVHMeta {
+  EBGeometry::BVH::MetaUpdater<Node, BVHMeta> metaUpdater = [&a_point](const Node& a_node) noexcept -> BVHMeta {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
   // Update rule for the BVH. Go through the faces and check
   EBGeometry::BVH::Updater<Face> updater = [&shortestDistanceSoFar, &a_point, &candidateFaces](
-                                             const std::vector<std::shared_ptr<const Face>>& a_faces) -> void {
+                                             const std::vector<std::shared_ptr<const Face>>& a_faces) noexcept -> void {
     // Calculate the distance to each face in the leaf node. If it is shorter than the shortest distance so far, add this face
     // to the list of faces and update the shortest distance.
     for (const auto& f : a_faces) {

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -33,8 +33,9 @@ DCEL::buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dc
   // Partition the BVH using the default input arguments.
   auto bvh = std::make_shared<EBGeometry::BVH::NodeT<T, Prim, BV, K>>(primsAndBVs);
 
-#if 0
-#warning "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
+#if 1
+#warning \
+  "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
   bvh->template bottomUpSortAndPartition<SFC::Morton>();
 #else
   bvh->topDownSortAndPartition();

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -33,6 +33,11 @@ DCEL::buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dc
   // Partition the BVH using the default input arguments.
   auto bvh = std::make_shared<EBGeometry::BVH::NodeT<T, Prim, BV, K>>(primsAndBVs);
 
+#if __cplusplus >= 202002L // Development code
+#warning "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
+  bvh->template bottomUpSortAndPartition<SFC::Morton>();
+#endif        
+
   bvh->topDownSortAndPartition();
 
   return bvh;

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -34,8 +34,7 @@ DCEL::buildFullBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dc
   auto bvh = std::make_shared<EBGeometry::BVH::NodeT<T, Prim, BV, K>>(primsAndBVs);
 
 #if __cplusplus >= 202002L // Development code
-#warning \
-  "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
+#warning "In file EBGeometry::MeshDistanceFunctionsImplem.hpp DCEL::buildFullBVH<T, P, BV, K> - dev code enabled but must be removed later"
   bvh->template bottomUpSortAndPartition<SFC::Morton>();
 #endif
 

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -153,7 +153,7 @@ namespace Parser {
   compress(std::vector<EBGeometry::Vec3T<T>>& a_vertices, std::vector<std::vector<size_t>>& a_facets) noexcept;
 
   /*!
-    @brief Turn raw vertices into DCEL vertices. Does not include vertex normal vectors. 
+    @brief Turn raw vertices into DCEL vertices. 
     @param[out] a_verticesDCEL DCEL vertices
     @param[in]  a_verticesRaw  Raw vertices
     @param[in]  a_facets       Facets

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -37,11 +37,11 @@ Parser::readIntoDCEL(const std::string a_filename) noexcept
 
     break;
   }
-  case Parser::FileType::PLY: {
-    mesh = Parser::PLY<T>::read(a_filename);
+  // case Parser::FileType::PLY: {
+  //   mesh = Parser::PLY<T>::read(a_filename);
 
-    break;
-  }
+  //   break;
+  // }
   case Parser::FileType::Unsupported: {
     std::cerr << "Parser::read - file type unsupported for '" + a_filename + "'\n";
 

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -38,7 +38,7 @@ Parser::readIntoDCEL(const std::string a_filename) noexcept
     break;
   }
   case Parser::FileType::PLY: {
-    //    mesh = Parser::PLY<T>::read(a_filename);
+    mesh = Parser::PLY<T>::read(a_filename);
 
     break;
   }

--- a/Source/EBGeometry_SFC.hpp
+++ b/Source/EBGeometry_SFC.hpp
@@ -40,6 +40,17 @@ namespace SFC {
   */
   static constexpr Code ValidSpan = ((uint64_t)1 << ValidBits) - 1;
 
+#if __cplusplus >= 202002L
+  /*!
+    @brief Encodable SFC concept -- class must have a static function static uint64_t encode(const Index&). This is the main interface for SFCs
+  */
+  template <typename S>
+  concept Encodable = requires(const Index& point, const SFC::Code code) {
+    { S::encode(point) } -> std::same_as<SFC::Code>;
+    { S::decode(code) } -> std::same_as<Index>;
+  };
+#endif
+
   /*!
     @brief Implementation of the Morton SFC
   */
@@ -90,6 +101,11 @@ namespace SFC {
 } // namespace SFC
 
 #include "EBGeometry_NamespaceFooter.hpp"
+
+#if __cplusplus >= 202002L
+static_assert(EBGeometry::SFC::Encodable<EBGeometry::SFC::Morton>);
+static_assert(EBGeometry::SFC::Encodable<EBGeometry::SFC::Nested>);
+#endif
 
 #include "EBGeometry_SFCImplem.hpp"
 

--- a/Source/EBGeometry_SFC.hpp
+++ b/Source/EBGeometry_SFC.hpp
@@ -38,7 +38,7 @@ namespace SFC {
   /*!
     @brief Maximum permitted span along any spatial coordinate. 
   */
-  static constexpr Code ValidSpan = ((uint64_t)1 << ValidBits) - 1;
+  static constexpr Code ValidSpan = (static_cast<uint64_t>(1) << ValidBits) - 1;
 
 #if __cplusplus >= 202002L
   /*!

--- a/Source/EBGeometry_SFC.hpp
+++ b/Source/EBGeometry_SFC.hpp
@@ -9,6 +9,8 @@
   @author Robert Marskar
 */
 
+#if __cplusplus >= 202002L
+
 #ifndef EBGeometry_SFC
 #define EBGeometry_SFC
 
@@ -16,7 +18,6 @@
 #include <cstdint>
 
 // Our includes
-#include "EBGeometry_Index.hpp"
 #include "EBGeometry_NamespaceHeader.hpp"
 
 namespace SFC {
@@ -46,8 +47,8 @@ namespace SFC {
   */
   template <typename T>
   concept Encodable = requires(const Index& point, const SFC::Code code) {
-    { T::encode(point) } -> SFC::Code;
-    { T::decode(code) } -> Index;
+    { T::encode(point) } -> std::same_as<SFC::Code>;
+    { T::decode(code) } -> std::same_as<Index>;
   };
 
   /*!
@@ -102,5 +103,7 @@ namespace SFC {
 #include "EBGeometry_NamespaceFooter.hpp"
 
 #include "EBGeometry_SFCImplem.hpp"
+
+#endif
 
 #endif

--- a/Source/EBGeometry_SFC.hpp
+++ b/Source/EBGeometry_SFC.hpp
@@ -1,0 +1,106 @@
+/* EBGeometry
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the EBGeometry root directory.
+ */
+
+/*!
+  @file   EBGeometry_SFC.hpp
+  @brief  Declaration of various space-filling curves
+  @author Robert Marskar
+*/
+
+#ifndef EBGeometry_SFC
+#define EBGeometry_SFC
+
+// Std includes
+#include <cstdint>
+
+// Our includes
+#include "EBGeometry_Index.hpp"
+#include "EBGeometry_NamespaceHeader.hpp"
+
+namespace SFC {
+
+  /*!
+    @brief Alias for SFC code
+  */
+  using Code = uint64_t;
+
+  /*!
+    @brief Alias for 3D cell index
+  */
+  using Index = std::array<unsigned int, 3>;
+
+  /*!
+    @brief Maximum available bits. Using same number = 21 for all dimensions (strictly speaking, we could use 32 bits in 2D and all 64 bits in 1D).
+  */
+  static constexpr unsigned int ValidBits = 21;
+
+  /*!
+    @brief Maximum permitted span along any spatial coordinate. 
+  */
+  static constexpr Code ValidSpan = ((uint64_t)1 << ValidBits) - 1;
+
+  /*!
+    @brief Encodable SFC concept -- class must have a static function static uint64_t encode(const Index&). This is the main interface for SFCs
+  */
+  template <typename T>
+  concept Encodable = requires(const Index& point, const SFC::Code code) {
+    { T::encode(point) } -> SFC::Code;
+    { T::decode(code) } -> Index;
+  };
+
+  /*!
+    @brief Implementation of the Morton SFC
+  */
+  struct Morton
+  {
+    /*!
+      @brief Encode an input point into a Morton index with a 64-bit representation.
+      @param[in] a_point 
+    */
+    inline static uint64_t
+    encode(const Index& a_point) noexcept;
+
+    /*!
+      @brief Decode the 64-bit Morton code into an Index.
+      @param[in] a_code Morton code
+    */
+    inline static Index
+    decode(const uint64_t& a_code) noexcept;
+
+  protected:
+    /*!
+      @brief Mask for magic-bits encoding of 3D Morton code
+    */
+    static constexpr uint_fast64_t Mask_64[6]{
+      0x1fffff, 0x1f00000000ffff, 0x1f0000ff0000ff, 0x100f00f00f00f00f, 0x10c30c30c30c30c3, 0x1249249249249249};
+  };
+
+  /*!
+    @brief Implementation of a nested index SFC.
+    @details The SFC is encoded by the code = i + j * N + k * N * N in 3D, where i,j,k are the block indices. 
+  */
+  struct Nested
+  {
+    /*!
+      @brief Encode the input point into the SFC code.
+      @param[in] a_point 
+    */
+    inline static uint64_t
+    encode(const Index& a_point) noexcept;
+
+    /*!
+      @brief Decode the 64-bit SFC code into an Index.
+      @param[in] a_code SFC code.
+    */
+    inline static Index
+    decode(const uint64_t& a_code) noexcept;
+  };
+} // namespace SFC
+
+#include "EBGeometry_NamespaceFooter.hpp"
+
+#include "EBGeometry_SFCImplem.hpp"
+
+#endif

--- a/Source/EBGeometry_SFC.hpp
+++ b/Source/EBGeometry_SFC.hpp
@@ -9,8 +9,6 @@
   @author Robert Marskar
 */
 
-#if __cplusplus >= 202002L
-
 #ifndef EBGeometry_SFC
 #define EBGeometry_SFC
 
@@ -41,15 +39,6 @@ namespace SFC {
     @brief Maximum permitted span along any spatial coordinate. 
   */
   static constexpr Code ValidSpan = ((uint64_t)1 << ValidBits) - 1;
-
-  /*!
-    @brief Encodable SFC concept -- class must have a static function static uint64_t encode(const Index&). This is the main interface for SFCs
-  */
-  template <typename S>
-  concept Encodable = requires(const Index& point, const SFC::Code code) {
-    { S::encode(point) } -> std::same_as<SFC::Code>;
-    { S::decode(code) } -> std::same_as<Index>;
-  };
 
   /*!
     @brief Implementation of the Morton SFC
@@ -103,7 +92,5 @@ namespace SFC {
 #include "EBGeometry_NamespaceFooter.hpp"
 
 #include "EBGeometry_SFCImplem.hpp"
-
-#endif
 
 #endif

--- a/Source/EBGeometry_SFC.hpp
+++ b/Source/EBGeometry_SFC.hpp
@@ -45,10 +45,10 @@ namespace SFC {
   /*!
     @brief Encodable SFC concept -- class must have a static function static uint64_t encode(const Index&). This is the main interface for SFCs
   */
-  template <typename T>
+  template <typename S>
   concept Encodable = requires(const Index& point, const SFC::Code code) {
-    { T::encode(point) } -> std::same_as<SFC::Code>;
-    { T::decode(code) } -> std::same_as<Index>;
+    { S::encode(point) } -> std::same_as<SFC::Code>;
+    { S::decode(code) } -> std::same_as<Index>;
   };
 
   /*!

--- a/Source/EBGeometry_SFCImplem.hpp
+++ b/Source/EBGeometry_SFCImplem.hpp
@@ -1,0 +1,134 @@
+/* EBGeometry
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the EBGeometry root directory.
+ */
+
+/*!
+  @file   EBGeometry_SFCImplem.hpp
+  @brief  Implementation of EBGeometry_SFC.hpp
+  @author Robert Marskar
+*/
+
+#if __cplusplus >= 202002L
+
+#ifndef _EBGeometry_SFCImplem_
+#define _EBGeometry_SFCImplem_
+
+// Std includes
+#include <climits>
+
+// Our includes
+#include "EBGeometry_SFC.hpp"
+
+namespace EBGeometry {
+  namespace SFC {
+
+    template <Encodable T>
+    inline SFC::Code
+    encode(const Index& a_point) noexcept
+    {
+      return T::encode(a_point);
+    }
+
+    template <Encodable T>
+    inline Index
+    decode(const SFC::Code& a_code) noexcept
+    {
+      return T::decode(a_code);
+    }
+
+    template <Encodable T>
+    inline void
+    sort(std::vector<Index>& a_points) noexcept
+    {
+      std::vector<uint64_t> codes;
+
+      for (const auto& p : a_points) {
+        codes.emplace_back(T::encode(p));
+      }
+
+      std::sort(codes.begin(), codes.end());
+
+      a_points.clear();
+      for (const auto& c : codes) {
+        a_points.emplace_back(T::decode(c));
+      }
+    }
+
+    inline uint64_t
+    Morton::encode(const Index& a_point) noexcept
+    {
+      uint64_t code = 0;
+
+      const uint_fast32_t x = a_point[0];
+      const uint_fast32_t y = a_point[1];
+      const uint_fast32_t z = a_point[2];
+
+      auto PartBy3 = [](const uint_fast32_t a) -> uint64_t {
+        uint64_t x = a & Mask_64[0];
+
+        x = (x | x << 32) & Mask_64[1];
+        x = (x | x << 16) & Mask_64[2];
+        x = (x | x << 8) & Mask_64[3];
+        x = (x | x << 4) & Mask_64[4];
+        x = (x | x << 2) & Mask_64[5];
+
+        return x;
+      };
+
+      code |= PartBy3(x) | PartBy3(y) << 1 | PartBy3(z) << 2;
+
+      return code;
+    }
+
+    inline Index
+    Morton::decode(const uint64_t& a_code) noexcept
+    {
+      auto getEveryThirdBit = [](const uint64_t m) -> uint_fast32_t {
+        uint_fast32_t x = m & Mask_64[5];
+
+        x = (x ^ (x >> 2)) & Mask_64[4];
+        x = (x ^ (x >> 4)) & Mask_64[3];
+        x = (x ^ (x >> 8)) & Mask_64[2];
+        x = (x ^ (x >> 16)) & Mask_64[1];
+        x = (x ^ (x >> 32)) & Mask_64[0];
+
+        return x;
+      };
+
+      const unsigned int x = (unsigned int)getEveryThirdBit(a_code);
+      const unsigned int y = (unsigned int)getEveryThirdBit(a_code >> 1);
+      const unsigned int z = (unsigned int)getEveryThirdBit(a_code >> 2);
+
+      return Index({x, y, z});
+    }
+
+    inline uint64_t
+    Nested::encode(const Index& a_point) noexcept
+    {
+      uint64_t code = 0;
+
+      const uint32_t x = a_point[0];
+      const uint32_t y = a_point[1];
+      const uint32_t z = a_point[2];
+
+      code = x + (y * SFC::ValidSpan) + (z * SFC::ValidSpan * SFC::ValidSpan);
+
+      return code;
+    }
+
+    inline Index
+    Nested::decode(const uint64_t& a_code) noexcept
+    {
+      const unsigned int z = a_code / (SFC::ValidSpan * SFC::ValidSpan);
+      const unsigned int y = (a_code - z * SFC::ValidSpan * SFC::ValidSpan) / SFC::ValidSpan;
+      const unsigned int x = a_code - z * SFC::ValidSpan * SFC::ValidSpan - y * SFC::ValidSpan;
+
+      return Index({x, y, z});
+    }
+  } // namespace SFC
+} // namespace EBGeometry
+
+#endif
+
+#endif

--- a/Source/EBGeometry_SFCImplem.hpp
+++ b/Source/EBGeometry_SFCImplem.hpp
@@ -31,15 +31,15 @@ namespace EBGeometry {
       const uint_fast32_t z = a_point[2];
 
       auto PartBy3 = [](const uint_fast32_t a) -> uint64_t {
-        uint64_t x = a & Mask_64[0];
+        uint64_t b = a & Mask_64[0];
 
-        x = (x | x << 32) & Mask_64[1];
-        x = (x | x << 16) & Mask_64[2];
-        x = (x | x << 8) & Mask_64[3];
-        x = (x | x << 4) & Mask_64[4];
-        x = (x | x << 2) & Mask_64[5];
+        b = (b | b << 32) & Mask_64[1];
+        b = (b | b << 16) & Mask_64[2];
+        b = (b | b << 8) & Mask_64[3];
+        b = (b | b << 4) & Mask_64[4];
+        b = (b | b << 2) & Mask_64[5];
 
-        return x;
+        return b;
       };
 
       code |= PartBy3(x) | PartBy3(y) << 1 | PartBy3(z) << 2;
@@ -62,9 +62,9 @@ namespace EBGeometry {
         return x;
       };
 
-      const unsigned int x = (unsigned int)getEveryThirdBit(a_code);
-      const unsigned int y = (unsigned int)getEveryThirdBit(a_code >> 1);
-      const unsigned int z = (unsigned int)getEveryThirdBit(a_code >> 2);
+      const unsigned int x = static_cast<unsigned int>(getEveryThirdBit(a_code));
+      const unsigned int y = static_cast<unsigned int>(getEveryThirdBit(a_code >> 1));
+      const unsigned int z = static_cast<unsigned int>(getEveryThirdBit(a_code >> 2));
 
       return Index({x, y, z});
     }

--- a/Source/EBGeometry_SFCImplem.hpp
+++ b/Source/EBGeometry_SFCImplem.hpp
@@ -23,38 +23,6 @@
 namespace EBGeometry {
   namespace SFC {
 
-    template <Encodable T>
-    inline SFC::Code
-    encode(const Index& a_point) noexcept
-    {
-      return T::encode(a_point);
-    }
-
-    template <Encodable T>
-    inline Index
-    decode(const SFC::Code& a_code) noexcept
-    {
-      return T::decode(a_code);
-    }
-
-    template <Encodable T>
-    inline void
-    sort(std::vector<Index>& a_points) noexcept
-    {
-      std::vector<uint64_t> codes;
-
-      for (const auto& p : a_points) {
-        codes.emplace_back(T::encode(p));
-      }
-
-      std::sort(codes.begin(), codes.end());
-
-      a_points.clear();
-      for (const auto& c : codes) {
-        a_points.emplace_back(T::decode(c));
-      }
-    }
-
     inline uint64_t
     Morton::encode(const Index& a_point) noexcept
     {

--- a/Source/EBGeometry_SFCImplem.hpp
+++ b/Source/EBGeometry_SFCImplem.hpp
@@ -9,8 +9,6 @@
   @author Robert Marskar
 */
 
-#if __cplusplus >= 202002L
-
 #ifndef _EBGeometry_SFCImplem_
 #define _EBGeometry_SFCImplem_
 
@@ -96,7 +94,5 @@ namespace EBGeometry {
     }
   } // namespace SFC
 } // namespace EBGeometry
-
-#endif
 
 #endif

--- a/Source/EBGeometry_SimpleTimer.hpp
+++ b/Source/EBGeometry_SimpleTimer.hpp
@@ -1,0 +1,80 @@
+/* chombo-discharge
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   EBGeometry_SimpleTimer.hpp
+  @brief  Header for the SimpleTimer class
+  @author Robert Marskar
+*/
+
+#ifndef EBGeometry_SimpleTimer
+#define EBGeometry_SimpleTimer
+
+// Std includes
+#include <chrono>
+
+namespace EBGeometry {
+
+  /*!
+    @brief Simple timer class used for local performance profiling. Does not include MPI capabilities and is therefore local to each rank. 
+  */
+  class SimpleTimer
+  {
+  public:
+    /*!
+      @brief Clock alias
+    */
+    using Clock = std::chrono::steady_clock;
+
+    /*!
+      @brief Time point alias
+    */
+    using TimePoint = Clock::time_point;
+
+    /*!
+      @brief Constructor
+    */
+    inline SimpleTimer() noexcept;
+
+    /*!
+      @brief Destructor
+    */
+    inline ~SimpleTimer() noexcept = default;
+
+    /*!
+      @brief Start timing
+    */
+    inline void
+    start() noexcept;
+
+    /*!
+      @brief Stop timing
+    */
+    inline void
+    stop() noexcept;
+
+    /*!
+      @brief Report result -- prints result in seconds
+    */
+    inline double
+    seconds() const noexcept;
+
+  protected:
+    /*!
+      @brief Start point
+    */
+    TimePoint m_start;
+
+    /*!
+      @brief Stop point
+    */
+    TimePoint m_stop;
+  };
+
+} // namespace EBGeometry
+
+#include "EBGeometry_SimpleTimerImplem.hpp"
+
+#endif

--- a/Source/EBGeometry_SimpleTimerImplem.hpp
+++ b/Source/EBGeometry_SimpleTimerImplem.hpp
@@ -1,0 +1,46 @@
+/* chombo-discharge
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   EBGeometry_SimpleTimerImplem.hpp
+  @brief  Implementation of EBGeometry_SimpleTimer.hpp
+  @author Robert Marskar
+*/
+
+#ifndef EBGeometry_SimpleTimerImplem
+#define EBGeometry_SimpleTimerImplem
+
+// Our includes
+#include "EBGeometry_SimpleTimer.hpp"
+
+namespace EBGeometry {
+
+  inline SimpleTimer::SimpleTimer() noexcept
+  {
+    this->start();
+    this->stop();
+  }
+
+  inline void
+  SimpleTimer::start() noexcept
+  {
+    m_start = Clock::now();
+  }
+
+  inline void
+  SimpleTimer::stop() noexcept
+  {
+    m_stop = Clock::now();
+  }
+
+  inline double
+  SimpleTimer::seconds() const noexcept
+  {
+    return std::chrono::duration_cast<std::chrono::duration<double>>(m_stop - m_start).count();
+  }
+
+} // namespace EBGeometry
+
+#endif

--- a/Source/EBGeometry_Vec.hpp
+++ b/Source/EBGeometry_Vec.hpp
@@ -231,7 +231,7 @@ public:
   /*!
     @brief Default constructor. Sets the vector to the zero vector.
   */
-  Vec3T();
+  Vec3T() noexcept;
 
   /*!
     @brief Copy constructor
@@ -247,12 +247,12 @@ public:
     @param[in] a_z Third vector component
     @details Sets this->x = a_x, this->y = a_y, and this->z = a_z
   */
-  constexpr Vec3T(const T& a_x, const T& a_y, const T& a_z);
+  constexpr Vec3T(const T& a_x, const T& a_y, const T& a_z) noexcept;
 
   /*!
     @brief Destructor (does nothing)
   */
-  ~Vec3T() = default;
+  ~Vec3T() noexcept = default;
 
   /*!
     @brief Return av vector with x = y = z = 0

--- a/Source/EBGeometry_VecImplem.hpp
+++ b/Source/EBGeometry_VecImplem.hpp
@@ -200,7 +200,7 @@ operator/(const T& s, const Vec2T<T>& a_other) noexcept
 }
 
 template <typename T>
-inline Vec3T<T>::Vec3T()
+inline Vec3T<T>::Vec3T() noexcept
 {
   (*this) = Vec3T<T>::zero();
 }
@@ -214,7 +214,7 @@ inline Vec3T<T>::Vec3T(const Vec3T<T>& u) noexcept
 }
 
 template <typename T>
-inline constexpr Vec3T<T>::Vec3T(const T& a_x, const T& a_y, const T& a_z) : m_X{a_x, a_y, a_z}
+inline constexpr Vec3T<T>::Vec3T(const T& a_x, const T& a_y, const T& a_z) noexcept : m_X{a_x, a_y, a_z}
 {}
 
 template <typename T>


### PR DESCRIPTION
This PR adds a bottom-up construction of the BVH using space-filling curves. 

Todo: 

- [x] Finish the bottom-up construction method.
- [ ] For performance reasons, primitives should be distributed evenly throughout the leaf cells (don't assigned remainder to one half of the tree)
- [x] Fix the noexcept errors
- [x] Profile the SFC method. 
- [x] Fix all parser methods so they select between top-down and bottom-up construction methods (maybe use a default input parameter for this). 
- [x] Add sphinx documentation. Must also clarify how to select between bottom-up and top-down methods.
- [x] Add doxygen documentation

Closes #64 
Closes #68 