### PR TITLE
Add triangles with pseudonormals and faces. 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,7 +85,7 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: |
           source /opt/intel/oneapi/setvars.sh
-          icx -std=c++17 -O0 \
+          icpx -std=c++17 -O0 \
           -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull \
           -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable \
           -Wunused-variable -Wwrite-strings -Werror \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           icpx -std=c++17 -O0 \
-          -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull \
+          -Wall -Warray-bounds -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull \
           -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable \
           -Wunused-variable -Wwrite-strings -Werror \
           main.cpp -lstdc++fs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,7 +85,7 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: |
           source /opt/intel/oneapi/setvars.sh
-          icpc -std=c++17 -O0 \
+          icx -std=c++17 -O0 \
           -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull \
           -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable \
           -Wunused-variable -Wwrite-strings -Werror \

--- a/Docs/Sphinx/source/Concepts.rst
+++ b/Docs/Sphinx/source/Concepts.rst
@@ -155,6 +155,13 @@ where the sum runs over all faces which share :math:`v` as a vertex, and where :
 
    Edge and vertex pseudonormals.
 
+Triangles
+=========
+
+``EBGeometry`` also supports using direct triangles rather than DCEL polygons.
+In this case the user can parse his/her files and ask for triangle description rather than a DCEL description.
+Internally, triangles are represented as *pseudo-triangles* that contain normal vectors on both the edges and vertices, completely similar to a DCEL polygon.
+
 .. _Chap:BVH:
 
 Bounding volume hierarchies

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -85,6 +85,7 @@ To use bottom-up construction, one may use the member function
 .. literalinclude:: ../../../Source/EBGeometry_BVH.hpp
    :language: c++
    :lines: 298-309
+   :dedent: 4
 
 The template argument is the space-filling curve that the user wants to apply.
 Currently, we support Morton codes and nested indices.
@@ -273,6 +274,7 @@ If the traversal decides to visit a node, it immediately computes the specified 
 .. literalinclude:: ../../../Source/EBGeometry_BVHImplem.hpp
    :language: c++
    :lines: 284-322
+   :dedent: 2
    :caption: Tree traversal algorithm for the BVH tree.
 
 Traversal examples
@@ -294,7 +296,7 @@ These rules are given below.
 
 .. literalinclude:: ../../../Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
    :language: c++
-   :lines: 97-132
+   :lines: 145-181
    :caption: Tree traversal criterion for computing the signed distance to a DCEL mesh using the BVH accelerator.
 	     See :file:`Source/EBGeometry_MeshDistanceFunctionsImplem.hpp` for details.
 

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -25,6 +25,18 @@ If you have one or multiple STL files, you can quickly turn them into signed dis
 This will build DCEL meshes for each input file, and wrap the meshes in BVHs.
 See :ref:`Chap:LinearSTL` for further details.
 
+.. tip::
+
+   If the input files consist only of triangles, use the version
+
+   .. code-block:: c++
+
+      std::vector<std::string> files; // <---- List of file names.
+   
+      const auto distanceFields = EBGeometry::Parser::readIntoTriangleBVH<float>(files);
+
+   This version will convert all DCEL polygons to triangles, and usually provides a nice code speedup.
+
 Reading STL files
 -----------------
 
@@ -42,7 +54,8 @@ To read one or multiple STL files and turn it into DCEL meshes, use
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 53-67
+   :lines: 54-68
+   :dedent: 2	   
 
 Note that this will only expose the DCEL mesh, but not include any signed distance functionality.
 
@@ -53,7 +66,8 @@ To read one or multiple STL files and also turn it into signed distance represen
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 69-83
+   :lines: 70-84
+   :dedent: 2	   
 
 DCEL mesh SDF with full BVH
 ___________________________
@@ -62,7 +76,8 @@ To read one or multiple STL files and turn it into signed distance representatio
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 85-105
+   :lines: 86-106
+   :dedent: 2	   
 
 .. _Chap:LinearSTL:
 
@@ -73,7 +88,22 @@ To read one or multiple STL files and turn it into signed distance representatio
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 107-127
+   :lines: 107-128
+   :dedent: 2
+
+	   
+Triangle meshes with BVH
+________________________
+
+To read one or multiple STL files and turn it into signed distance representations using a compact BVH representation, use
+
+.. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
+   :language: c++
+   :lines: 130-147
+   :dedent: 2	   
+
+This version differs from the DCEL meshes in that each DCEL polygon is converted into triangles after parsing.
+The code will throw an error if not all DCEL polygon are not actual triangles.
 
 .. _Chap:PolySoups:
 
@@ -94,7 +124,7 @@ To turn this into a DCEL mesh, one should compress the triangle soup (get rid of
 
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
-   :lines: 146-165
+   :lines: 182-201
 
 The ``compress`` function will discard duplicate vertices from the soup, while the ``soupToDCEL`` will tie the remaining polygons into a DCEL mesh.
 This function will also compute the vertex and edge normal vectors.

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -125,6 +125,7 @@ To turn this into a DCEL mesh, one should compress the triangle soup (get rid of
 .. literalinclude:: ../../../Source/EBGeometry_Parser.hpp
    :language: c++
    :lines: 182-201
+   :dedent: 2
 
 The ``compress`` function will discard duplicate vertices from the soup, while the ``soupToDCEL`` will tie the remaining polygons into a DCEL mesh.
 This function will also compute the vertex and edge normal vectors.

--- a/EBGeometry.hpp
+++ b/EBGeometry.hpp
@@ -14,6 +14,8 @@
 #include "Source/EBGeometry_SignedDistanceFunction.hpp"
 #include "Source/EBGeometry_SimpleTimer.hpp"
 #include "Source/EBGeometry_Transform.hpp"
+#include "Source/EBGeometry_Triangle.hpp"
+#include "Source/EBGeometry_Triangle2D.hpp"
 
 /*!
   @brief Name space for all of EBGeometry

--- a/Examples/AMReX_DCEL/main.cpp
+++ b/Examples/AMReX_DCEL/main.cpp
@@ -13,6 +13,8 @@
 // Our include
 #include "../../EBGeometry.hpp"
 
+#warning "Example must be updated to use the trimesh class"
+
 using namespace amrex;
 
 /*!

--- a/Examples/AMReX_DCEL/main.cpp
+++ b/Examples/AMReX_DCEL/main.cpp
@@ -13,8 +13,6 @@
 // Our include
 #include "../../EBGeometry.hpp"
 
-#warning "Example must be updated to use the trimesh class"
-
 using namespace amrex;
 
 /*!
@@ -33,7 +31,7 @@ public:
   AMReXSDF(const std::string a_filename, const bool a_use_bvh)
   {
     if (a_use_bvh) {
-      m_sdf = EBGeometry::Parser::readIntoLinearBVH<T, Meta, BV, K>(a_filename);
+      m_sdf = EBGeometry::Parser::readIntoTriangleBVH<T, Meta, BV, K>(a_filename);
     }
     else {
       m_sdf = EBGeometry::Parser::readIntoMesh<T, Meta>(a_filename);

--- a/Examples/AMReX_F18/main.cpp
+++ b/Examples/AMReX_F18/main.cpp
@@ -16,8 +16,6 @@
 // Our include
 #include "../../EBGeometry.hpp"
 
-#warning "Example must be updated to use the trimesh class"
-
 using namespace amrex;
 
 constexpr size_t K = 4;
@@ -27,7 +25,7 @@ using Vec3         = EBGeometry::Vec3T<T>;
 using BV           = EBGeometry::BoundingVolumes::AABBT<T>;
 using Face         = EBGeometry::DCEL::FaceT<T, MetaData>;
 using Mesh         = EBGeometry::DCEL::MeshT<T, MetaData>;
-using FastSDF      = EBGeometry::FastCompactMeshSDF<T, MetaData, BV, K>;
+using FastSDF      = EBGeometry::FastTriMeshSDF<T, MetaData, BV, K>;
 
 // F18 geometry, using nifty EBGeometry bindings and accelerators.
 class F18

--- a/Examples/AMReX_F18/main.cpp
+++ b/Examples/AMReX_F18/main.cpp
@@ -16,6 +16,8 @@
 // Our include
 #include "../../EBGeometry.hpp"
 
+#warning "Example must be updated to use the trimesh class"
+
 using namespace amrex;
 
 constexpr size_t K = 4;

--- a/Examples/AMReX_PaintEB/main.cpp
+++ b/Examples/AMReX_PaintEB/main.cpp
@@ -13,6 +13,8 @@
 // Our include
 #include "../../EBGeometry.hpp"
 
+#warning "Example must be updated to use the trimesh class"
+
 using namespace amrex;
 
 /*!

--- a/Examples/AMReX_PaintEB/main.cpp
+++ b/Examples/AMReX_PaintEB/main.cpp
@@ -13,8 +13,6 @@
 // Our include
 #include "../../EBGeometry.hpp"
 
-#warning "Example must be updated to use the trimesh class"
-
 using namespace amrex;
 
 /*!
@@ -39,7 +37,7 @@ public:
   {
     // Read in the mesh into a DCEL mesh and partition it into a bounding volume hierarchy
     auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
-
+    
     // Set the meta-data for all facets to their "index", i.e. position in the list of facets
     auto& faces = mesh->getFaces();
     for (size_t i = 0; i < faces.size(); i++) {

--- a/Examples/AMReX_PaintEB/main.cpp
+++ b/Examples/AMReX_PaintEB/main.cpp
@@ -39,13 +39,14 @@ public:
   {
     // Read in the mesh into a DCEL mesh and partition it into a bounding volume hierarchy
     auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
-    m_sdf     = std::make_shared<EBGeometry::FastCompactMeshSDF<T, Meta, BV, K>>(mesh);
 
     // Set the meta-data for all facets to their "index", i.e. position in the list of facets
     auto& faces = mesh->getFaces();
     for (size_t i = 0; i < faces.size(); i++) {
       faces[i]->getMetaData() = 1.0 * i;
     }
+
+    m_sdf = std::make_shared<EBGeometry::FastTriMeshSDF<T, Meta, BV, K>>(mesh);
   }
 
   /*!

--- a/Examples/AMReX_PaintEB/main.cpp
+++ b/Examples/AMReX_PaintEB/main.cpp
@@ -37,7 +37,7 @@ public:
   {
     // Read in the mesh into a DCEL mesh and partition it into a bounding volume hierarchy
     auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
-    
+
     // Set the meta-data for all facets to their "index", i.e. position in the list of facets
     auto& faces = mesh->getFaces();
     for (size_t i = 0; i < faces.size(); i++) {

--- a/Examples/Chombo3_DCEL/main.cpp
+++ b/Examples/Chombo3_DCEL/main.cpp
@@ -18,6 +18,8 @@
 // Our includes
 #include "EBGeometry.hpp"
 
+#warning "Example must be updated to use the trimesh class"
+
 // Binding for exposing EBGeometry's signed distance functions to Chombo
 template <class T, class Meta, class BV, int K>
 class ChomboSDF : public BaseIF

--- a/Examples/Chombo3_DCEL/main.cpp
+++ b/Examples/Chombo3_DCEL/main.cpp
@@ -18,8 +18,6 @@
 // Our includes
 #include "EBGeometry.hpp"
 
-#warning "Example must be updated to use the trimesh class"
-
 // Binding for exposing EBGeometry's signed distance functions to Chombo
 template <class T, class Meta, class BV, int K>
 class ChomboSDF : public BaseIF
@@ -29,7 +27,7 @@ public:
 
   ChomboSDF(const std::string a_filename)
   {
-    m_implicitFunction = EBGeometry::Parser::readIntoLinearBVH<T, Meta, BV, K>(a_filename);
+    m_implicitFunction = EBGeometry::Parser::readIntoTriangleBVH<T, Meta, BV, K>(a_filename);
     m_implicitFunction = EBGeometry::Complement<T>(m_implicitFunction);
   }
 

--- a/Examples/Chombo3_F18/main.cpp
+++ b/Examples/Chombo3_F18/main.cpp
@@ -16,15 +16,13 @@
 // Our includes
 #include "EBGeometry.hpp"
 
-#warning "Example must be updated to use the trimesh class"
-
 constexpr size_t K = 4;
 using T            = Real;
 using MetaData     = EBGeometry::DCEL::DefaultMetaData;
 using Face         = EBGeometry::DCEL::FaceT<T>;
 using Mesh         = EBGeometry::DCEL::MeshT<T>;
 using BV           = EBGeometry::BoundingVolumes::AABBT<T>;
-using FastSDF      = EBGeometry::FastCompactMeshSDF<T, MetaData, BV, K>;
+using FastSDF      = EBGeometry::FastTriMeshBVH<T, MetaData, BV, K>;
 using Vec3         = EBGeometry::Vec3T<T>;
 
 class F18 : public BaseIF

--- a/Examples/Chombo3_F18/main.cpp
+++ b/Examples/Chombo3_F18/main.cpp
@@ -16,6 +16,8 @@
 // Our includes
 #include "EBGeometry.hpp"
 
+#warning "Example must be updated to use the trimesh class"
+
 constexpr size_t K = 4;
 using T            = Real;
 using MetaData     = EBGeometry::DCEL::DefaultMetaData;

--- a/Examples/EBGeometry_DCEL/main.cpp
+++ b/Examples/EBGeometry_DCEL/main.cpp
@@ -119,7 +119,7 @@ main(int argc, char* argv[])
   std::cout << "Accumulated distance and time using full BVH    = " << bvhSum  << ", which took " << bvhTime.count()  / Nsamp << " us\n";
   std::cout << "Accumulated distance and time using compact BVH = " << linSum  << ", which took " << linTime.count()  / Nsamp << " us\n";
   std::cout << "Accumulated distance and time using trimesh BVH = " << triSum  << ", which took " << triTime.count()  / Nsamp << " us\n";  
-  std::cout << "Relative speedup using BVH vs direct DCL        = " << dcelTime.count()/linTime.count() << "\n";
+  std::cout << "Relative speedup using BVH vs direct DCEL        = " << dcelTime.count()/triTime.count() << "\n";
   // clang-format on  
 
   return 0;

--- a/Examples/EBGeometry_DCEL/main.cpp
+++ b/Examples/EBGeometry_DCEL/main.cpp
@@ -10,8 +10,6 @@
 
 #include "../../EBGeometry.hpp"
 
-#warning "When the TriMesh class is done, all example files should be updated to use the new functionality."
-
 using namespace EBGeometry;
 using namespace EBGeometry::DCEL;
 

--- a/Examples/EBGeometry_F18/main.cpp
+++ b/Examples/EBGeometry_F18/main.cpp
@@ -137,6 +137,9 @@ main(int argc, char* argv[])
   if (std::abs(sumSlowSlow) - std::abs(sumFastFast) > std::numeric_limits<T>::min()) {
     std::cerr << "Got wrong distance! Diff = " << std::abs(sumSlowFast) - std::abs(sumFastFast) << "\n";
   }
+  if (std::abs(sumSlowSlow) - std::abs(sumFastSlow) > std::numeric_limits<T>::min()) {
+    std::cerr << "Got wrong distance! Diff = " << std::abs(sumSlowFast) - std::abs(sumFastSlow) << "\n";
+  }
 
   const std::chrono::duration<T, std::micro> slowSlowTime = (t1 - t0);
   const std::chrono::duration<T, std::micro> slowFastTime = (t2 - t1);

--- a/Examples/EBGeometry_F18/main.cpp
+++ b/Examples/EBGeometry_F18/main.cpp
@@ -12,6 +12,8 @@
 
 #include "../../EBGeometry.hpp"
 
+#warning "Example must be updated to use the trimesh class"
+
 using namespace EBGeometry;
 using namespace EBGeometry::DCEL;
 

--- a/Examples/EBGeometry_F18/main.cpp
+++ b/Examples/EBGeometry_F18/main.cpp
@@ -12,8 +12,6 @@
 
 #include "../../EBGeometry.hpp"
 
-#warning "Example must be updated to use the trimesh class"
-
 using namespace EBGeometry;
 using namespace EBGeometry::DCEL;
 
@@ -23,7 +21,7 @@ using MetaData     = std::map<int, std::vector<unsigned long long>>; // Attach s
 using Vec3         = EBGeometry::Vec3T<T>;
 using BV           = EBGeometry::BoundingVolumes::AABBT<T>;
 using SlowSDF      = EBGeometry::MeshSDF<T, MetaData>;
-using FastSDF      = EBGeometry::FastCompactMeshSDF<T, MetaData, BV, K>;
+using FastSDF      = EBGeometry::FastTriMeshSDF<T, MetaData, BV, K>;
 
 int
 main(int argc, char* argv[])

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -330,11 +330,10 @@ FastUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
-    std::sort(
-      a_leaves.begin(),
-      a_leaves.end(),
-      [&a_point](const std::pair<std::shared_ptr<const Node>, T>& n1,
+    [](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
+    std::sort(a_leaves.begin(),
+              a_leaves.end(),
+              [](const std::pair<std::shared_ptr<const Node>, T>& n1,
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 

--- a/Source/EBGeometry_DCEL_EdgeImplem.hpp
+++ b/Source/EBGeometry_DCEL_EdgeImplem.hpp
@@ -234,10 +234,11 @@ namespace DCEL {
   inline T
   EdgeT<T, Meta>::signedDistance(const Vec3& a_x0) const noexcept
   {
+    T retval = std::numeric_limits<T>::max();
+
     // Project point to edge.
     const T t = this->projectPointToEdge(a_x0);
 
-    T retval;
     if (t <= 0.0) {
       // Closest point is the starting vertex
       retval = this->getVertex()->signedDistance(a_x0);

--- a/Source/EBGeometry_DCEL_Face.hpp
+++ b/Source/EBGeometry_DCEL_Face.hpp
@@ -260,6 +260,13 @@ namespace DCEL {
     gatherVertices() const noexcept;
 
     /*!
+      @brief Return all the half-edges on this polygon
+      @details This builds a list of all the edges and returns it.
+    */
+    inline std::vector<EdgePtr>
+    gatherEdges() const noexcept;
+
+    /*!
       @brief Get the lower-left-most coordinate of this polygon face
     */
     inline Vec3T<T>

--- a/Source/EBGeometry_DCEL_FaceImplem.hpp
+++ b/Source/EBGeometry_DCEL_FaceImplem.hpp
@@ -245,6 +245,21 @@ namespace DCEL {
   }
 
   template <class T, class Meta>
+  inline std::vector<std::shared_ptr<EdgeT<T, Meta>>>
+  FaceT<T, Meta>::gatherEdges() const noexcept
+  {
+    std::vector<EdgePtr> edges;
+
+    for (EdgeIterator iter(*this); iter.ok(); ++iter) {
+      EdgePtr& edge = iter();
+
+      edges.emplace_back(edge);
+    }
+
+    return edges;
+  }
+
+  template <class T, class Meta>
   inline std::vector<Vec3T<T>>
   FaceT<T, Meta>::getAllVertexCoordinates() const noexcept
   {

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -20,8 +20,6 @@
 #include "EBGeometry_Triangle.hpp"
 #include "EBGeometry_NamespaceHeader.hpp"
 
-#warning "Must add the getClosestTriangles functions to TriMesh"
-
 namespace DCEL {
 
   /*!
@@ -305,6 +303,17 @@ public:
   */
   virtual T
   signedDistance(const Vec3T<T>& a_point) const noexcept override;
+
+  /*!
+    @brief Get the closest triangles to the input point
+    @details This returns a list of candidate triangles that are close to the input point. The returned
+    argment consists of the triangles and the unsigned distance to the triangles.
+    @param[in] a_point Input point
+    @param[in] a_sorted Sort the output vector by distance or not. Closest go first. 
+    @return List of candidate triangles (potentially sorted)
+  */
+  virtual std::vector<std::pair<std::shared_ptr<const Tri>, T>>
+  getClosestTriangles(const Vec3T<T>& a_point, const bool a_sorted) const noexcept;  
 
   /*!
     @brief Get the bounding volume hierarchy enclosing the mesh

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -265,6 +265,11 @@ class FastTriMeshSDF : public SignedDistanceFunction<T>
 {
 public:
   /*!
+    @brief Alias for DCEL mesh type
+  */
+  using Mesh = EBGeometry::DCEL::MeshT<T, Meta>;
+
+  /*!
     @brief Alias for DCEL face type
   */
   using Tri = typename EBGeometry::Triangle<T, Meta>;
@@ -283,6 +288,13 @@ public:
     @brief Default disallowed constructor
   */
   FastTriMeshSDF() = delete;
+
+  /*!
+    @brief Full constructor. Takes a DCEL mesh and creates the input triangles. Then creates the BVH.
+    @param[in] a_mesh DCEL mesh
+    @param[in] a_build Specification of build method. Must be TopDown, Morton, or Nested.
+  */
+  FastTriMeshSDF(const std::shared_ptr<Mesh>& a_mesh, const BVH::Build a_build = BVH::Build::TopDown) noexcept;
 
   /*!
     @brief Full constructor. Takes the input triangles and creates the BVH.
@@ -313,7 +325,7 @@ public:
     @return List of candidate triangles (potentially sorted)
   */
   virtual std::vector<std::pair<std::shared_ptr<const Tri>, T>>
-  getClosestTriangles(const Vec3T<T>& a_point, const bool a_sorted) const noexcept;  
+  getClosestTriangles(const Vec3T<T>& a_point, const bool a_sorted) const noexcept;
 
   /*!
     @brief Get the bounding volume hierarchy enclosing the mesh

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -17,7 +17,10 @@
 #include "EBGeometry_SignedDistanceFunction.hpp"
 #include "EBGeometry_DCEL_Mesh.hpp"
 #include "EBGeometry_BVH.hpp"
+#include "EBGeometry_Triangle.hpp"
 #include "EBGeometry_NamespaceHeader.hpp"
+
+#warning "Must add the getClosestTriangles functions to TriMesh"
 
 namespace DCEL {
 
@@ -230,6 +233,78 @@ public:
   */
   virtual std::vector<std::pair<std::shared_ptr<const Face>, T>>
   getClosestFaces(const Vec3T<T>& a_point, const bool a_sorted) const noexcept;
+
+  /*!
+    @brief Get the bounding volume hierarchy enclosing the mesh
+  */
+  virtual std::shared_ptr<Root>&
+  getRoot() noexcept;
+
+  /*!
+    @brief Get the bounding volume hierarchy enclosing the mesh
+  */
+  virtual const std::shared_ptr<Root>&
+  getRoot() const noexcept;
+
+  /*!
+    @brief Compute bounding volume for this mesh. 
+  */
+  BV
+  computeBoundingVolume() const noexcept;
+
+protected:
+  /*!
+    @brief Bounding volume hierarchy
+  */
+  std::shared_ptr<Root> m_bvh;
+};
+
+/*!
+  @brief Signed distance function for a triangle mesh. This class uses the full BVH representation. 
+*/
+template <class T, class Meta, class BV, size_t K>
+class FastTriMeshSDF : public SignedDistanceFunction<T>
+{
+public:
+  /*!
+    @brief Alias for DCEL face type
+  */
+  using Tri = typename EBGeometry::Triangle<T, Meta>;
+
+  /*!
+    @brief Alias for which BVH root node 
+  */
+  using Root = typename EBGeometry::BVH::LinearBVH<T, Tri, BV, K>;
+
+  /*!
+    @brief Alias for linearized BVH
+  */
+  using Node = typename Root::LinearNode;
+
+  /*!
+    @brief Default disallowed constructor
+  */
+  FastTriMeshSDF() = delete;
+
+  /*!
+    @brief Full constructor. Takes the input triangles and creates the BVH.
+    @param[in] a_triangles Input triangle soup
+    @param[in] a_build Specification of build method. Must be TopDown, Morton, or Nested.
+  */
+  FastTriMeshSDF(const std::vector<std::shared_ptr<Tri>>& a_triangles,
+                 const BVH::Build                         a_build = BVH::Build::TopDown) noexcept;
+
+  /*!
+    @brief Destructor
+  */
+  virtual ~FastTriMeshSDF() = default;
+
+  /*!
+    @brief Value function
+    @param[in] a_point Input point. 
+  */
+  virtual T
+  signedDistance(const Vec3T<T>& a_point) const noexcept override;
 
   /*!
     @brief Get the bounding volume hierarchy enclosing the mesh

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -423,6 +423,8 @@ FastTriMeshSDF<T, Meta, BV, K>::FastTriMeshSDF(const std::shared_ptr<Mesh>& a_me
     tri->setVertexNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
     tri->setEdgeNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
 
+#warning "Must set metadata here"
+
     triangles.emplace_back(tri);
   }
 

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -146,7 +146,7 @@ template <class T, class Meta, class BV, size_t K>
 T
 FastMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexcept
 {
-  T minDist = std::numeric_limits<T>::infinity();
+  T minDist = std::numeric_limits<T>::max();
 
   BVH::Updater<Face> updater = [&minDist,
                                 &a_point](const std::vector<std::shared_ptr<const Face>>& faces) noexcept -> void {
@@ -157,16 +157,15 @@ FastMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexc
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&minDist, &a_point](const Node& a_node, const T& a_bvDist) noexcept -> bool {
+  BVH::Visiter<Node, T> visiter = [&minDist](const Node& a_node, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= std::abs(minDist);
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
-    std::sort(
-      a_leaves.begin(),
-      a_leaves.end(),
-      [&a_point](const std::pair<std::shared_ptr<const Node>, T>& n1,
+    [](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
+    std::sort(a_leaves.begin(),
+              a_leaves.end(),
+              [](const std::pair<std::shared_ptr<const Node>, T>& n1,
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
@@ -193,7 +192,7 @@ FastMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, const bool
   using BVHMeta = T;
 
   // Shortest distance so far.
-  BVHMeta shortestDistanceSoFar = std::numeric_limits<T>::infinity();
+  BVHMeta shortestDistanceSoFar = std::numeric_limits<T>::max();
 
   // Visitation pattern - go into the node if the point is inside or the distance to the BV is shorter than
   // the shortest distance so far.
@@ -204,11 +203,10 @@ FastMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, const bool
 
   // Sorter for BVH nodes, visit closest nodes first
   EBGeometry::BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
-    std::sort(
-      a_leaves.begin(),
-      a_leaves.end(),
-      [&a_point](const std::pair<std::shared_ptr<const Node>, T>& n1,
+    [](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
+    std::sort(a_leaves.begin(),
+              a_leaves.end(),
+              [](const std::pair<std::shared_ptr<const Node>, T>& n1,
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
@@ -280,7 +278,7 @@ template <class T, class Meta, class BV, size_t K>
 T
 FastCompactMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexcept
 {
-  T minDist = std::numeric_limits<T>::infinity();
+  T minDist = std::numeric_limits<T>::max();
 
   BVH::Updater<Face> updater = [&minDist,
                                 &a_point](const std::vector<std::shared_ptr<const Face>>& faces) noexcept -> void {
@@ -291,16 +289,15 @@ FastCompactMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) cons
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&minDist, &a_point](const Node& a_node, const T& a_bvDist) noexcept -> bool {
+  BVH::Visiter<Node, T> visiter = [&minDist](const Node& a_node, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= std::abs(minDist);
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
-    std::sort(
-      a_leaves.begin(),
-      a_leaves.end(),
-      [&a_point](const std::pair<std::shared_ptr<const Node>, T>& n1,
+    [](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
+    std::sort(a_leaves.begin(),
+              a_leaves.end(),
+              [](const std::pair<std::shared_ptr<const Node>, T>& n1,
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
@@ -326,7 +323,7 @@ FastCompactMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, con
   using BVHMeta = T;
 
   // Shortest distance so far.
-  BVHMeta shortestDistanceSoFar = std::numeric_limits<T>::infinity();
+  BVHMeta shortestDistanceSoFar = std::numeric_limits<T>::max();
 
   // Visitation pattern - go into the node if the point is inside or the distance to the BV is shorter than
   // the shortest distance so far.
@@ -337,11 +334,10 @@ FastCompactMeshSDF<T, Meta, BV, K>::getClosestFaces(const Vec3T<T>& a_point, con
 
   // Sorter for BVH nodes, visit closest nodes first
   EBGeometry::BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
-    std::sort(
-      a_leaves.begin(),
-      a_leaves.end(),
-      [&a_point](const std::pair<std::shared_ptr<const Node>, T>& n1,
+    [](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
+    std::sort(a_leaves.begin(),
+              a_leaves.end(),
+              [](const std::pair<std::shared_ptr<const Node>, T>& n1,
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
@@ -445,7 +441,7 @@ template <class T, class Meta, class BV, size_t K>
 T
 FastTriMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const noexcept
 {
-  T minDist = std::numeric_limits<T>::infinity();
+  T minDist = std::numeric_limits<T>::max();
 
   BVH::Updater<Tri> updater = [&minDist,
                                &a_point](const std::vector<std::shared_ptr<const Tri>>& triangles) noexcept -> void {
@@ -456,16 +452,15 @@ FastTriMeshSDF<T, Meta, BV, K>::signedDistance(const Vec3T<T>& a_point) const no
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&minDist, &a_point](const Node& a_node, const T& a_bvDist) noexcept -> bool {
+  BVH::Visiter<Node, T> visiter = [&minDist](const Node& a_node, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= std::abs(minDist);
   };
 
   BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
-    std::sort(
-      a_leaves.begin(),
-      a_leaves.end(),
-      [&a_point](const std::pair<std::shared_ptr<const Node>, T>& n1,
+    [](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
+    std::sort(a_leaves.begin(),
+              a_leaves.end(),
+              [](const std::pair<std::shared_ptr<const Node>, T>& n1,
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 
@@ -492,7 +487,7 @@ FastTriMeshSDF<T, Meta, BV, K>::getClosestTriangles(const Vec3T<T>& a_point, con
   using BVHMeta = T;
 
   // Shortest distance so far.
-  BVHMeta shortestDistanceSoFar = std::numeric_limits<T>::infinity();
+  BVHMeta shortestDistanceSoFar = std::numeric_limits<T>::max();
 
   // Visitation pattern - go into the node if the point is inside or the distance to the BV is shorter than
   // the shortest distance so far.
@@ -503,11 +498,10 @@ FastTriMeshSDF<T, Meta, BV, K>::getClosestTriangles(const Vec3T<T>& a_point, con
 
   // Sorter for BVH nodes, visit closest nodes first
   EBGeometry::BVH::Sorter<Node, T, K> sorter =
-    [&a_point](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
-    std::sort(
-      a_leaves.begin(),
-      a_leaves.end(),
-      [&a_point](const std::pair<std::shared_ptr<const Node>, T>& n1,
+    [](std::array<std::pair<std::shared_ptr<const Node>, T>, K>& a_leaves) noexcept -> void {
+    std::sort(a_leaves.begin(),
+              a_leaves.end(),
+              [](const std::pair<std::shared_ptr<const Node>, T>& n1,
                  const std::pair<std::shared_ptr<const Node>, T>& n2) -> bool { return n1.second > n2.second; });
   };
 

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -411,7 +411,7 @@ FastTriMeshSDF<T, Meta, BV, K>::FastTriMeshSDF(const std::shared_ptr<Mesh>& a_me
     const auto vertices = f->gatherVertices();
     const auto edges    = f->gatherEdges();
 
-    if (vertices.size() != 3) {
+    if ((vertices.size() != 3) || (edges.size() != 3)) {
       std::cerr << "Parser::readIntoTriangles -- DCEL mesh not composed of only triangles!" << "\n";
     }
 
@@ -421,9 +421,8 @@ FastTriMeshSDF<T, Meta, BV, K>::FastTriMeshSDF(const std::shared_ptr<Mesh>& a_me
     tri->setNormal(normal);
     tri->setVertexPositions({vertices[0]->getPosition(), vertices[1]->getPosition(), vertices[2]->getPosition()});
     tri->setVertexNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
-    tri->setEdgeNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
-
-#warning "Must set metadata here"
+    tri->setEdgeNormals({edges[0]->getNormal(), edges[1]->getNormal(), edges[2]->getNormal()});
+    tri->setMetaData(f->getMetaData());
 
     triangles.emplace_back(tri);
   }

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -19,9 +19,10 @@
 #include <map>
 
 // Our includes
+#include "EBGeometry_BoundingVolumes.hpp"
 #include "EBGeometry_DCEL_Mesh.hpp"
 #include "EBGeometry_MeshDistanceFunctions.hpp"
-#include "EBGeometry_BoundingVolumes.hpp"
+#include "EBGeometry_Triangle.hpp"
 #include "EBGeometry_NamespaceHeader.hpp"
 
 /*!
@@ -83,6 +84,22 @@ namespace Parser {
   readIntoMesh(const std::vector<std::string> a_files) noexcept;
 
   /*!
+    @brief Read a file containing a single watertight object and return it as an implicit function.
+    @param[in] a_filename File name
+  */
+  template <typename T, typename Meta>
+  inline static std::vector<std::shared_ptr<Triangle<T, Meta>>>
+  readIntoTriangles(const std::string a_filename) noexcept;
+
+  /*!
+    @brief Read multiple files containing single watertight objects and return them as an implicit functions.
+    @param[in] a_files File names
+  */
+  template <typename T, typename Meta>
+  inline static std::vector<std::vector<std::shared_ptr<Triangle<T, Meta>>>>
+  readIntoTriangles(const std::vector<std::string> a_files) noexcept;
+
+  /*!
     @brief Read a file containing a single watertight object and return it as a DCEL mesh enclosed in a full BVH.
     @param[in] a_filename File name
   */
@@ -103,6 +120,25 @@ namespace Parser {
             size_t K      = 4>
   inline static std::vector<std::shared_ptr<FastMeshSDF<T, Meta, BV, K>>>
   readIntoFullBVH(const std::vector<std::string> a_files) noexcept;
+
+  /*!
+    @brief Read a file containing a single watertight object and return it as a DCEL mesh enclosed in a full BVH.
+    @param[in] a_filename File name
+  */
+  template <typename T, typename Meta, typename BV = EBGeometry::BoundingVolumes::AABBT<T>, size_t K = 4>
+  inline static std::shared_ptr<FastTriMeshSDF<T, Meta, BV, K>>
+  readIntoTriangleBVH(const std::string a_filename) noexcept;
+
+  /*!
+    @brief Read multiple files containing single watertight objects and return them as DCEL meshes enclosed in BVHs.
+    @param[in] a_files File names
+  */
+  template <typename T,
+            typename Meta = DCEL::DefaultMetaData,
+            typename BV   = EBGeometry::BoundingVolumes::AABBT<T>,
+            size_t K      = 4>
+  inline static std::vector<std::shared_ptr<FastMeshSDF<T, Meta, BV, K>>>
+  readIntoTriangleBVH(const std::vector<std::string> a_files) noexcept;
 
   /*!
     @brief Read a file containing a single watertight object and return it as a DCEL mesh enclosed in a linearized BVH

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -84,22 +84,6 @@ namespace Parser {
   readIntoMesh(const std::vector<std::string> a_files) noexcept;
 
   /*!
-    @brief Read a file containing a single watertight object and return it as an implicit function.
-    @param[in] a_filename File name
-  */
-  template <typename T, typename Meta>
-  inline static std::vector<std::shared_ptr<Triangle<T, Meta>>>
-  readIntoTriangles(const std::string a_filename) noexcept;
-
-  /*!
-    @brief Read multiple files containing single watertight objects and return them as an implicit functions.
-    @param[in] a_files File names
-  */
-  template <typename T, typename Meta>
-  inline static std::vector<std::vector<std::shared_ptr<Triangle<T, Meta>>>>
-  readIntoTriangles(const std::vector<std::string> a_files) noexcept;
-
-  /*!
     @brief Read a file containing a single watertight object and return it as a DCEL mesh enclosed in a full BVH.
     @param[in] a_filename File name
   */
@@ -122,25 +106,6 @@ namespace Parser {
   readIntoFullBVH(const std::vector<std::string> a_files) noexcept;
 
   /*!
-    @brief Read a file containing a single watertight object and return it as a DCEL mesh enclosed in a full BVH.
-    @param[in] a_filename File name
-  */
-  template <typename T, typename Meta, typename BV = EBGeometry::BoundingVolumes::AABBT<T>, size_t K = 4>
-  inline static std::shared_ptr<FastTriMeshSDF<T, Meta, BV, K>>
-  readIntoTriangleBVH(const std::string a_filename) noexcept;
-
-  /*!
-    @brief Read multiple files containing single watertight objects and return them as DCEL meshes enclosed in BVHs.
-    @param[in] a_files File names
-  */
-  template <typename T,
-            typename Meta = DCEL::DefaultMetaData,
-            typename BV   = EBGeometry::BoundingVolumes::AABBT<T>,
-            size_t K      = 4>
-  inline static std::vector<std::shared_ptr<FastMeshSDF<T, Meta, BV, K>>>
-  readIntoTriangleBVH(const std::vector<std::string> a_files) noexcept;
-
-  /*!
     @brief Read a file containing a single watertight object and return it as a DCEL mesh enclosed in a linearized BVH
     @param[in] a_filename File name
   */
@@ -161,6 +126,41 @@ namespace Parser {
             size_t K      = 4>
   inline static std::vector<std::shared_ptr<FastCompactMeshSDF<T, Meta, BV, K>>>
   readIntoLinearBVH(const std::vector<std::string> a_files) noexcept;
+
+  /*!
+    @brief Read a file containing a single watertight object and return it as a DCEL mesh enclosed in a full BVH.
+    @param[in] a_filename File name
+  */
+  template <typename T, typename Meta, typename BV = EBGeometry::BoundingVolumes::AABBT<T>, size_t K = 4>
+  inline static std::shared_ptr<FastTriMeshSDF<T, Meta, BV, K>>
+  readIntoTriangleBVH(const std::string a_filename) noexcept;
+
+  /*!
+    @brief Read multiple files containing single watertight objects and return them as DCEL meshes enclosed in BVHs.
+    @param[in] a_files File names
+  */
+  template <typename T,
+            typename Meta = DCEL::DefaultMetaData,
+            typename BV   = EBGeometry::BoundingVolumes::AABBT<T>,
+            size_t K      = 4>
+  inline static std::vector<std::shared_ptr<FastMeshSDF<T, Meta, BV, K>>>
+  readIntoTriangleBVH(const std::vector<std::string> a_files) noexcept;  
+
+  /*!
+    @brief Read a file containing a single watertight object and return it as an implicit function.
+    @param[in] a_filename File name
+  */
+  template <typename T, typename Meta>
+  inline static std::vector<std::shared_ptr<Triangle<T, Meta>>>
+  readIntoTriangles(const std::string a_filename) noexcept;
+
+  /*!
+    @brief Read multiple files containing single watertight objects and return them as an implicit functions.
+    @param[in] a_files File names
+  */
+  template <typename T, typename Meta>
+  inline static std::vector<std::vector<std::shared_ptr<Triangle<T, Meta>>>>
+  readIntoTriangles(const std::vector<std::string> a_files) noexcept;  
 
   /*!
     @brief Get file type

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -144,7 +144,7 @@ namespace Parser {
             typename BV   = EBGeometry::BoundingVolumes::AABBT<T>,
             size_t K      = 4>
   inline static std::vector<std::shared_ptr<FastMeshSDF<T, Meta, BV, K>>>
-  readIntoTriangleBVH(const std::vector<std::string> a_files) noexcept;  
+  readIntoTriangleBVH(const std::vector<std::string> a_files) noexcept;
 
   /*!
     @brief Read a file containing a single watertight object and return it as an implicit function.
@@ -160,7 +160,7 @@ namespace Parser {
   */
   template <typename T, typename Meta>
   inline static std::vector<std::vector<std::shared_ptr<Triangle<T, Meta>>>>
-  readIntoTriangles(const std::vector<std::string> a_files) noexcept;  
+  readIntoTriangles(const std::vector<std::string> a_files) noexcept;
 
   /*!
     @brief Get file type

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -169,7 +169,7 @@ Parser::readIntoTriangleBVH(const std::string a_filename) noexcept
 }
 
 template <typename T, typename Meta, typename BV, size_t K>
-inline std::vector<std::shared_ptr<FastTriMeshSDF<T, Meta, BV, K>>>
+inline std::vector<std::shared_ptr<FastMeshSDF<T, Meta, BV, K>>>
 Parser::readIntoTriangleBVH(const std::vector<std::string> a_files) noexcept
 {
   std::vector<std::shared_ptr<FastTriMeshSDF<T, Meta, BV, K>>> implicitFunctions;

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -163,9 +163,9 @@ template <typename T, typename Meta, typename BV, size_t K>
 inline std::shared_ptr<FastTriMeshSDF<T, Meta, BV, K>>
 Parser::readIntoTriangleBVH(const std::string a_filename) noexcept
 {
-  auto triangles = EBGeometry::Parser::readIntoTriangles<T, Meta>(a_filename);
+  const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
 
-  return std::make_shared<FastTriMeshSDF<T, Meta, BV, K>>(triangles);
+  return std::make_shared<FastTriMeshSDF<T, Meta, BV, K>>(mesh);
 }
 
 template <typename T, typename Meta, typename BV, size_t K>

--- a/Source/EBGeometry_Triangle.hpp
+++ b/Source/EBGeometry_Triangle.hpp
@@ -1,0 +1,272 @@
+/* EBGeometry
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the EBGeometry root directory.
+ */
+
+/*!
+  @file   EBGeometry_Triangle.hpp
+  @brief  Declaration of a triangle class with signed distance functionality.
+  @author Robert Marskar
+*/
+
+#ifndef EBGeometry_Triangle
+#define EBGeometry_Triangle
+
+// Std includes
+#include <array>
+
+// Our includes
+#include "EBGeometry_Vec.hpp"
+#include "EBGeometry_Triangle2D.hpp"
+
+namespace EBGeometry {
+
+  /*!
+    @brief Triangle class with signed distance functionality.
+    @details This class represents a planar triangle and has a signed distance functionality. It is
+    self-contained such that it can be directly copied to GPUs. The class contains a triangle face normal
+    vector; three vertex positions, and normal vectors for the three vertices and three edges.
+
+    This class assumes that the vertices are organized with the right-hand rule. I.e., edges are enumerated
+    as follows:
+
+    Edge 1 points from vertex 1 to vertex 2
+    Edge 2 points from vertex 2 to vertex 3
+    Edge 3 points from vertex 3 to vertex 0       
+
+    This class can compute its own normal vector from the vertex positions, and the triangle orientation
+    is then implicitly given by the vertex order.
+
+    To compute the distance from a point to the triangle, one must determine if the point projects to the
+    "inside" or "outside" of the triangle. This class contains a 2D embedding of the triangle that can perform
+    this project. If the query point projects to the inside of the triangle, the distance is simply the
+    projected distance onto the triangle plane. If it projects to the outside of the triangle, we check the
+    distance against the triangle edges and vertices. 
+    the ed
+  */
+  template <class T, class Meta>
+  class Triangle
+  {
+  public:
+    /*!
+      @brief Alias for 2D vector type
+    */
+    using Vec2 = Vec2T<T>;
+
+    /*!
+      @brief Alias for 3D vector type
+    */
+    using Vec3 = Vec3T<T>;
+
+    /*!
+      @brief Default constructor. Does not put the triangle in a usable state.
+    */
+    Triangle() noexcept = default;
+
+    /*!
+      @brief Copy constructor. 
+      @param[in] a_otherTriangle Other triangle.
+    */
+    Triangle(const Triangle& a_otherTriangle) noexcept = default;
+
+    /*!
+      @brief Full constructor. 
+      @param[in] a_vertexPositions Triangle vertex positions
+    */
+    Triangle(const std::array<Vec3, 3>& a_vertexPositions) noexcept;
+
+    /*!
+      @brief Destructor (does nothing).
+    */
+    ~Triangle() noexcept = default;
+
+    /*!
+      @brief Copy assignment. 
+      @param[in] a_otherTriangle Other triangle.
+    */
+    Triangle&
+    operator=(const Triangle& a_otherTriangle) noexcept = default;
+
+    /*!
+      @brief Move assignment. 
+      @param[in, out] a_otherTriangle Other triangle.
+    */
+    Triangle&
+    operator=(Triangle&& a_otherTriangle) noexcept = default;
+
+    /*!
+      @brief Set the triangle normal vector.
+      @param[in] a_normal Normal vector (should be consistent with the vertex ordering!).
+    */
+    void
+    setNormal(const Vec3& a_normal) noexcept;
+
+    /*!
+      @brief Set the triangle vertex positions
+      @param[in] a_vertexPositions Vertex positions
+    */
+    void
+    setVertexPositions(const std::array<Vec3, 3>& a_vertexPositions) noexcept;
+
+    /*!
+      @brief Set the triangle vertex normals
+      @param[in] a_vertexNormals Vertex normals
+    */
+    void
+    setVertexNormals(const std::array<Vec3, 3>& a_vertexNormals) noexcept;
+
+    /*!
+      @brief Set the triangle edge normals
+      @param[in] a_edgeNormals Edge normals
+    */
+    void
+    setEdgeNormals(const std::array<Vec3, 3>& a_edgeNormals) noexcept;
+
+    /*!
+      @brief Set the triangle meta-data
+      @param[in] a_metaData Triangle metadata.
+    */
+    void
+    setMetaData(const Meta& a_metaData) noexcept;
+
+    /*!
+      @brief Compute the triangle normal vector.
+      @details This computes the normal vector from two of the triangle edges.
+    */
+    void
+    computeNormal() noexcept;
+
+    /*!
+      @brief Get the triangle normal vector.
+      @return m_triangleNormal
+    */
+    Vec3&
+    getNormal() noexcept;
+
+    /*!
+      @brief Get the triangle normal vector.
+      @return m_triangleNormal
+    */
+    const Vec3&
+    getNormal() const noexcept;
+
+    /*!
+      @brief Get the vertex positions
+      @return m_vertexPositions
+    */
+    std::array<Vec3, 3>&
+    getVertexPositions() noexcept;
+
+    /*!
+      @brief Get the vertex positions
+      @return m_vertexPositions
+    */
+    const std::array<Vec3, 3>&
+    getVertexPositions() const noexcept;
+
+    /*!
+      @brief Get the vertex normals
+      @return m_vertexNormals
+    */
+    std::array<Vec3, 3>&
+    getVertexNormals() noexcept;
+
+    /*!
+      @brief Get the vertex normals
+      @return m_vertexNormals
+    */
+    const std::array<Vec3, 3>&
+    getVertexNormals() const noexcept;
+
+    /*!
+      @brief Get the edge normals
+      @return m_edgeNormals
+    */
+    std::array<Vec3, 3>&
+    getEdgeNormals() noexcept;
+
+    /*!
+      @brief Get the edge normals
+      @return m_edgeNormals
+    */
+    const std::array<Vec3, 3>&
+    getEdgeNormals() const noexcept;
+
+    /*!
+      @brief Get the triangle meta-data
+      @return m_metaData
+    */
+    Meta&
+    getMetaData() noexcept;
+
+    /*!
+      @brief Get the triangle meta-data
+      @return m_metaData
+    */
+    const Meta&
+    getMetaData() const noexcept;
+
+    /*!
+      @brief Compute the signed distance from the input point x to the triangle
+      @param[in] a_point Point
+    */
+    T
+    signedDistance(const Vec3& a_point) const noexcept;
+
+    /*!
+      @brief Check if a line passes through the triangle.
+      @details Returns true if the line segment passes through the triangle, edges of the triangle,
+      or through one of the vertices.
+      @param[in] a_x0 One endpoint of the line
+      @param[in] a_x1 Other endpoint of the line
+    */
+    bool
+    intersects(const Vec3& a_x0, const Vec3& a_x1) const noexcept;
+
+  protected:
+    /*!
+      @brief Triangle face normal
+    */
+    Vec3 m_triangleNormal = Vec3::max();
+
+    /*!
+      @brief Triangle vertex positions
+    */
+    std::array<Vec3, 3> m_vertexPositions{Vec3::max(), Vec3::max(), Vec3::max()};
+
+    /*!
+      @brief Triangle vertex normals
+    */
+    std::array<Vec3, 3> m_vertexNormals{Vec3::max(), Vec3::max(), Vec3::max()};
+    /*!
+      @brief Triangle edge normals
+    */
+    std::array<Vec3, 3> m_edgeNormals{Vec3::max(), Vec3::max(), Vec3::max()};
+
+    /*!
+      @brief 2D projection of the triangle to one of the Cartesian coordinate directions
+    */
+    Triangle2D<T> m_triangle2D;
+
+    /*!
+      @brief Triangle meta-data normals
+    */
+    Meta m_metaData;
+
+    /*!
+      @brief Returns the "projection" of a point to an edge.
+      @details This function parametrizes the edge as x(t) = x0 + (x1-x0)*t and
+      returns where on the this edge the point a_x0 projects. If projects onto the
+      edge if t = [0,1] and to one of the start/end vertices otherwise.
+      @param[in] a_point Query point
+      @param[in] a_x0 Starting edge coordinate
+      @param[in] a_x1 Final edge coordinate	
+    */
+    T
+    projectPointToEdge(const Vec3& a_point, const Vec3& a_x0, const Vec3& a_x1) const noexcept;
+  };
+} // namespace EBGeometry
+
+#include "EBGeometry_TriangleImplem.hpp" // NOLINT
+
+#endif

--- a/Source/EBGeometry_Triangle.hpp
+++ b/Source/EBGeometry_Triangle.hpp
@@ -213,16 +213,6 @@ namespace EBGeometry {
     T
     signedDistance(const Vec3& a_point) const noexcept;
 
-    /*!
-      @brief Check if a line passes through the triangle.
-      @details Returns true if the line segment passes through the triangle, edges of the triangle,
-      or through one of the vertices.
-      @param[in] a_x0 One endpoint of the line
-      @param[in] a_x1 Other endpoint of the line
-    */
-    bool
-    intersects(const Vec3& a_x0, const Vec3& a_x1) const noexcept;
-
   protected:
     /*!
       @brief Triangle face normal

--- a/Source/EBGeometry_Triangle2D.hpp
+++ b/Source/EBGeometry_Triangle2D.hpp
@@ -1,0 +1,204 @@
+/* EBGeometry
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the EBGeometry root directory.
+ */
+/*!
+  @file   EBGeometry_Triangle2D.hpp
+  @brief  Declaration of a class that encapsulates the projection of a 3D triangle
+  into a 2D plane.
+  @author Robert Marskar
+*/
+
+#ifndef EBGeometry_Triangle2D
+#define EBGeometry_Triangle2D
+
+// Std includes
+#include <array>
+
+// Our includes
+#include "EBGeometry_Vec.hpp"
+
+namespace EBGeometry {
+  /*!
+    @brief Class for embedding a triangle face into 2D.
+    @details This class is required for determining whether or not a 3D point
+    projected to the plane of a triangle lies inside or outside the
+    triangle. To do this we compute the 2D embedding of the triangle face,
+    reducing the problem to a tractable dimension where we can use well-tested
+    algorithm. Once the 2D embedding is computed, we can use well-known
+    algorithms for checking if a point lies inside or outside. The supported
+    algorithms are 1) The winding number algorithm (computing the winding number),
+    2) Computing the subtended angle of the point with the edges of the polygon
+    (sums to 360 degrees if the point is inside), or computing the crossing number
+    which checks how many times a ray cast from the point crosses the edges of the
+    triangle.
+  */
+  template <class T>
+  class Triangle2D
+  {
+  public:
+    /*!
+      @brief Alias for 2D vector type
+    */
+    using Vec2 = Vec2T<T>;
+
+    /*!
+      @brief Alias for 3D vector type
+    */
+    using Vec3 = Vec3T<T>;
+
+    /*!
+      @brief Supported algorithms for performing inside/outside tests when
+      checking if a point projects to the inside or outside of a polygon face.
+    */
+    enum class InsideOutsideAlgorithm // NOLINT
+    {
+      SubtendedAngle,
+      CrossingNumber,
+      WindingNumber
+    };
+
+    /*!
+      @brief Default constructor. Must subsequently call the define function.
+    */
+    Triangle2D() noexcept = default;
+
+    /*!
+      @brief Full constructor
+      @param[in] a_normal Normal vector of the 3D triangle
+      @param[in] a_vertices Vertex coordinates of the 3D triangle
+    */
+    Triangle2D(const Vec3& a_normal, const std::array<Vec3, 3>& a_vertices) noexcept;
+
+    /*!
+      @brief Copy constructor.
+      @param[in] a_triangle2D Other triangle
+    */
+    Triangle2D(const Triangle2D& a_triangle2D) noexcept = default;
+
+    /*!
+      @brief Move constructor.
+      @param[in, out] a_triangle2D Other triangle
+    */
+    Triangle2D(Triangle2D&& a_triangle2D) noexcept = default;
+
+    /*!
+      @brief Destructor (does nothing)
+    */
+    ~Triangle2D() noexcept = default;
+
+    /*!
+      @brief Copy assignment.
+      @param[in] a_triangle2D Other triangle
+    */
+    Triangle2D&
+    operator=(const Triangle2D& a_triangle2D) noexcept = default;
+
+    /*!
+      @brief Move assignment.
+      @param[in, out] a_triangle2D Other triangle
+    */
+    Triangle2D&
+    operator=(Triangle2D&& a_triangle2D) noexcept = default;
+
+    /*!
+      @brief Define function. Puts object in usable state. 
+      @param[in] a_normal Normal vector of the 3D triangle
+      @param[in] a_vertices Vertex coordinates of the 3D triangle
+    */
+    void
+    define(const Vec3& a_normal, const std::array<Vec3, 3>& a_vertices) noexcept;
+
+    /*!
+      @brief Check if a point is inside or outside the 2D polygon
+      @param[in] a_point     3D point coordinates
+      @param[in] a_algorithm Inside/outside algorithm
+      @details This will call the function corresponding to a_algorithm.
+    */
+    bool
+    isPointInside(const Vec3& a_point, InsideOutsideAlgorithm a_algorithm) const noexcept;
+
+    /*!
+      @brief Check if a point is inside a 2D polygon, using the winding number
+      algorithm
+      @param[in] a_point 3D point coordinates
+      @return Returns true if the 3D point projects to the inside of the 2D
+      polygon
+    */
+    bool
+    isPointInsideWindingNumber(const Vec3& a_point) const noexcept;
+
+    /*!
+      @brief Check if a point is inside a 2D polygon, by computing the number of
+      times a ray crosses the polygon edges.
+      @param[in] a_point 3D point coordinates
+      @return Returns true if the 3D point projects to the inside of the 2D
+      polygon
+    */
+    bool
+    isPointInsideCrossingNumber(const Vec3& a_point) const noexcept;
+
+    /*!
+      @brief Check if a point is inside a 2D polygon, using the subtended angles
+      @param[in] a_point 3D point coordinates
+      @return Returns true if the 3D point projects to the inside of the 2D
+      polygon
+    */
+    bool
+    isPointInsideSubtend(const Vec3& a_point) const noexcept;
+
+  private:
+    /*!
+      @brief The corresponding 2D x-direction (one direction is ignored)
+    */
+    int m_xDir = -1;
+
+    /*!
+      @brief The corresponding 2D y-direction (one direction is ignored)
+    */
+    int m_yDir = -1;
+
+    /*!
+      @brief List of points in 2D.
+      @details This is the position of the vertices, projected into a 2D plane.
+    */
+    std::array<Vec2, 2> m_vertices{Vec2::max(), Vec2::max()};
+
+    /*!
+      @brief Project a 3D point onto the 2D polygon plane (this ignores one of the
+      vector components)
+      @param[in] a_poitn 3D point
+      @return 2D point, ignoring one of the coordinate directions.
+    */
+    Vec2
+    projectPoint(const Vec3& a_point) const noexcept;
+
+    /*!
+      @brief Compute the winding number for a point P with the 2D polygon
+      @param[in] P 2D point
+      @return Returns winding number.
+    */
+    int
+    computeWindingNumber(const Vec2& a_point) const noexcept;
+
+    /*!
+      @brief Compute the crossing number for a point P with the 2D polygon
+      @param[in] a_point 2D point
+      @return Returns crossing number.
+    */
+    int
+    computeCrossingNumber(const Vec2& a_point) const noexcept;
+
+    /*!
+      @brief Compute the subtended angle for a point a_point with the 2D polygon
+      @param[in] a_point 2D point
+      @return Returns subtended angle.
+    */
+    T
+    computeSubtendedAngle(const Vec2& a_point) const noexcept;
+  };
+} // namespace EBGeometry
+
+#include "EBGeometry_Triangle2DImplem.hpp" // NOLINT
+
+#endif

--- a/Source/EBGeometry_Triangle2DImplem.hpp
+++ b/Source/EBGeometry_Triangle2DImplem.hpp
@@ -1,0 +1,215 @@
+/* EBGeometry
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the EBGeometry root directory.
+ */
+/*!
+  @file   EBGeometry_Triangle2DImplem.hpp
+  @brief  Implementation of EBGeometry_Triangle2DImplem.hpp
+  @author Robert Marskar
+*/
+
+#ifndef EBGeometry_Triangle2DImplem
+#define EBGeometry_Triangle2DImplem
+
+// Std includes
+#include <cmath>
+
+// Our includes
+#include "EBGeometry_Triangle2D.hpp"
+
+namespace EBGeometry {
+
+  template <class T>
+  Triangle2D<T>::Triangle2D(const Vec3T<T>& a_normal, const std::array<Vec3T<T>, 3>& a_vertices) noexcept
+  {
+    this->define(a_normal, a_vertices);
+  }
+
+  template <class T>
+  void
+  Triangle2D<T>::define(const Vec3T<T>& a_normal, const std::array<Vec3T<T>, 3>& a_vertices) noexcept
+  {
+    int projectDir = 0;
+
+    for (int dir = 1; dir < 3; dir++) {
+      if (std::abs(a_normal[dir]) > std::abs(a_normal[projectDir])) {
+        projectDir = dir;
+      }
+    }
+
+    m_xDir = 3;
+    m_yDir = 0;
+
+    for (int dir = 0; dir < 3; dir++) {
+      if (dir != projectDir) {
+        m_xDir = std::min(m_xDir, dir);
+        m_yDir = std::max(m_yDir, dir);
+      }
+    }
+
+    for (int i = 0; i < 3; i++) {
+      m_vertices[i] = this->projectPoint(a_vertices[i]);
+    }
+  }
+
+  template <class T>
+  bool
+  Triangle2D<T>::isPointInside(const Vec3T<T>& a_point, const InsideOutsideAlgorithm a_algorithm) const noexcept
+  {
+    bool ret = false;
+
+    switch (a_algorithm) {
+    case InsideOutsideAlgorithm::SubtendedAngle: {
+      ret = this->isPointInsideSubtend(a_point);
+
+      break;
+    }
+    case InsideOutsideAlgorithm::CrossingNumber: {
+      ret = this->isPointInsideCrossingNumber(a_point);
+
+      break;
+    }
+    case InsideOutsideAlgorithm::WindingNumber: {
+      ret = this->isPointInsideWindingNumber(a_point);
+
+      break;
+    }
+    }
+
+    return ret;
+  }
+
+  template <class T>
+  bool
+  Triangle2D<T>::isPointInsideWindingNumber(const Vec3T<T>& a_point) const noexcept
+  {
+    const Vec2T<T> projectedPoint = this->projectPoint(a_point);
+
+    const int windingNumber = this->computeWindingNumber(projectedPoint);
+
+    return windingNumber != 0;
+  }
+
+  template <class T>
+  bool
+  Triangle2D<T>::isPointInsideCrossingNumber(const Vec3T<T>& a_point) const noexcept
+  {
+    const Vec2T<T> projectedPoint = this->projectPoint(a_point);
+
+    const int crossingNumber = this->computeCrossingNumber(projectedPoint);
+
+    return (crossingNumber & 1);
+  }
+
+  template <class T>
+  bool
+  Triangle2D<T>::isPointInsideSubtend(const Vec3T<T>& a_point) const noexcept
+  {
+    const Vec2T<T> projectedPoint = this->projectPoint(a_point);
+
+    T sumTheta = this->computeSubtendedAngle(projectedPoint);
+
+    sumTheta = std::abs(sumTheta) / (T(2.0) * M_PI); // NOLINT
+
+    return (round(sumTheta) == 1);
+  }
+
+  template <class T>
+  Vec2T<T>
+  Triangle2D<T>::projectPoint(const Vec3T<T>& a_point) const noexcept
+  {
+
+    return Vec2T<T>(a_point[m_xDir], a_point[m_yDir]);
+  }
+
+  template <class T>
+  int
+  Triangle2D<T>::computeWindingNumber(const Vec2T<T>& a_point) const noexcept
+  {
+    int windingNumber = 0;
+
+    constexpr T zero = T(0.0);
+
+    auto isLeft = [](const Vec2T<T>& p0, const Vec2T<T>& p1, const Vec2T<T>& p2) {
+      return (p1.x() - p0.x()) * (p2.y() - p0.y()) - (p2.x() - p0.x()) * (p1.y() - p0.y());
+    };
+
+    // Loop through all edges of the polygon
+    for (int i = 0; i < 3; i++) {
+
+      const Vec2T<T>& P  = a_point;
+      const Vec2T<T>& p1 = m_vertices[i];
+      const Vec2T<T>& p2 = m_vertices[(i + 1) % 3];
+
+      const T res = isLeft(p1, p2, P);
+
+      if (p1.y() <= P.y()) {
+        if (p2.y() > P.y() && res > zero) {
+          windingNumber += 1;
+        }
+      }
+      else {
+        if (p2.y() <= P.y() && res < zero) {
+          windingNumber -= 1;
+        }
+      }
+    }
+
+    return windingNumber;
+  }
+
+  template <class T>
+  int
+  Triangle2D<T>::computeCrossingNumber(const Vec2T<T>& a_point) const noexcept
+  {
+    int crossingNumber = 0;
+
+    for (int i = 0; i < 3; i++) {
+      const Vec2T<T>& p1 = m_vertices[i];
+      const Vec2T<T>& p2 = m_vertices[(i + 1) % 3];
+
+      const bool upwardCrossing   = (p1.y() <= a_point.y()) && (p2.y() > a_point.y());
+      const bool downwardCrossing = (p1.y() > a_point.y()) && (p2.y() <= a_point.y());
+
+      if (upwardCrossing || downwardCrossing) {
+        const T t = (a_point.y() - p1.y()) / (p2.y() - p1.y());
+
+        if (a_point.x() < p1.x() + t * (p2.x() - p1.x())) {
+          crossingNumber += 1;
+        }
+      }
+    }
+
+    return crossingNumber;
+  }
+
+  template <class T>
+  T
+  Triangle2D<T>::computeSubtendedAngle(const Vec2T<T>& a_point) const noexcept
+  {
+    T sumTheta = 0.0;
+
+    for (int i = 0; i < 3; i++) {
+      const Vec2T<T> p1 = m_vertices[i] - a_point;
+      const Vec2T<T> p2 = m_vertices[(i + 1) % 3] - a_point;
+
+      const T theta1 = static_cast<T>(atan2(p1.y(), p1.x()));
+      const T theta2 = static_cast<T>(atan2(p2.y(), p2.x()));
+
+      T dTheta = theta2 - theta1;
+
+      while (dTheta > M_PI) {
+        dTheta -= 2.0 * M_PI;
+      }
+      while (dTheta < -M_PI) {
+        dTheta += 2.0 * M_PI;
+      }
+
+      sumTheta += dTheta;
+    }
+
+    return sumTheta;
+  }
+} // namespace EBGeometry
+
+#endif

--- a/Source/EBGeometry_Triangle2DImplem.hpp
+++ b/Source/EBGeometry_Triangle2DImplem.hpp
@@ -131,7 +131,7 @@ namespace EBGeometry {
     constexpr T zero = T(0.0);
 
     auto isLeft = [](const Vec2T<T>& p0, const Vec2T<T>& p1, const Vec2T<T>& p2) {
-      return (p1.x() - p0.x()) * (p2.y() - p0.y()) - (p2.x() - p0.x()) * (p1.y() - p0.y());
+      return (p1.x - p0.x) * (p2.y - p0.y) - (p2.x - p0.x) * (p1.y - p0.y);
     };
 
     // Loop through all edges of the polygon
@@ -143,13 +143,13 @@ namespace EBGeometry {
 
       const T res = isLeft(p1, p2, P);
 
-      if (p1.y() <= P.y()) {
-        if (p2.y() > P.y() && res > zero) {
+      if (p1.y <= P.y) {
+        if (p2.y > P.y && res > zero) {
           windingNumber += 1;
         }
       }
       else {
-        if (p2.y() <= P.y() && res < zero) {
+        if (p2.y <= P.y && res < zero) {
           windingNumber -= 1;
         }
       }
@@ -168,13 +168,13 @@ namespace EBGeometry {
       const Vec2T<T>& p1 = m_vertices[i];
       const Vec2T<T>& p2 = m_vertices[(i + 1) % 3];
 
-      const bool upwardCrossing   = (p1.y() <= a_point.y()) && (p2.y() > a_point.y());
-      const bool downwardCrossing = (p1.y() > a_point.y()) && (p2.y() <= a_point.y());
+      const bool upwardCrossing   = (p1.y <= a_point.y) && (p2.y > a_point.y);
+      const bool downwardCrossing = (p1.y > a_point.y) && (p2.y <= a_point.y);
 
       if (upwardCrossing || downwardCrossing) {
-        const T t = (a_point.y() - p1.y()) / (p2.y() - p1.y());
+        const T t = (a_point.y - p1.y) / (p2.y - p1.y);
 
-        if (a_point.x() < p1.x() + t * (p2.x() - p1.x())) {
+        if (a_point.x < p1.x + t * (p2.x - p1.x)) {
           crossingNumber += 1;
         }
       }
@@ -193,8 +193,8 @@ namespace EBGeometry {
       const Vec2T<T> p1 = m_vertices[i] - a_point;
       const Vec2T<T> p2 = m_vertices[(i + 1) % 3] - a_point;
 
-      const T theta1 = static_cast<T>(atan2(p1.y(), p1.x()));
-      const T theta2 = static_cast<T>(atan2(p2.y(), p2.x()));
+      const T theta1 = static_cast<T>(atan2(p1.y, p1.x));
+      const T theta2 = static_cast<T>(atan2(p2.y, p2.x));
 
       T dTheta = theta2 - theta1;
 

--- a/Source/EBGeometry_Triangle2DImplem.hpp
+++ b/Source/EBGeometry_Triangle2DImplem.hpp
@@ -29,11 +29,11 @@ namespace EBGeometry {
   void
   Triangle2D<T>::define(const Vec3T<T>& a_normal, const std::array<Vec3T<T>, 3>& a_vertices) noexcept
   {
-    int projectDir = 0;
+    int ignoreDir = 0;
 
     for (int dir = 1; dir < 3; dir++) {
-      if (std::abs(a_normal[dir]) > std::abs(a_normal[projectDir])) {
-        projectDir = dir;
+      if (std::abs(a_normal[dir]) > std::abs(a_normal[ignoreDir])) {
+        ignoreDir = dir;
       }
     }
 
@@ -41,7 +41,7 @@ namespace EBGeometry {
     m_yDir = 0;
 
     for (int dir = 0; dir < 3; dir++) {
-      if (dir != projectDir) {
+      if (dir != ignoreDir) {
         m_xDir = std::min(m_xDir, dir);
         m_yDir = std::max(m_yDir, dir);
       }
@@ -118,7 +118,6 @@ namespace EBGeometry {
   Vec2T<T>
   Triangle2D<T>::projectPoint(const Vec3T<T>& a_point) const noexcept
   {
-
     return Vec2T<T>(a_point[m_xDir], a_point[m_yDir]);
   }
 

--- a/Source/EBGeometry_TriangleImplem.hpp
+++ b/Source/EBGeometry_TriangleImplem.hpp
@@ -1,0 +1,235 @@
+/* EBGeometry
+ * Copyright © 2024 Robert Marskar
+ * Please refer to Copyright.txt and LICENSE in the EBGeometry root directory.
+ */
+
+/*!
+  @file   EBGeometry_TriangleImplem.hpp
+  @brief  Implementation of EBGeometry_Triangle.hpp
+  @author Robert Marskar
+*/
+
+#ifndef EBGeometry_TriangleImplem
+#define EBGeometry_TriangleImplem
+
+// Our includes
+#include "EBGeometry_Triangle.hpp"
+
+namespace EBGeometry {
+
+  template <class T, class Meta>
+  Triangle<T, Meta>::Triangle(const std::array<Vec3T<T>, 3>& a_vertexPositions) noexcept
+  {
+    this->setVertexPositions(a_vertexPositions);
+  }
+
+  template <class T, class Meta>
+  void
+  Triangle<T, Meta>::setNormal(const Vec3T<T>& a_normal) noexcept
+  {
+    this->m_triangleNormal = a_normal;
+  }
+
+  template <class T, class Meta>
+  void
+  Triangle<T, Meta>::setVertexPositions(const std::array<Vec3T<T>, 3>& a_vertexPositions) noexcept
+  {
+    for (int i = 0; i < 3; i++) {
+      this->m_vertexPositions[i] = a_vertexPositions[i];
+    }
+
+    this->computeNormal();
+
+    m_triangle2D.define(m_triangleNormal, m_vertexPositions);
+  }
+
+  template <class T, class Meta>
+  void
+  Triangle<T, Meta>::setVertexNormals(const std::array<Vec3T<T>, 3>& a_vertexNormals) noexcept
+  {
+    for (int i = 0; i < 3; i++) {
+      this->m_vertexNormals[i] = a_vertexNormals[i];
+    }
+  }
+
+  template <class T, class Meta>
+  void
+  Triangle<T, Meta>::setEdgeNormals(const std::array<Vec3T<T>, 3>& a_edgeNormals) noexcept
+  {
+    for (int i = 0; i < 3; i++) {
+      this->m_edgeNormals[i] = a_edgeNormals[i];
+    }
+  }
+
+  template <class T, class Meta>
+  void
+  Triangle<T, Meta>::setMetaData(const Meta& a_metaData) noexcept
+  {
+    this->m_metaData = a_metaData;
+  }
+
+  template <class T, class Meta>
+  void
+  Triangle<T, Meta>::computeNormal() noexcept
+  {
+    const Vec3T<T> x1x0 = m_vertexPositions[1] - m_vertexPositions[0];
+    const Vec3T<T> x2x1 = m_vertexPositions[2] - m_vertexPositions[1];
+
+    m_triangleNormal = cross(x1x0, x2x1);
+    m_triangleNormal = m_triangleNormal / m_triangleNormal.length();
+  }
+
+  template <class T, class Meta>
+  Vec3T<T>&
+  Triangle<T, Meta>::getNormal() noexcept
+  {
+    return (this->m_triangleNormal);
+  }
+
+  template <class T, class Meta>
+  const Vec3T<T>&
+  Triangle<T, Meta>::getNormal() const noexcept
+  {
+    return (this->m_triangleNormal);
+  }
+
+  template <class T, class Meta>
+  std::array<Vec3T<T>, 3>&
+  Triangle<T, Meta>::getVertexPositions() noexcept
+  {
+    return (this->m_vertexPositions);
+  }
+
+  template <class T, class Meta>
+  const std::array<Vec3T<T>, 3>&
+  Triangle<T, Meta>::getVertexPositions() const noexcept
+  {
+    return (this->m_vertexPositions);
+  }
+
+  template <class T, class Meta>
+  std::array<Vec3T<T>, 3>&
+  Triangle<T, Meta>::getVertexNormals() noexcept
+  {
+    return (this->m_vertexNormals);
+  }
+
+  template <class T, class Meta>
+  const std::array<Vec3T<T>, 3>&
+  Triangle<T, Meta>::getVertexNormals() const noexcept
+  {
+    return (this->m_vertexNormals);
+  }
+  template <class T, class Meta>
+  std::array<Vec3T<T>, 3>&
+  Triangle<T, Meta>::getEdgeNormals() noexcept
+  {
+    return (this->m_edgeNormals);
+  }
+
+  template <class T, class Meta>
+  const std::array<Vec3T<T>, 3>&
+  Triangle<T, Meta>::getEdgeNormals() const noexcept
+  {
+    return (this->m_edgeNormals);
+  }
+
+  template <class T, class Meta>
+  Meta&
+  Triangle<T, Meta>::getMetaData() noexcept
+  {
+    return (this->m_metaData);
+  }
+
+  template <class T, class Meta>
+  const Meta&
+  Triangle<T, Meta>::getMetaData() const noexcept
+  {
+    return (this->m_metaData);
+  }
+
+  template <class T, class Meta>
+  T
+  Triangle<T, Meta>::signedDistance(const Vec3T<T>& a_point) const noexcept
+  {
+    // Check if projection falls inside.
+    const bool isPointInside = m_triangle2D.isPointInsideWindingNumber(a_point);
+
+    T ret = std::numeric_limits<T>::max();
+
+    if (isPointInside) {
+      ret = m_triangleNormal.dot(a_point - m_vertexPositions[0]);
+    }
+    else {
+      // If this triggers then
+      auto sgn = [](const T x) -> int { return (x > 0.0) ? 1 : -1; };
+
+      // Check distances to vertices.
+      for (int i = 0; i < 3; i++) {
+        const Vec3T<T> delta = a_point - m_vertexPositions[i];
+
+        ret = (delta.length() > std::abs(ret)) ? ret : delta.length() * sgn(m_vertexNormals[i].dot(delta));
+      }
+
+      // Check distances to edges
+      for (int i = 0; i < 3; i++) {
+        const Vec3T<T>& a = m_vertexPositions[i];
+        const Vec3T<T>& b = m_vertexPositions[(i + 1) % 3];
+
+        const T t = this->projectPointToEdge(a_point, a, b);
+
+        if (t > 0.0 && t < 1.0) {
+          const Vec3T<T> delta = a_point - (a + t * (b - a));
+
+          ret = (delta.length() > std::abs(ret)) ? ret : delta.length() * sgn(m_edgeNormals[i].dot(delta));
+        }
+      }
+    }
+
+    return ret;
+  }
+
+  template <class T, class Meta>
+  T
+  Triangle<T, Meta>::projectPointToEdge(const Vec3T<T>& a_point,
+                                        const Vec3T<T>& a_x0,
+                                        const Vec3T<T>& a_x1) const noexcept
+  {
+    const Vec3T<T> a = a_point - a_x0;
+    const Vec3T<T> b = a_x1 - a_x0;
+
+    EBGEOMETRY_EXPECT(b.length() > std::numeric_limits<T>::min());
+
+    return a.dot(b) / (b.dot(b));
+  }
+
+  template <class T, class Meta>
+  bool
+  Triangle<T, Meta>::intersects(const Vec3T<T>& a_x0, const Vec3T<T>& a_x1) const noexcept
+  {
+    const T epsilon = std::numeric_limits<T>::eps();
+
+    const Vec3T<T> edge1 = m_vertexPositions[1] - m_vertexPositions[0];
+    const Vec3T<T> edge2 = m_vertexPositions[2] - m_vertexPositions[0];
+    const Vec3T<T> ray   = a_x1 - a_x0;
+
+    const T det    = -dot(ray, m_triangleNormal);
+    const T invDet = T(1.0) / det;
+
+    const Vec3T<T> AO  = a_x0 - m_vertexPositions[0];
+    const Vec3T<T> DAO = cross(AO, ray);
+
+    const T u = dot(edge2, DAO) * invDet;
+    const T v = -dot(edge1, DAO) * invDet;
+    const T t = dot(AO, m_triangleNormal) * invDet;
+
+    const bool a = std::abs(det) > epsilon;
+    const bool b = (t >= 0.0) && (t <= 1.0);
+    const bool c = (u >= 0.0) && (std::abs(u - 1.0) >= 0.0);
+    const bool d = (v >= 0.0) && (std::abs(u + v - 1.0) >= 0.0);
+
+    return (a && b && c && d);
+  }
+} // namespace EBGeometry
+
+#endif

--- a/Source/EBGeometry_TriangleImplem.hpp
+++ b/Source/EBGeometry_TriangleImplem.hpp
@@ -14,7 +14,6 @@
 
 // Our includes
 #include "EBGeometry_Triangle.hpp"
-#include "EBGeometry_Polygon2D.hpp"
 
 namespace EBGeometry {
 
@@ -147,32 +146,12 @@ namespace EBGeometry {
   T
   Triangle<T, Meta>::signedDistance(const Vec3T<T>& a_point) const noexcept
   {
+    T ret = std::numeric_limits<T>::max();
+
     // Check if projection falls inside. x is the projected point
     const auto x = a_point - m_triangleNormal * (m_triangleNormal.dot(a_point - m_vertexPositions[0]));
 
-#if 1
     const bool isPointInside = m_triangle2D.isPointInsideCrossingNumber(x);
-#else
-#warning "Restore original code when debugging is done"    
-    std::vector<Vec3T<T>> vertices;
-    for (const auto& v : m_vertexPositions) {
-      vertices.emplace_back(v);
-    }
-
-    auto tri2  = std::make_shared<Triangle2D<T>>(m_triangleNormal, m_vertexPositions);
-    auto poly2 = std::make_shared<Polygon2D<T>>(m_triangleNormal, vertices);
-
-    const bool isPointInsideTri  = tri2->isPointInsideCrossingNumber(x);
-    const bool isPointInsidePoly = poly2->isPointInside(x, Polygon2D<T>::InsideOutsideAlgorithm::CrossingNumber);
-
-    const bool isPointInside = isPointInsidePoly;
-
-    if (isPointInsideTri != isPointInsidePoly) {
-      std::cout << "should not happen" << std::endl;
-    }
-#endif
-
-    T ret = std::numeric_limits<T>::max();
 
     if (isPointInside) {
       ret = m_triangleNormal.dot(a_point - m_vertexPositions[0]);

--- a/Source/EBGeometry_TriangleImplem.hpp
+++ b/Source/EBGeometry_TriangleImplem.hpp
@@ -75,7 +75,7 @@ namespace EBGeometry {
     const Vec3T<T> x1x0 = m_vertexPositions[1] - m_vertexPositions[0];
     const Vec3T<T> x2x1 = m_vertexPositions[2] - m_vertexPositions[1];
 
-    m_triangleNormal = cross(x1x0, x2x1);
+    m_triangleNormal = x1x0.cross(x2x1);
     m_triangleNormal = m_triangleNormal / m_triangleNormal.length();
   }
 
@@ -198,8 +198,6 @@ namespace EBGeometry {
     const Vec3T<T> a = a_point - a_x0;
     const Vec3T<T> b = a_x1 - a_x0;
 
-    EBGEOMETRY_EXPECT(b.length() > std::numeric_limits<T>::min());
-
     return a.dot(b) / (b.dot(b));
   }
 
@@ -217,7 +215,7 @@ namespace EBGeometry {
     const T invDet = T(1.0) / det;
 
     const Vec3T<T> AO  = a_x0 - m_vertexPositions[0];
-    const Vec3T<T> DAO = cross(AO, ray);
+    const Vec3T<T> DAO = AO.cross(ray);
 
     const T u = dot(edge2, DAO) * invDet;
     const T v = -dot(edge1, DAO) * invDet;

--- a/Source/EBGeometry_TriangleImplem.hpp
+++ b/Source/EBGeometry_TriangleImplem.hpp
@@ -200,34 +200,6 @@ namespace EBGeometry {
 
     return a.dot(b) / (b.dot(b));
   }
-
-  template <class T, class Meta>
-  bool
-  Triangle<T, Meta>::intersects(const Vec3T<T>& a_x0, const Vec3T<T>& a_x1) const noexcept
-  {
-    const T epsilon = std::numeric_limits<T>::eps();
-
-    const Vec3T<T> edge1 = m_vertexPositions[1] - m_vertexPositions[0];
-    const Vec3T<T> edge2 = m_vertexPositions[2] - m_vertexPositions[0];
-    const Vec3T<T> ray   = a_x1 - a_x0;
-
-    const T det    = -dot(ray, m_triangleNormal);
-    const T invDet = T(1.0) / det;
-
-    const Vec3T<T> AO  = a_x0 - m_vertexPositions[0];
-    const Vec3T<T> DAO = AO.cross(ray);
-
-    const T u = dot(edge2, DAO) * invDet;
-    const T v = -dot(edge1, DAO) * invDet;
-    const T t = dot(AO, m_triangleNormal) * invDet;
-
-    const bool a = std::abs(det) > epsilon;
-    const bool b = (t >= 0.0) && (t <= 1.0);
-    const bool c = (u >= 0.0) && (std::abs(u - 1.0) >= 0.0);
-    const bool d = (v >= 0.0) && (std::abs(u + v - 1.0) >= 0.0);
-
-    return (a && b && c && d);
-  }
 } // namespace EBGeometry
 
 #endif


### PR DESCRIPTION
- [x] Todo: Update ALL examples to use the triangle mesh clas
- [x] Implement getClosestFaces for the triangle mesh class
- [x] Triangles don't produce the correct result. Could be an inside/outside error
- [x] TriMesh and Triangle should have a flipping functionality. This is in DCEL but not in the triangle mesh. Solved by letting TriMeshSDF take the DCEL mesh as input and then convert to triangles. 
- [x] Fix Intel CI errors
- [x] Run all examples and ensure that they make sense
- [x] After all the above is done, Update documentation to make it clear that we can also use direct triangle meshes, which will avoid some DCEL loop iterations. Must go through all literalincludes to ensure that they make sense.
