### PR TITLE
Add Claude Code GitHub Actions workflows, gated to write-access users

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,63 @@
+name: Claude Code Review
+
+# Security gate: see the comment in claude.yml -- the same actor-permission check is used
+# here so both Claude-triggering workflows in this repo enforce access the same way.
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  check-mention:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude review')
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+    steps:
+      - name: Check that the triggering actor has write access
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = ['admin', 'write'].includes(data.permission);
+            core.setOutput('allowed', allowed);
+            if (!allowed) {
+              core.notice(`@claude review ignored: ${context.actor} has '${data.permission}' permission on this repo (needs write or admin).`);
+            }
+
+  claude-review:
+    needs: check-mention
+    if: needs.check-mention.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,85 @@
+name: Claude Code
+
+# Security gate: every trigger below is checked against the triggering actor's actual
+# repository permission (job "check-mention") before the "claude" job is allowed to run.
+# github.actor is the user whose action fired the workflow (the commenter, reviewer, or
+# issue author/assigner, depending on event type), so this uniformly restricts every
+# @claude mention -- not just PR review comments -- to users with write or admin access,
+# regardless of which of the four event types below fired. Assigning an issue already
+# requires triage-or-higher access on GitHub's own side, so the "assigned" case is
+# redundant-but-harmless here; it is included anyway so the gate is applied uniformly
+# rather than special-cased per trigger.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  check-mention:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+    steps:
+      - name: Check that the triggering actor has write access
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = ['admin', 'write'].includes(data.permission);
+            core.setOutput('allowed', allowed);
+            if (!allowed) {
+              core.notice(`@claude ignored: ${context.actor} has '${data.permission}' permission on this repo (needs write or admin).`);
+            }
+
+  claude:
+    needs: check-mention
+    if: needs.check-mention.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'


### PR DESCRIPTION
# Summary

Adds the Claude Code GitHub Actions integration so `@claude` mentions and `@claude review` work
in issues and PRs on this repo, gated so only users with write access can trigger it.

### Background

The PR template already references `@claude review` as a checklist item, but nothing in the repo
actually wires that up yet. `rmrsk/chombo-discharge` already has this set up
(`.github/workflows/claude.yml`, `claude-code-review.yml`), so this mirrors that setup rather than
inventing a new one -- with one deliberate change (see Solution).

### Solution

- `.github/workflows/claude.yml`: responds to `@claude` mentions in issue comments, PR review
  comments, PR reviews, and newly opened issues.
- `.github/workflows/claude-code-review.yml`: responds specifically to `@claude review` on a PR,
  running the `code-review` plugin.
- Both use `claude_code_oauth_token` (a subscription-backed OAuth token) rather than
  `anthropic_api_key`, matching chombo-discharge.
- **Every** trigger in both workflows is gated by a `check-mention` job that looks up the
  triggering actor's actual collaborator permission on this repo via the GitHub API
  (`repos.getCollaboratorPermissionLevel`) and only lets the real job run if that permission is
  `write` or `admin`. chombo-discharge's `claude.yml` has no such gate at all (anyone could tag
  `@claude` in a comment or a brand-new issue on that repo and consume the subscription quota);
  only its separate review workflow gates on comment `author_association`. This repo gates
  uniformly across all four trigger types in `claude.yml`, not just comment-triggered ones, since
  opening a new public issue with `@claude ...` in the body is otherwise completely unrestricted.

### Side-effects

- Neither workflow can actually run yet -- `CLAUDE_CODE_OAUTH_TOKEN` is not set as a repository
  secret. Generate one locally with `claude setup-token` and add it under Settings -> Secrets and
  variables -> Actions before merging, or merge first and add the secret right after; either
  order is safe, since a missing secret just fails the one step that needs it; it doesn't block
  the gating logic or anything else in CI.
- Anyone without write access who tags `@claude` gets silently ignored (a `core.notice()` is
  logged in the Action run for visibility, but no comment is posted back to them) -- this is
  intentional, to avoid confirming to an outside user whether the bot exists at all, but flagging
  it in case a friendlier "sorry, no access" reply is preferred instead.

### Alternative solutions

Considered matching chombo-discharge's `author_association` check (inline in the job's `if:`,
checking `["OWNER", "MEMBER", "COLLABORATOR"]`) instead of a separate permission-lookup job --
rejected because `author_association` isn't available in a consistent shape across all four event
types this repo's `claude.yml` listens to (in particular, `issues: opened` doesn't have a
per-actor field that isn't also just "the issue author," which would be the wrong entity to gate
on if a maintainer ever wants to invoke Claude via a differently-authored issue by assigning it).
A single actor-permission lookup via the API sidesteps that per-event-type mismatch and is
authoritative (it's the same permission model that decides who can push/merge), at the cost of one
extra job/API call per trigger.

### PR-review checklist

- [x] I have run the test suite and made sure that it passed. *(N/A -- workflow-only change, no
      library code touched; YAML validated with a syntax check)*
- [x] I have documented all relevant new features in the user documentation (Sphinx).
- [x] I have ensured that this contribution does not break existing sections in the user documentation.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information. *(REUSE lint passed; no
      license header required for these files under this repo's policy)*
- [ ] I have run a PR review using `@claude review`. *(Can't yet -- this PR is what wires that up;
      the secret still needs to be added first)*

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01HS5LFQihKoMrE6nbPaQW9R
