### PR TITLE
Add functionality for detecting polygon-polygon intersections.

### DIFF
--- a/Source/EBGeometry_DCEL_Face.hpp
+++ b/Source/EBGeometry_DCEL_Face.hpp
@@ -154,6 +154,13 @@ namespace DCEL {
     setInsideOutsideAlgorithm(typename Polygon2D<T>::InsideOutsideAlgorithm& a_algorithm) noexcept;
 
     /*!
+      @brief Check if this face intersections with another face
+      @param[in] a_otherFace Other face to test against.
+    */
+    inline bool
+    intersects(const Face& a_otherFace) const noexcept;
+
+    /*!
       @brief Get modifiable half-edge
     */
     inline EdgePtr&

--- a/Source/EBGeometry_DCEL_FaceImplem.hpp
+++ b/Source/EBGeometry_DCEL_FaceImplem.hpp
@@ -92,6 +92,15 @@ namespace DCEL {
   }
 
   template <class T, class Meta>
+  inline bool
+  FaceT<T, Meta>::intersects(const Face& a_otherFace) const noexcept
+  {
+#warning "FaceT<T,Meta>::intersects - not implemented"
+
+    return true;
+  }
+
+  template <class T, class Meta>
   inline void
   FaceT<T, Meta>::computeCentroid() noexcept
   {

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -12,6 +12,9 @@
 #ifndef EBGeometry_MeshDistanceFunctions
 #define EBGeometry_MeshDistanceFunctions
 
+// Std includes
+#include <set>
+
 // Our includes
 #include "EBGeometry_BoundingVolumes.hpp"
 #include "EBGeometry_SignedDistanceFunction.hpp"
@@ -145,6 +148,18 @@ public:
   getClosestFaces(const Vec3T<T>& a_point, const bool a_sorted) const noexcept;
 
   /*!
+    @brief Check for intersections between the polygon faces.
+    @details This routine will run through all polygons in the input mesh, and check whether or not the
+    polygons intersect with any of the other polygons the BVH-stored mesh. To make this search efficient, the
+    routine uses the BVH to accelerate the search. Note that if one passes in the same mesh as in the constructor,
+    one obtains the number of self-intersections in this mesh.
+    @param[in] a_mesh Mesh to check for intersections against the current BVH-stored mesh.
+    @returns Returns unique pairs of intersecting faces
+  */
+  virtual std::set<std::pair<std::shared_ptr<const Face>, std::shared_ptr<const Face>>>
+  getIntersectingFaces(const std::shared_ptr<Mesh>& a_mesh) const noexcept;
+
+  /*!
     @brief Get the bounding volume hierarchy enclosing the mesh
   */
   virtual std::shared_ptr<Node>&
@@ -230,6 +245,18 @@ public:
   */
   virtual std::vector<std::pair<std::shared_ptr<const Face>, T>>
   getClosestFaces(const Vec3T<T>& a_point, const bool a_sorted) const noexcept;
+
+  /*!
+    @brief Check for intersections between the polygon faces.
+    @details This routine will run through all polygons in the input mesh, and check whether or not the
+    polygons intersect with any of the other polygons the BVH-stored mesh. To make this search efficient, the
+    routine uses the BVH to accelerate the search. Note that if one passes in the same mesh as in the constructor,
+    one obtains the number of self-intersections in this mesh.
+    @param[in] a_mesh Mesh to check for intersections against the current BVH-stored mesh.
+    @returns Returns unique pairs of intersecting faces
+  */
+  virtual std::set<std::pair<std::shared_ptr<const Face>, std::shared_ptr<const Face>>>
+  getIntersectingFaces(const std::shared_ptr<Mesh>& a_mesh) const noexcept;
 
   /*!
     @brief Get the bounding volume hierarchy enclosing the mesh

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -54,6 +54,8 @@ Parser::readIntoDCEL(const std::string a_filename) noexcept
   }
   }
 
+  mesh->sanityCheck();
+
   return mesh;
 }
 
@@ -99,7 +101,16 @@ Parser::readIntoFullBVH(const std::string a_filename) noexcept
 {
   const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
 
-  return std::make_shared<FastMeshSDF<T, Meta, BV, K>>(mesh);
+  auto fastMeshSDF = std::make_shared<FastMeshSDF<T, Meta, BV, K>>(mesh);
+
+  const auto intersectingFaces = fastMeshSDF->getIntersectingFaces(mesh);
+
+  if (intersectingFaces.size() > 0) {
+    std::cerr << "Parser::readIntoFullBVH - file '" << a_filename << "' might contain up to "
+              << intersectingFaces.size() << " self-intersections.\n";
+  }
+
+  return fastMeshSDF;
 }
 
 template <typename T, typename Meta, typename BV, size_t K>
@@ -121,7 +132,16 @@ Parser::readIntoLinearBVH(const std::string a_filename) noexcept
 {
   const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
 
-  return std::make_shared<FastCompactMeshSDF<T, Meta, BV, K>>(mesh);
+  auto fastMeshSDF = std::make_shared<FastCompactMeshSDF<T, Meta, BV, K>>(mesh);
+
+  const auto intersectingFaces = fastMeshSDF->getIntersectingFaces(mesh);
+
+  if (intersectingFaces.size() > 0) {
+    std::cerr << "Parser::readIntoFullBVH - file '" << a_filename << "' might contain up to "
+              << intersectingFaces.size() << " self-intersections.\n";
+  }
+
+  return fastMeshSDF;
 }
 
 template <typename T, typename Meta, typename BV, size_t K>


### PR DESCRIPTION
This functionality uses a BVH structure for detecting whether or not a set of input polygons intersect the polygons of another mesh. This is normally used for detecting self-intersections.

TODO: 

- [ ] Add face-face intersection test 
- [x] Add BVH traversal functionality to mesh distance functions
- [ ] Add a known (bad) self-intersecting mesh (e.g., Klein bottle)