### PR TITLE
Rename BVH/Octree traversal role-names to match their actual roles

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Curated static-analysis set for EBGeometry (a header-only, template-heavy library).
-# Disabled checks are either intentional design here (decl/impl include cycle), unsafe in
-# headers (anonymous namespace / internal linkage), or pure style noise (use-auto, enum-size).
+# Disabled checks are either intentional design here (decl/impl include cycle; hand-written
+# x86 SIMD intrinsics guarded by ISA macros, which simd-intrinsics wants replaced by a portable
+# wrapper), unsafe in headers (anonymous namespace / internal linkage), or pure style noise
+# (use-auto, enum-size).
 ---
 Checks: >
   bugprone-*,
@@ -25,7 +27,8 @@ Checks: >
   -modernize-avoid-c-arrays,
   -modernize-use-auto,
   -modernize-concat-nested-namespaces,
-  -performance-enum-size
+  -performance-enum-size,
+  -portability-simd-intrinsics
 
 WarningsAsErrors: ''
 HeaderFilterRegex: 'EBGeometry_[A-Za-z0-9_]*\.hpp'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ### Alternative solutions 
 
-### Reviewer checklist
+### Reviewer checklist (to be completed by a human)
 
 - [ ] The test suite compiles and runs to completion without warnings or errors.
 - [ ] All relevant new features are documented in the user documentation (Sphinx).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,12 +8,14 @@
 
 ### Alternative solutions 
 
-### PR-review checklist
+### Reviewer checklist
 
-- [ ] I have run the test suite and made sure that it passed.
-- [ ] I have documented all relevant new features in the user documentation (Sphinx).
-- [ ] I have ensured that this contribution does not break existing sections in the user documentation. 
-- [ ] I have added all relevant APIs to the doxygen documentation.
-- [ ] I have added appropriate labels to this PR.
-- [ ] I have added/revised proper licensing and copyright information.
-- [ ] I have run a PR review using `@claude review`.
+- [ ] The test suite compiles and runs to completion without warnings or errors.
+- [ ] All relevant new features are documented in the user documentation (Sphinx).
+- [ ] This contribution does not break existing sections in the user documentation. 
+- [ ] All relevant APIs are documented in the doxygen documentation.
+- [ ] Appropriate labels have been assigned to this PR.
+- [ ] New or revised proper licensing and copyright information is in place.
+- [ ] A PR review has been run using `@claude review`.
+- [ ] The continuous integration and testing hooks at GitHub run to completion.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,23 @@ hooks (clang-tidy, the debug build, Sphinx) only run via this script or explicit
 compilers, SIMD levels, precisions, sanitizers, both Debug and Release) that isn't practical to
 reproduce byte-for-byte locally.
 
+## Branching, pull requests, and other spin-offs
+
+**You are never allowed to automatically create new branches, submit pull requests, create git
+worktrees, or take any similar spin-off action without first asking the user and obtaining explicit
+approval.** Any spin-off must obtain explicit user approval. This holds even when it looks like the
+obvious next step — for example, isolating an unrelated change onto its own branch, or opening a PR
+once work is done: surface the option and let the user decide, do not just do it. Committing to the
+branch you are *already on* (once the user has asked for that work) is fine; it is the creation of
+new refs and the outward submission of PRs that always needs a green light first.
+
+When the user *does* ask you to open a PR, **always use the repository's pull-request template**
+(`.github/pull_request_template.md`) — its `# Summary` sections (`Background`, `Solution`,
+`Side-effects`, `Alternative solutions`) followed by the `Reviewer checklist`. Fill in the prose
+sections (this is the "PR note") but **leave every checklist item unchecked** (`- [ ]`) — the
+checklist is for a human reviewer to complete, not you. If a PR was already opened with a body that
+does not follow this template, edit the PR body to conform to it.
+
 ## A few non-obvious things worth knowing
 
 - **Precision is a compile-time parameter, not a runtime one.** Nearly everything is templated on

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -79,7 +79,7 @@ Top-down construction
 ______________________
 
 Top-down construction is done through the member function ``topDownSortAndPartition()``, which
-takes two optional arguments: a *partitioner* and a *stop function*.
+takes two optional arguments: a *partitioner* and a *leaf predicate*.
 
 The partitioner is a functor that splits a list of ``(primitive, BV)`` pairs into ``K`` new
 lists whenever a leaf is subdivided. Three ready-made partitioners are provided:
@@ -87,9 +87,9 @@ lists whenever a leaf is subdivided. Three ready-made partitioners are provided:
 default), ``PrimitiveCentroidPartitioner`` (the same idea, but splits on primitive centroids
 instead), and ``BinnedSAHPartitioner`` (a Surface-Area-Heuristic partitioner, used automatically
 when building via ``BVH::Build::SAH`` -- see below -- and typically producing the
-best-performing trees at a higher construction cost). The stop function takes a ``TreeBVH`` node
-and decides whether it should be split any further; a default is provided, but callers are free
-to supply their own of either kind.
+best-performing trees at a higher construction cost). The leaf predicate takes a ``TreeBVH`` node
+and decides whether it should become a leaf (i.e. not be split any further); a default is provided,
+but callers are free to supply their own of either kind.
 
 Bottom-up construction
 ________________________
@@ -292,9 +292,9 @@ The DCEL mesh distance fields use a traversal pattern based on
 * When visiting a leaf node, check if the primitives are closer than the minimum distance computed so far.
 
 ``MeshSDF::signedDistance()`` implements these rules directly as the four traversal callbacks:
-the updater scans a leaf's faces and keeps the signed distance with the smallest magnitude seen so
-far; the visiter prunes any node whose bounding-volume distance already exceeds that magnitude;
-the sorter visits the closest child first; and the meta-updater supplies each node's distance to
+the leaf-evaluator scans a leaf's faces and keeps the signed distance with the smallest magnitude seen so
+far; the prune-predicate prunes any node whose bounding-volume distance already exceeds that magnitude;
+the child-orderer visits the closest child first; and the node-key-factory supplies each node's distance to
 its bounding volume. For the full API, see the Doxygen reference for
 `MeshSDF <doxygen/html/classEBGeometry_1_1MeshSDF.html>`__.
 
@@ -305,9 +305,9 @@ Combinations of implicit functions in EBGeometry into aggregate objects can be d
 One such union is known as the *smooth union*, in which the transition between two objects is gradual rather than abrupt.
 
 ``BVHSmoothUnionIF::value()`` traverses the tree while tracking the two smallest values seen so
-far, ``a`` and ``b`` (``a`` the closest, ``b`` the second-closest): the updater updates both as
-leaves are scanned, the visiter prunes any node whose bounding-volume distance exceeds both,
-the sorter visits the closest child first, and the meta-updater again supplies each node's
+far, ``a`` and ``b`` (``a`` the closest, ``b`` the second-closest): the leaf-evaluator updates both as
+leaves are scanned, the prune-predicate prunes any node whose bounding-volume distance exceeds both,
+the child-orderer visits the closest child first, and the node-key-factory again supplies each node's
 distance to its bounding volume. Once traversal completes, the two values are blended with the
 stored smooth-minimum operator. See :ref:`Chap:ImplemCSG` for the CSG combinators themselves, and
 the Doxygen reference for

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -168,51 +168,51 @@ BVH with user-specified criteria. For both BVH representations, tree traversal i
 single ``traverse()`` member function taking four caller-supplied callbacks, and uses a
 stack-based traversal pattern driven by those callbacks. The full type signatures for the four
 callback roles below are documented on `the BVH namespace's doxygen page
-<doxygen/html/namespaceEBGeometry_1_1BVH.html>`__ (look for ``Visiter``, ``Sorter``/
-``PackedSorter``, ``Updater``/``PackedUpdater``, and ``MetaUpdater``).
+<doxygen/html/namespaceEBGeometry_1_1BVH.html>`__ (look for ``PrunePredicate``, ``ChildOrderer``/
+``PackedChildOrderer``, ``LeafEvaluator``/``PackedLeafEvaluator``, and ``NodeKeyFactory``).
 
 Node visit
 __________
 
-The *visiter* callback decides, for a given node and its associated meta-data (see below),
+The *prune-predicate* callback decides, for a given node and its associated node key (see below),
 whether that node's subtree should be investigated or pruned from the traversal: it is a
-predicate taking the node and its meta-data, returning ``true`` to visit the subtree and
-``false`` to prune it. Typically, the meta-data parameter will contain the necessary information
+predicate taking the node and its node key, returning ``true`` to visit the subtree and
+``false`` to prune it. Typically, the node key will contain the necessary information
 that determines whether or not to visit the subtree.
 
-Traversal pattern
-_________________
+Child ordering
+______________
 
 If a subtree is visited in the traversal, there is a question of which of the child nodes to visit first.
-The *sorter* callback determines this order by letting the user sort the ``K`` children (each
-paired with its meta-data) in-place based on order of importance -- for ``PackedBVH`` the
+The *child-orderer* callback determines this order by letting the user sort the ``K`` children (each
+paired with its node key) in-place based on order of importance -- for ``PackedBVH`` the
 children are identified by their node index rather than a pointer, halving the per-entry stack
 size relative to ``TreeBVH``. Note that a correct visitation pattern can yield large performance
-benefits. Sorting the child nodes is completely optional; the user can leave this function empty
+benefits. Ordering the child nodes is completely optional; the user can leave this function empty
 if it does not matter which subtrees are visited first.
 
-Update rule
-___________
+Leaf evaluation
+_______________
 
 If a leaf node is visited in the traversal, distance or other types of queries to the geometric
-primitive(s) in the node are usually made. These are done by the *updater* callback. For
+primitive(s) in the node are usually made. These are done by the *leaf-evaluator* callback. For
 ``PackedBVH`` this callback receives an offset and count into the BVH's global primitive array,
 rather than a freshly-allocated sub-list, avoiding a heap allocation per leaf visit; for
-``TreeBVH`` it receives the leaf's primitive list directly. Typically, the updater will modify
+``TreeBVH`` it receives the leaf's primitive list directly. Typically, the leaf-evaluator will modify
 parameters that appear in a local scope outside of the tree traversal (e.g. updating the minimum
 distance to a DCEL mesh).
 
-Meta-data
-_________
+Node key
+________
 
-During the traversal, it might be necessary to compute meta-data that is helpful during the traversal, and this meta-data is attached to each node that is queried.
-This meta-data is usually, but not necessarily, equal to the distance to the nodes' bounding volumes.
-The *meta-updater* callback produces this meta-data for a node's children, given the node itself.
-The biggest difference between the updater and the meta-updater is that the updater is *only*
-called on leaf nodes whereas the meta-updater is also called for internal nodes. One typical
-example for DCEL meshes is that the updater computes the distance from an input point to the
-triangles in a leaf node, whereas the meta-updater computes the distance from the input point to
-the bounding volumes of a child node. This information is then used by the sorter in order to
+During the traversal, it might be necessary to compute a per-node key that is helpful during the traversal, and this key is attached to each node that is queried.
+This key is usually, but not necessarily, equal to the distance to the nodes' bounding volumes.
+The *node-key-factory* callback produces this key for a node's children, given the node itself.
+The biggest difference between the leaf-evaluator and the node-key-factory is that the leaf-evaluator is *only*
+called on leaf nodes whereas the node-key-factory is also called for internal nodes. One typical
+example for DCEL meshes is that the leaf-evaluator computes the distance from an input point to the
+triangles in a leaf node, whereas the node-key-factory computes the distance from the input point to
+the bounding volumes of a child node. This information is then used by the child-orderer in order to
 determine a preferred child visit pattern when descending along subtrees.
 
 Traversal algorithm
@@ -220,9 +220,9 @@ ___________________
 
 ``PackedBVH::traverse()`` implements this with a non-recursive, vector-backed stack rather than
 recursion. Each stack entry holds a node index together with that node's already-computed
-meta-data. The root is pushed first; then, until the stack is empty, the traversal pops an entry,
-asks the visiter whether to visit it, and if so either runs the updater (if it is a leaf) or
-computes the meta-updater for each of its ``K`` children, lets the sorter reorder them, and
+node key. The root is pushed first; then, until the stack is empty, the traversal pops an entry,
+asks the prune-predicate whether to visit it, and if so either runs the leaf-evaluator (if it is a leaf) or
+computes the node-key-factory for each of its ``K`` children, lets the child-orderer reorder them, and
 pushes them all onto the stack. For the full API, see the Doxygen reference for
 `PackedBVH <doxygen/html/classEBGeometry_1_1BVH_1_1PackedBVH.html>`__.
 

--- a/Docs/Sphinx/source/ImplemOctree.rst
+++ b/Docs/Sphinx/source/ImplemOctree.rst
@@ -54,15 +54,15 @@ Tree traversal
 ---------------
 
 Tree traversal is done through the member function ``traverse``, which visits nodes top-down using
-a visit-sort-update pattern analogous to the BVH traversal described in :ref:`Chap:ImplemBVH`. The
+a prune-order-evaluate pattern analogous to the BVH traversal described in :ref:`Chap:ImplemBVH`. The
 input functions to ``traverse`` are as follows:
 
-#. ``Visiter`` -- a predicate ``bool(const Node&)`` called on every node (interior or leaf);
+#. ``PrunePredicate`` -- a predicate ``bool(const Node&)`` called on every node (interior or leaf);
    returning ``false`` prunes that entire subtree from the traversal.
-#. ``Sorter`` -- reorders a node's (up to) eight children in-place before they are visited, so the
+#. ``ChildOrderer`` -- reorders a node's (up to) eight children in-place before they are visited, so the
    traversal can, e.g., visit the closest child first. By default, no sorting is done and children
    are visited in lexicographical octant order.
-#. ``Updater`` -- called on every *leaf* node that ``Visiter`` did not prune; this is where the
+#. ``LeafEvaluator`` -- called on every *leaf* node that ``PrunePredicate`` did not prune; this is where the
    caller actually consumes the leaf (e.g. to accumulate a result).
 
 .. _Sec:OctreeBoundingVolume:
@@ -97,7 +97,7 @@ Given an initial search box and a maximum tree depth, the algorithm is:
    -- this is the "bounded refinement" mentioned above, implemented entirely inside the
    ``SplitFunction``/``MetaConstructor`` pair rather than by any feature of ``Node`` itself. The
    tree is built with ``buildBreadthFirst``.
-#. The tree is then traversed (``Visiter`` keeps only flagged nodes, ``Updater`` collects each
+#. The tree is then traversed (``PrunePredicate`` keeps only flagged nodes, ``LeafEvaluator`` collects each
    surviving leaf's eight corner points), and the final bounding volume is constructed directly
    from that point set: ``BV`` need only be constructible from a ``std::vector<Vec3T<T>>``.
 

--- a/Docs/mainpage.md
+++ b/Docs/mainpage.md
@@ -31,7 +31,7 @@ integration, the underlying geometric concepts), see the
 |---|---|
 | `EBGeometry` | Vectors (`Vec2T`, `Vec3T`), implicit functions, signed distance functions, analytic shapes, CSG operators, transformations, the SDF/BVH wrapper classes (`MeshSDF`, `TriMeshSDF`, `FlatMeshSDF`) |
 | `EBGeometry::DCEL` | The half-edge surface mesh: `VertexT`, `EdgeT`, `FaceT`, `MeshT`, and mesh iterators |
-| `EBGeometry::BVH` | `TreeBVH`, `PackedBVH`, partitioners, traversal callback types (`Updater`, `Visiter`, `Sorter`, `MetaUpdater`) |
+| `EBGeometry::BVH` | `TreeBVH`, `PackedBVH`, partitioners, traversal callback types (`LeafEvaluator`, `PrunePredicate`, `ChildOrderer`, `NodeKeyFactory`) |
 | `EBGeometry::BoundingVolumes` | `AABBT` (axis-aligned box) and `SphereT` (bounding sphere) |
 | `EBGeometry::Octree` | Pointer-based octree used internally for bounding-volume estimation of arbitrary implicit functions |
 | `EBGeometry::SFC` | Space-filling curves (`Morton`, `Nested`) used for bottom-up BVH construction |

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -94,7 +94,7 @@ DefaultBranchingRatio() noexcept
 }
 
 /**
- * @brief Forward declaration of the tree-structured BVH. Needed by StopFunction and the
+ * @brief Forward declaration of the tree-structured BVH. Needed by LeafPredicate and the
  * default-partitioner lambdas defined below.
  */
 template <class T, class P, class BV, size_t K>
@@ -151,19 +151,19 @@ using Partitioner = std::function<std::array<PrimAndBVList<P, BV>, K>(const Prim
  * @return True if the node should not be sub-divided further.
  */
 template <class T, class P, class BV, size_t K>
-using StopFunction = std::function<bool(const TreeBVH<T, P, BV, K>& a_node)>;
+using LeafPredicate = std::function<bool(const TreeBVH<T, P, BV, K>& a_node)>;
 
 /**
- * @brief Leaf-update callback for TreeBVH::traverse.
+ * @brief Leaf-evaluation callback for TreeBVH::traverse.
  * @details Called once for every leaf node visited during traversal.
  * @tparam P Primitive type.
  * @param[in] a_primitives Primitive list stored in the leaf.
  */
 template <class P>
-using Updater = std::function<void(const PrimitiveList<P>& a_primitives)>;
+using LeafEvaluator = std::function<void(const PrimitiveList<P>& a_primitives)>;
 
 /**
- * @brief Leaf-update callback for PackedBVH::traverse.
+ * @brief Leaf-evaluation callback for PackedBVH::traverse.
  * @details Receives a view into the global primitive array (offset + count) rather than a
  * temporary sub-list, avoiding a heap allocation per leaf visit.
  * @tparam P Primitive type.
@@ -172,55 +172,56 @@ using Updater = std::function<void(const PrimitiveList<P>& a_primitives)>;
  * @param[in] a_count      Number of primitives in this leaf.
  */
 template <class P>
-using PackedUpdater = std::function<void(const PrimitiveList<P>& a_primitives, size_t a_offset, size_t a_count)>;
+using PackedLeafEvaluator = std::function<void(const PrimitiveList<P>& a_primitives, size_t a_offset, size_t a_count)>;
 
 /**
  * @brief Node-visit predicate for BVH traversal.
  * @details Must return true to descend into the node and false to prune it.
  * @tparam NodeType Node type (TreeBVH or PackedBVH::Node).
- * @tparam Meta     Caller-supplied auxiliary data type attached to each stack entry
+ * @tparam NodeKey  Caller-supplied per-node key attached to each stack entry
  * (e.g. a running minimum distance).
  * @param[in] a_node Node under consideration.
- * @param[in] a_meta Caller-supplied meta-data for this stack entry.
+ * @param[in] a_nodeKey Caller-supplied key for this stack entry.
  * @return True if the subtree rooted at a_node should be visited.
  */
-template <class NodeType, class Meta>
-using Visiter = std::function<bool(const NodeType& a_node, const Meta& a_meta)>;
+template <class NodeType, class NodeKey>
+using PrunePredicate = std::function<bool(const NodeType& a_node, const NodeKey& a_nodeKey)>;
 
 /**
  * @brief Child-ordering callback for TreeBVH traversal.
- * @details Sorts an array of (child-node-pointer, meta) pairs in-place so that
+ * @details Sorts an array of (child-node-pointer, key) pairs in-place so that
  * the most promising child is visited first.
  * @tparam NodeType Node type (TreeBVH).
- * @tparam Meta     Auxiliary data type attached to each stack entry.
+ * @tparam NodeKey  Per-node key attached to each stack entry.
  * @tparam K        Tree branching factor.
- * @param[in,out] a_children K child nodes together with their meta-data.
+ * @param[in,out] a_children K child nodes together with their node keys.
  */
-template <class NodeType, class Meta, size_t K>
-using Sorter = std::function<void(std::array<std::pair<std::shared_ptr<const NodeType>, Meta>, K>& a_children)>;
+template <class NodeType, class NodeKey, size_t K>
+using ChildOrderer =
+  std::function<void(std::array<std::pair<std::shared_ptr<const NodeType>, NodeKey>, K>& a_children)>;
 
 /**
  * @brief Child-ordering callback for PackedBVH traversal.
- * @details Same role as Sorter but uses 32-bit node indices instead of shared_ptrs,
+ * @details Same role as ChildOrderer but uses 32-bit node indices instead of shared_ptrs,
  * halving the stack-entry size.
- * @tparam Meta Auxiliary data type attached to each stack entry.
+ * @tparam NodeKey Per-node key attached to each stack entry.
  * @tparam K    Tree branching factor.
- * @param[in,out] a_children K (node-index, meta) pairs to sort.
+ * @param[in,out] a_children K (node-index, key) pairs to sort.
  */
-template <class Meta, size_t K>
-using PackedSorter = std::function<void(std::array<std::pair<uint32_t, Meta>, K>& a_children)>;
+template <class NodeKey, size_t K>
+using PackedChildOrderer = std::function<void(std::array<std::pair<uint32_t, NodeKey>, K>& a_children)>;
 
 /**
- * @brief Meta-data factory called once per node during BVH traversal.
- * @details Produces the Meta value that will be passed to Visiter and Sorter for
+ * @brief Node-key factory called once per node during BVH traversal.
+ * @details Produces the NodeKey value that will be passed to PrunePredicate and ChildOrderer for
  * each child of the current node.
  * @tparam NodeType Node type (TreeBVH or PackedBVH::Node).
- * @tparam Meta     Auxiliary data type to produce.
+ * @tparam NodeKey  Per-node key type to produce.
  * @param[in] a_node Current node.
- * @return Meta value for a_node's children.
+ * @return NodeKey value for a_node's children.
  */
-template <class NodeType, class Meta>
-using MetaUpdater = std::function<Meta(const NodeType& a_node)>;
+template <class NodeType, class NodeKey>
+using NodeKeyFactory = std::function<NodeKey(const NodeType& a_node)>;
 
 /**
  * @brief Utility: split a vector into K almost-equal contiguous chunks.
@@ -551,7 +552,7 @@ auto BinnedSAHPartitioner = [](const PrimAndBVList<P, BV>& a_primsAndBVs) -> std
  * @return True if the node has fewer than K primitives.
  */
 template <class T, class P, class BV, size_t K>
-auto DefaultStopFunction =
+auto DefaultLeafPredicate =
   [](const BVH::TreeBVH<T, P, BV, K>& a_node) noexcept -> bool { return (a_node.getPrimitives()).size() < K; };
 
 /**
@@ -606,7 +607,7 @@ public:
   /**
    * @brief Alias for the stop-function type.
    */
-  using StopFunction = BVH::StopFunction<T, P, BV, K>;
+  using LeafPredicate = BVH::LeafPredicate<T, P, BV, K>;
 
   /**
    * @brief Default constructor. Creates an empty interior node.
@@ -631,8 +632,8 @@ public:
    * @param[in] a_stopCrit    Stop function. Returns true when a node should become a leaf.
    */
   inline void
-  topDownSortAndPartition(const Partitioner&  a_partitioner = BVCentroidPartitioner<T, P, BV, K>,
-                          const StopFunction& a_stopCrit    = DefaultStopFunction<T, P, BV, K>);
+  topDownSortAndPartition(const Partitioner&   a_partitioner = BVCentroidPartitioner<T, P, BV, K>,
+                          const LeafPredicate& a_stopCrit    = DefaultLeafPredicate<T, P, BV, K>);
 
   /**
    * @brief Recursively partition this node bottom-up along a space-filling curve.
@@ -701,40 +702,40 @@ public:
 
   /**
    * @brief Recursion-free BVH traversal using an explicit LIFO stack (depth-first order).
-   * @details The traversal maintains a stack of (node, Meta) pairs. It is seeded with the
-   * root node paired with @p a_metaUpdater applied to the root. On each iteration:
+   * @details The traversal maintains a stack of (node, NodeKey) pairs. It is seeded with the
+   * root node paired with @p a_nodeKeyFactory applied to the root. On each iteration:
    *
-   * 1. Pop the top (node, meta) pair.
-   * 2. Call @p a_visiter(node, meta). If it returns false the entire subtree rooted at
+   * 1. Pop the top (node, nodeKey) pair.
+   * 2. Call @p a_prunePredicate(node, nodeKey). If it returns false the entire subtree rooted at
    * that node is skipped (pruned) and the loop continues with the next stack entry.
-   * 3. If the node is a leaf, call @p a_updater with the leaf's primitive list.
+   * 3. If the node is a leaf, call @p a_leafEvaluator with the leaf's primitive list.
    * 4. If the node is an interior node:
-   * a. Compute a Meta value for each of the K children by calling
-   * @p a_metaUpdater on each child.
-   * b. Collect the K (child, Meta) pairs into a local array and pass them to
-   * @p a_sorter, which reorders the array in-place.
+   * a. Compute a NodeKey value for each of the K children by calling
+   * @p a_nodeKeyFactory on each child.
+   * b. Collect the K (child, NodeKey) pairs into a local array and pass them to
+   * @p a_childOrderer, which reorders the array in-place.
    * c. Push all K pairs onto the stack in sorted order.
    *
-   * Because the stack is LIFO, the child pushed last is visited first. @p a_sorter
+   * Because the stack is LIFO, the child pushed last is visited first. @p a_childOrderer
    * should therefore place the most promising child last in the array. For a
    * nearest-distance query this means sorting children in descending order of
    * distance — farthest child first, nearest child last — so the nearest child
    * sits on top of the stack and is expanded next.
    *
-   * @tparam Meta Auxiliary data type carried on the traversal stack (e.g. a running minimum distance).
-   * @param[in] a_updater     Called at each leaf with the leaf's primitive list.
-   * @param[in] a_visiter     Called at each node; return true to descend, false to prune.
-   * @param[in] a_sorter      Reorders the K (child, Meta) pairs in-place before they are
+   * @tparam NodeKey Auxiliary data type carried on the traversal stack (e.g. a running minimum distance).
+   * @param[in] a_leafEvaluator     Called at each leaf with the leaf's primitive list.
+   * @param[in] a_prunePredicate     Called at each node; return true to descend, false to prune.
+   * @param[in] a_childOrderer      Reorders the K (child, NodeKey) pairs in-place before they are
    * pushed; the last element after sorting is visited first.
-   * @param[in] a_metaUpdater Produces a Meta value for a node; called once for the root
+   * @param[in] a_nodeKeyFactory Produces a NodeKey value for a node; called once for the root
    * and once per child of every interior node that is visited.
    */
-  template <class Meta>
+  template <class NodeKey>
   inline void
-  traverse(const BVH::Updater<P>&              a_updater,
-           const BVH::Visiter<Node, Meta>&     a_visiter,
-           const BVH::Sorter<Node, Meta, K>&   a_sorter,
-           const BVH::MetaUpdater<Node, Meta>& a_metaUpdater) const noexcept;
+  traverse(const BVH::LeafEvaluator<P>&               a_leafEvaluator,
+           const BVH::PrunePredicate<Node, NodeKey>&  a_prunePredicate,
+           const BVH::ChildOrderer<Node, NodeKey, K>& a_childOrderer,
+           const BVH::NodeKeyFactory<Node, NodeKey>&  a_nodeKeyFactory) const noexcept;
 
   /**
    * @brief Flatten this tree into a cache-friendly PackedBVH with the same primitive type.
@@ -818,7 +819,7 @@ protected:
  * TreeBVH::packWith<Q>(converter) (type-converting pack).
  *
  * PackedBVH imposes no interface requirement on P by itself -- it holds primitives opaquely and
- * only ever hands them back to a caller-supplied callback (traverse()'s Updater, or
+ * only ever hands them back to a caller-supplied callback (traverse()'s LeafEvaluator, or
  * pruneTraverse()'s LeafEvaluator). Nearest-surface (signed-distance-style) queries are not a
  * PackedBVH member; callers build their own thin wrapper around pruneTraverse(), supplying
  * whatever primitive interface their own query needs.
@@ -850,7 +851,7 @@ public:
    * @brief Compact BVH node stored in the flat node array.
    * @details Each node holds a bounding volume, a primitive range (leaves) or child
    * index table (interior nodes). Exposed as a public nested type so that users can
-   * write traverse() callbacks (Visiter, MetaUpdater) that inspect nodes.
+   * write traverse() callbacks (PrunePredicate, NodeKeyFactory) that inspect nodes.
    */
   struct Node
   {
@@ -1059,43 +1060,43 @@ public:
    *
    * The stack is a std::vector used as a LIFO queue via push_back/pop_back, pre-reserved to
    * 64 entries to avoid reallocation for typical tree depths. It is seeded with node index 0
-   * (the root) paired with @p a_metaUpdater applied to the root node. On each iteration:
+   * (the root) paired with @p a_nodeKeyFactory applied to the root node. On each iteration:
    *
-   * 1. Pop the back entry to obtain a (nodeIdx, meta) pair.
+   * 1. Pop the back entry to obtain a (nodeIdx, nodeKey) pair.
    * 2. Look up the node at m_linearNodes[nodeIdx].
-   * 3. Call @p a_visiter(node, meta). If it returns false the entire subtree rooted at
+   * 3. Call @p a_prunePredicate(node, nodeKey). If it returns false the entire subtree rooted at
    * that node is skipped (pruned) and the loop continues.
-   * 4. If the node is a leaf, call @p a_updater with the global primitive list
-   * m_primitives, the leaf's primitive offset, and its primitive count. The updater
+   * 4. If the node is a leaf, call @p a_leafEvaluator with the global primitive list
+   * m_primitives, the leaf's primitive offset, and its primitive count. The leafEvaluator
    * receives a view into the shared list rather than a freshly allocated sub-list,
    * avoiding a heap allocation per leaf visit.
    * 5. If the node is an interior node:
    * a. Collect the K child indices from node.getChildOffsets(), look each child up in
-   * m_linearNodes, and call @p a_metaUpdater on each to produce a Meta value.
-   * b. Bundle the K (childIdx, Meta) pairs into a local array and pass it to
-   * @p a_sorter, which reorders the array in-place.
+   * m_linearNodes, and call @p a_nodeKeyFactory on each to produce a NodeKey value.
+   * b. Bundle the K (childIdx, NodeKey) pairs into a local array and pass it to
+   * @p a_childOrderer, which reorders the array in-place.
    * c. Push all K pairs onto the back of the stack in sorted order.
    *
-   * Because the stack is LIFO, the child pushed last is visited first. @p a_sorter
+   * Because the stack is LIFO, the child pushed last is visited first. @p a_childOrderer
    * should therefore place the most promising child last in the array. For a
    * nearest-distance query this means sorting children in descending order of
    * distance — farthest child first, nearest child last — so the nearest child
    * sits at the back of the vector and is expanded next.
    *
-   * @tparam Meta Auxiliary data type carried on the traversal stack (e.g. a running minimum distance).
-   * @param[in] a_updater     Called at each leaf with the global primitive list, offset, and count.
-   * @param[in] a_visiter     Called at each node; return true to descend, false to prune.
-   * @param[in] a_sorter      Reorders the K (childIdx, Meta) pairs in-place before they are
+   * @tparam NodeKey Auxiliary data type carried on the traversal stack (e.g. a running minimum distance).
+   * @param[in] a_leafEvaluator     Called at each leaf with the global primitive list, offset, and count.
+   * @param[in] a_prunePredicate     Called at each node; return true to descend, false to prune.
+   * @param[in] a_childOrderer      Reorders the K (childIdx, NodeKey) pairs in-place before they are
    * pushed; the last element after sorting is visited first.
-   * @param[in] a_metaUpdater Produces a Meta value for a node; called once for the root
+   * @param[in] a_nodeKeyFactory Produces a NodeKey value for a node; called once for the root
    * and once per child of every interior node that is visited.
    */
-  template <class Meta>
+  template <class NodeKey>
   inline void
-  traverse(const BVH::PackedUpdater<P>&        a_updater,
-           const BVH::Visiter<Node, Meta>&     a_visiter,
-           const BVH::PackedSorter<Meta, K>&   a_sorter,
-           const BVH::MetaUpdater<Node, Meta>& a_metaUpdater) const noexcept;
+  traverse(const BVH::PackedLeafEvaluator<P>&         a_leafEvaluator,
+           const BVH::PrunePredicate<Node, NodeKey>&  a_prunePredicate,
+           const BVH::PackedChildOrderer<NodeKey, K>& a_childOrderer,
+           const BVH::NodeKeyFactory<Node, NodeKey>&  a_nodeKeyFactory) const noexcept;
 
   /**
    * @brief Generic SIMD-accelerated, distance-pruned traversal.

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -120,7 +120,7 @@ TreeBVH<T, P, BV, K>::getChildren() const noexcept
 
 template <class T, class P, class BV, size_t K>
 inline void
-TreeBVH<T, P, BV, K>::topDownSortAndPartition(const Partitioner& a_partitioner, const StopFunction& a_stopCrit)
+TreeBVH<T, P, BV, K>::topDownSortAndPartition(const Partitioner& a_partitioner, const LeafPredicate& a_stopCrit)
 {
   // Check if this node should be split into more nodes.
   const auto numPrimsInThisNode = m_primitives.size();
@@ -311,36 +311,36 @@ TreeBVH<T, P, BV, K>::getDistanceToBoundingVolume(const Vec3& a_point) const noe
 }
 
 template <class T, class P, class BV, size_t K>
-template <class Meta>
+template <class NodeKey>
 inline void
-TreeBVH<T, P, BV, K>::traverse(const BVH::Updater<P>&              a_updater,
-                               const BVH::Visiter<Node, Meta>&     a_visiter,
-                               const BVH::Sorter<Node, Meta, K>&   a_sorter,
-                               const BVH::MetaUpdater<Node, Meta>& a_metaUpdater) const noexcept
+TreeBVH<T, P, BV, K>::traverse(const BVH::LeafEvaluator<P>&               a_leafEvaluator,
+                               const BVH::PrunePredicate<Node, NodeKey>&  a_prunePredicate,
+                               const BVH::ChildOrderer<Node, NodeKey, K>& a_childOrderer,
+                               const BVH::NodeKeyFactory<Node, NodeKey>&  a_nodeKeyFactory) const noexcept
 {
-  std::array<std::pair<std::shared_ptr<const Node>, Meta>, K> children;
-  std::stack<std::pair<std::shared_ptr<const Node>, Meta>>    q;
+  std::array<std::pair<std::shared_ptr<const Node>, NodeKey>, K> children;
+  std::stack<std::pair<std::shared_ptr<const Node>, NodeKey>>    q;
 
-  q.emplace(this->shared_from_this(), a_metaUpdater(*this));
+  q.emplace(this->shared_from_this(), a_nodeKeyFactory(*this));
 
   while (!(q.empty())) {
-    const auto& node = q.top().first;
-    const auto& meta = q.top().second;
+    const auto& node    = q.top().first;
+    const auto& nodeKey = q.top().second;
 
     q.pop();
 
-    if (a_visiter(*node, meta)) {
+    if (a_prunePredicate(*node, nodeKey)) {
       if (node->isLeaf()) {
-        a_updater(node->getPrimitives());
+        a_leafEvaluator(node->getPrimitives());
       }
       else {
         for (size_t k = 0; k < K; k++) {
           children[k].first  = node->getChildren()[k];
-          children[k].second = a_metaUpdater(*children[k].first);
+          children[k].second = a_nodeKeyFactory(*children[k].first);
         }
 
         // User-based visit pattern.
-        a_sorter(children);
+        a_childOrderer(children);
 
         for (const auto& child : children) {
           q.push(child);
@@ -518,40 +518,40 @@ PackedBVH<T, P, K>::computeBoundingVolume() const noexcept
 }
 
 template <class T, class P, size_t K>
-template <class Meta>
+template <class NodeKey>
 inline void
-PackedBVH<T, P, K>::traverse(const BVH::PackedUpdater<P>&        a_updater,
-                             const BVH::Visiter<Node, Meta>&     a_visiter,
-                             const BVH::PackedSorter<Meta, K>&   a_sorter,
-                             const BVH::MetaUpdater<Node, Meta>& a_metaUpdater) const noexcept
+PackedBVH<T, P, K>::traverse(const BVH::PackedLeafEvaluator<P>&         a_leafEvaluator,
+                             const BVH::PrunePredicate<Node, NodeKey>&  a_prunePredicate,
+                             const BVH::PackedChildOrderer<NodeKey, K>& a_childOrderer,
+                             const BVH::NodeKeyFactory<Node, NodeKey>&  a_nodeKeyFactory) const noexcept
 {
-  std::array<std::pair<uint32_t, Meta>, K> children;
+  std::array<std::pair<uint32_t, NodeKey>, K> children;
 
   // Vector-backed stack avoids deque chunk allocations; reserve avoids reallocs.
-  std::vector<std::pair<uint32_t, Meta>> q;
+  std::vector<std::pair<uint32_t, NodeKey>> q;
 
   q.reserve(64);
-  q.emplace_back(static_cast<uint32_t>(0), a_metaUpdater(m_linearNodes[0]));
+  q.emplace_back(static_cast<uint32_t>(0), a_nodeKeyFactory(m_linearNodes[0]));
 
   while (!q.empty()) {
     const uint32_t nodeIdx = q.back().first;
-    const Meta     meta    = q.back().second;
+    const NodeKey  nodeKey = q.back().second;
     q.pop_back();
 
     const Node& node = m_linearNodes[nodeIdx];
 
-    if (a_visiter(node, meta)) {
+    if (a_prunePredicate(node, nodeKey)) {
       if (node.isLeaf()) {
-        a_updater(m_primitives, node.getPrimitivesOffset(), node.getNumPrimitives());
+        a_leafEvaluator(m_primitives, node.getPrimitivesOffset(), node.getNumPrimitives());
       }
       else {
         for (size_t k = 0; k < K; k++) {
           const uint32_t childIdx = node.getChildOffsets()[k];
           children[k].first       = childIdx;
-          children[k].second      = a_metaUpdater(m_linearNodes[childIdx]);
+          children[k].second      = a_nodeKeyFactory(m_linearNodes[childIdx]);
         }
 
-        a_sorter(children);
+        a_childOrderer(children);
 
         for (const auto& child : children) {
           q.push_back(child);
@@ -1045,27 +1045,27 @@ PackedBVH<T, P, K>::pruneTraverse(const Vec3T<T>&    a_point,
 #endif
 
   // Scalar fallback for all other (T, K) combinations.
-  const BVH::PackedUpdater<P> updater = [&a_state, &a_evalLeaf](const std::vector<std::shared_ptr<const P>>&,
-                                                                size_t offset,
-                                                                size_t count) noexcept -> void {
-    a_evalLeaf(a_state, offset, count);
-  };
+  const BVH::PackedLeafEvaluator<P> leafEvaluator =
+    [&a_state, &a_evalLeaf](const std::vector<std::shared_ptr<const P>>&,
+                            size_t offset,
+                            size_t count) noexcept -> void { a_evalLeaf(a_state, offset, count); };
 
-  const BVH::Visiter<Node, T> visiter = [&a_state, &a_pruneDist2](const Node& /*n*/, const T& d) noexcept -> bool {
+  const BVH::PrunePredicate<Node, T> prunePredicate = [&a_state, &a_pruneDist2](const Node& /*n*/,
+                                                                                const T& d) noexcept -> bool {
     return d * d <= a_pruneDist2(a_state);
   };
 
-  const BVH::PackedSorter<T, K> sorter = [](std::array<std::pair<uint32_t, T>, K>& ch) noexcept -> void {
+  const BVH::PackedChildOrderer<T, K> childOrderer = [](std::array<std::pair<uint32_t, T>, K>& ch) noexcept -> void {
     std::sort(ch.begin(), ch.end(), [](const std::pair<uint32_t, T>& a, const std::pair<uint32_t, T>& b) noexcept {
       return a.second > b.second;
     });
   };
 
-  const BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& n) noexcept -> T {
+  const BVH::NodeKeyFactory<Node, T> nodeKeyFactory = [&a_point](const Node& n) noexcept -> T {
     return n.getDistanceToBoundingVolume(a_point);
   };
 
-  this->traverse(updater, visiter, sorter, metaUpdater);
+  this->traverse(leafEvaluator, prunePredicate, childOrderer, nodeKeyFactory);
 }
 
 } // namespace BVH

--- a/Source/EBGeometry_CSG.hpp
+++ b/Source/EBGeometry_CSG.hpp
@@ -521,7 +521,7 @@ public:
   /**
    * @brief Destructor.
    */
-  virtual ~BVHSmoothUnionIF() = default;
+  ~BVHSmoothUnionIF() override = default;
 
   /**
    * @brief Evaluates the smoothly blended signed distance at a_point using BVH traversal.

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -76,9 +76,9 @@ buildBVH(const std::vector<std::pair<std::shared_ptr<const P>, BV>>& a_primsAndB
   }
   case BVH::Build::SAH: {
     using Node     = EBGeometry::BVH::TreeBVH<T, P, BV, K>;
-    using StopFunc = typename Node::StopFunction;
+    using LeafPred = typename Node::LeafPredicate;
 
-    const StopFunc stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
+    const LeafPred stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
 
     root->topDownSortAndPartition(EBGeometry::BVH::BinnedSAHPartitioner<T, P, BV, K>, stopCrit);
 
@@ -470,7 +470,7 @@ BVHUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
 
   T minDist = std::numeric_limits<T>::infinity();
 
-  const BVH::PackedUpdater<P> updater =
+  const BVH::PackedLeafEvaluator<P> leafEvaluator =
     [&minDist, &a_point](
       const std::vector<std::shared_ptr<const P>>& a_implicitFunctions, size_t offset, size_t count) noexcept -> void {
     for (size_t i = offset; i < offset + count; i++) {
@@ -482,22 +482,23 @@ BVHUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
     }
   };
 
-  const BVH::Visiter<Node, T> visiter = [&minDist](const Node&, const T& a_bvDist) noexcept -> bool {
+  const BVH::PrunePredicate<Node, T> prunePredicate = [&minDist](const Node&, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= T(0.0) || a_bvDist <= minDist;
   };
 
-  const BVH::PackedSorter<T, K> sorter = [](std::array<std::pair<uint32_t, T>, K>& a_leaves) noexcept -> void {
+  const BVH::PackedChildOrderer<T, K> childOrderer =
+    [](std::array<std::pair<uint32_t, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(), a_leaves.end(), [](const std::pair<uint32_t, T>& n1, const std::pair<uint32_t, T>& n2) -> bool {
         return n1.second > n2.second;
       });
   };
 
-  const BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) noexcept -> T {
+  const BVH::NodeKeyFactory<Node, T> nodeKeyFactory = [&a_point](const Node& a_node) noexcept -> T {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
-  m_bvh->traverse(updater, visiter, sorter, metaUpdater);
+  m_bvh->traverse(leafEvaluator, prunePredicate, childOrderer, nodeKeyFactory);
 
   return minDist;
 }
@@ -557,9 +558,9 @@ BVHSmoothUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
   T a = std::numeric_limits<T>::infinity();
   T b = std::numeric_limits<T>::infinity();
 
-  BVH::PackedUpdater<P> updater = [&a, &b, &a_point](const std::vector<std::shared_ptr<const P>>& a_implicitFunctions,
-                                                     size_t                                       offset,
-                                                     size_t count) noexcept -> void {
+  BVH::PackedLeafEvaluator<P> leafEvaluator =
+    [&a, &b, &a_point](
+      const std::vector<std::shared_ptr<const P>>& a_implicitFunctions, size_t offset, size_t count) noexcept -> void {
     for (size_t i = offset; i < offset + count; i++) {
       const T d = a_implicitFunctions[i]->value(a_point);
       EBGEOMETRY_EXPECT(!std::isnan(d));
@@ -574,22 +575,22 @@ BVHSmoothUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
     }
   };
 
-  BVH::Visiter<Node, T> visiter = [&a, &b](const Node&, const T& a_bvDist) noexcept -> bool {
+  BVH::PrunePredicate<Node, T> prunePredicate = [&a, &b](const Node&, const T& a_bvDist) noexcept -> bool {
     return a_bvDist <= T(0.0) || a_bvDist <= a || a_bvDist <= b;
   };
 
-  BVH::PackedSorter<T, K> sorter = [](std::array<std::pair<uint32_t, T>, K>& a_leaves) noexcept -> void {
+  BVH::PackedChildOrderer<T, K> childOrderer = [](std::array<std::pair<uint32_t, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(), a_leaves.end(), [](const std::pair<uint32_t, T>& n1, const std::pair<uint32_t, T>& n2) -> bool {
         return n1.second > n2.second;
       });
   };
 
-  BVH::MetaUpdater<Node, T> metaUpdater = [&a_point](const Node& a_node) noexcept -> T {
+  BVH::NodeKeyFactory<Node, T> nodeKeyFactory = [&a_point](const Node& a_node) noexcept -> T {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
-  m_bvh->traverse(updater, visiter, sorter, metaUpdater);
+  m_bvh->traverse(leafEvaluator, prunePredicate, childOrderer, nodeKeyFactory);
 
   return m_smoothMin(a, b, m_smoothLen);
 }

--- a/Source/EBGeometry_ImplicitFunctionImplem.hpp
+++ b/Source/EBGeometry_ImplicitFunctionImplem.hpp
@@ -150,7 +150,7 @@ ImplicitFunction<T>::approximateBoundingVolumeOctree(const Vec3T<T>&    a_initia
 
     // Traverse the octree and collect the vertex coordinates of each node that contains an
     // intersection.
-    auto updater = [&vertices](const Node& a_node) -> void {
+    auto leafEvaluator = [&vertices](const Node& a_node) -> void {
       if (std::get<3>(a_node.getMetaData())) {
         const Vec3 lo = std::get<0>(a_node.getMetaData());
         const Vec3 hi = std::get<1>(a_node.getMetaData());
@@ -166,13 +166,13 @@ ImplicitFunction<T>::approximateBoundingVolumeOctree(const Vec3T<T>&    a_initia
       }
     };
 
-    auto visiter = [](const Node& a_node) -> bool {
+    auto prunePredicate = [](const Node& a_node) -> bool {
       const MetaData& meta = a_node.getMetaData();
 
       return std::get<3>(meta);
     };
 
-    root->traverse(updater, visiter);
+    root->traverse(leafEvaluator, prunePredicate);
   }
 
   return BV(vertices);

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -96,9 +96,9 @@ buildDCELTreeBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcel
   }
   case BVH::Build::SAH: {
     using Node     = EBGeometry::BVH::TreeBVH<T, Prim, BV, K>;
-    using StopFunc = typename Node::StopFunction;
+    using LeafPred = typename Node::LeafPredicate;
 
-    const StopFunc stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
+    const LeafPred stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
 
     bvh->topDownSortAndPartition(EBGeometry::BVH::BinnedSAHPartitioner<T, Prim, BV, K>, stopCrit);
 
@@ -164,8 +164,8 @@ buildTriTreeBVH(const std::vector<std::shared_ptr<EBGeometry::Triangle<T, Meta>>
   switch (a_build) {
   case BVH::Build::TopDown: {
     using Node              = EBGeometry::BVH::TreeBVH<T, Prim, BV, K>;
-    using StopFunc          = typename Node::StopFunction;
-    const StopFunc stopCrit = [a_maxLeafSize](const Node& n) noexcept -> bool {
+    using LeafPred          = typename Node::LeafPredicate;
+    const LeafPred stopCrit = [a_maxLeafSize](const Node& n) noexcept -> bool {
       return n.getPrimitives().size() <= a_maxLeafSize;
     };
     bvh->topDownSortAndPartition(EBGeometry::BVH::BVCentroidPartitioner<T, Prim, BV, K>, stopCrit);
@@ -184,9 +184,9 @@ buildTriTreeBVH(const std::vector<std::shared_ptr<EBGeometry::Triangle<T, Meta>>
   }
   case BVH::Build::SAH: {
     using Node     = EBGeometry::BVH::TreeBVH<T, Prim, BV, K>;
-    using StopFunc = typename Node::StopFunction;
+    using LeafPred = typename Node::LeafPredicate;
 
-    const StopFunc stopCrit = [a_maxLeafSize](const Node& n) noexcept -> bool {
+    const LeafPred stopCrit = [a_maxLeafSize](const Node& n) noexcept -> bool {
       return n.getPrimitives().size() <= a_maxLeafSize;
     };
 
@@ -309,17 +309,17 @@ MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorte
   std::vector<FaceAndDist> candidateFaces;
 
   // Declaration of the BVH metadata attached to each node - this will be the distance to the node itself.
-  using BVHMeta = T;
+  using BVHNodeKey = T;
 
   // Shortest distance so far.
-  BVHMeta shortestDistanceSoFar = std::numeric_limits<T>::max();
+  BVHNodeKey shortestDistanceSoFar = std::numeric_limits<T>::max();
 
-  const EBGeometry::BVH::Visiter<Node, T> visiter = [&shortestDistanceSoFar](const Node&,
-                                                                             const BVHMeta& a_bvDist) noexcept -> bool {
+  const EBGeometry::BVH::PrunePredicate<Node, T> prunePredicate =
+    [&shortestDistanceSoFar](const Node&, const BVHNodeKey& a_bvDist) noexcept -> bool {
     return a_bvDist <= T(0.0) || a_bvDist <= shortestDistanceSoFar;
   };
 
-  const EBGeometry::BVH::PackedSorter<T, K> sorter =
+  const EBGeometry::BVH::PackedChildOrderer<T, K> childOrderer =
     [](std::array<std::pair<uint32_t, T>, K>& a_leaves) noexcept -> void {
     std::sort(
       a_leaves.begin(), a_leaves.end(), [](const std::pair<uint32_t, T>& n1, const std::pair<uint32_t, T>& n2) -> bool {
@@ -327,11 +327,10 @@ MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorte
       });
   };
 
-  const EBGeometry::BVH::MetaUpdater<Node, BVHMeta> metaUpdater = [&a_point](const Node& a_node) noexcept -> BVHMeta {
-    return a_node.getDistanceToBoundingVolume(a_point);
-  };
+  const EBGeometry::BVH::NodeKeyFactory<Node, BVHNodeKey> nodeKeyFactory =
+    [&a_point](const Node& a_node) noexcept -> BVHNodeKey { return a_node.getDistanceToBoundingVolume(a_point); };
 
-  const EBGeometry::BVH::PackedUpdater<Face> updater =
+  const EBGeometry::BVH::PackedLeafEvaluator<Face> leafEvaluator =
     [&shortestDistanceSoFar, &a_point, &candidateFaces](
       const std::vector<std::shared_ptr<const Face>>& a_faces, size_t offset, size_t count) noexcept -> void {
     for (size_t i = offset; i < offset + count; i++) {
@@ -346,7 +345,7 @@ MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorte
     }
   };
 
-  m_bvh->traverse(updater, visiter, sorter, metaUpdater);
+  m_bvh->traverse(leafEvaluator, prunePredicate, childOrderer, nodeKeyFactory);
 
   if (a_sorted) {
     std::sort(candidateFaces.begin(), candidateFaces.end(), [](const FaceAndDist& a, const FaceAndDist& b) {

--- a/Source/EBGeometry_Octree.hpp
+++ b/Source/EBGeometry_Octree.hpp
@@ -104,23 +104,23 @@ public:
     std::function<std::shared_ptr<Data>(const OctantIndex& a_index, const std::shared_ptr<Data>& a_parentData)>;
 
   /**
-   * @brief Updater pattern for Node::traverse. This is called when visiting a leaf node.
+   * @brief LeafEvaluator pattern for Node::traverse. This is called when visiting a leaf node.
    * @param[in] a_node Leaf node that is visited.
    */
-  using Updater = std::function<void(const Node<Meta, Data>& a_node)>;
+  using LeafEvaluator = std::function<void(const Node<Meta, Data>& a_node)>;
 
   /**
-   * @brief Visiter pattern for Node::traverse. This is called on interior and leaf nodes. Must return true if we should
+   * @brief PrunePredicate pattern for Node::traverse. This is called on interior and leaf nodes. Must return true if we should
    * query the node and false otherwise.
    * @param[in] a_node Node to visit or not.
    */
-  using Visiter = std::function<bool(const Node<Meta, Data>& a_node)>;
+  using PrunePredicate = std::function<bool(const Node<Meta, Data>& a_node)>;
 
   /**
-   * @brief Sorter for traverse pattern. This is called on interior nodes for deciding which sub-tree to visit first.
+   * @brief ChildOrderer for traverse pattern. This is called on interior nodes for deciding which sub-tree to visit first.
    * @param[inout] a_children Sortable children nodes, first node is visited first, then the second, etc.
    */
-  using Sorter = std::function<void(std::array<std::shared_ptr<const Node<Meta, Data>>, 8>& a_children)>;
+  using ChildOrderer = std::function<void(std::array<std::shared_ptr<const Node<Meta, Data>>, 8>& a_children)>;
 
   /**
    * @brief Default constructor. All children default-null (leaf node); m_meta and m_data are
@@ -244,17 +244,17 @@ public:
   /**
    * @brief Traverse the tree
    * @details Since this uses shared_from_this() internally, the node must already be owned by a
-   * std::shared_ptr (see the class-level @note). a_updater and a_visiter must be non-empty
-   * (callable); a_sorter, if explicitly supplied, must be non-empty too.
-   * @param[in] a_updater Updater when visiting leaf nodes.
-   * @param[in] a_visiter Visiter for deciding to visit a node.
-   * @param[in] a_sorter Sorter method for deciding which subtree to investigate first.
+   * std::shared_ptr (see the class-level @note). a_leafEvaluator and a_prunePredicate must be non-empty
+   * (callable); a_childOrderer, if explicitly supplied, must be non-empty too.
+   * @param[in] a_leafEvaluator LeafEvaluator when visiting leaf nodes.
+   * @param[in] a_prunePredicate PrunePredicate for deciding to visit a node.
+   * @param[in] a_childOrderer ChildOrderer method for deciding which subtree to investigate first.
    */
   inline void
   traverse(
-    const Updater& a_updater,
-    const Visiter& a_visiter,
-    const Sorter&  a_sorter = [](std::array<std::shared_ptr<const Node<Meta, Data>>, 8>&) -> void {
+    const LeafEvaluator&  a_leafEvaluator,
+    const PrunePredicate& a_prunePredicate,
+    const ChildOrderer&   a_childOrderer = [](std::array<std::shared_ptr<const Node<Meta, Data>>, 8>&) -> void {
       return;
     }) const noexcept;
 

--- a/Source/EBGeometry_OctreeImplem.hpp
+++ b/Source/EBGeometry_OctreeImplem.hpp
@@ -167,11 +167,13 @@ Node<Meta, Data>::buildBreadthFirst(const SplitFunction&   a_splitFunction,
 
 template <typename Meta, typename Data>
 inline void
-Node<Meta, Data>::traverse(const Updater& a_updater, const Visiter& a_visiter, const Sorter& a_sorter) const noexcept
+Node<Meta, Data>::traverse(const LeafEvaluator&  a_leafEvaluator,
+                           const PrunePredicate& a_prunePredicate,
+                           const ChildOrderer&   a_childOrderer) const noexcept
 {
-  EBGEOMETRY_EXPECT(a_updater);
-  EBGEOMETRY_EXPECT(a_visiter);
-  EBGEOMETRY_EXPECT(a_sorter);
+  EBGEOMETRY_EXPECT(a_leafEvaluator);
+  EBGEOMETRY_EXPECT(a_prunePredicate);
+  EBGEOMETRY_EXPECT(a_childOrderer);
   EBGEOMETRY_EXPECT(!this->weak_from_this().expired());
 
   std::array<std::shared_ptr<const Node<Meta, Data>>, 8> children;
@@ -186,9 +188,9 @@ Node<Meta, Data>::traverse(const Updater& a_updater, const Visiter& a_visiter, c
 
     q.pop();
 
-    if (a_visiter(curNode)) {
+    if (a_prunePredicate(curNode)) {
       if (curNode.isLeaf()) {
-        a_updater(curNode);
+        a_leafEvaluator(curNode);
       }
       else {
         for (size_t k = 0; k < 8; k++) {
@@ -197,7 +199,7 @@ Node<Meta, Data>::traverse(const Updater& a_updater, const Visiter& a_visiter, c
           EBGEOMETRY_EXPECT(children[k] != nullptr);
         }
 
-        a_sorter(children);
+        a_childOrderer(children);
 
         for (const auto& c : children) {
           q.push(c);

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -71,16 +71,6 @@ traversalMargin()
   return std::is_same_v<T, float> ? 1.0e-2 : 1.0e-6;
 }
 
-// Bare point primitive -- just a position, with no signedDistance() (or any other) member. Used
-// below to exercise bottomUpSortAndPartition() on primitive sets whose centroids are degenerate
-// along one or more axes; the nearest-neighbor query is done via pruneTraverse(), which imposes
-// no interface requirement on the primitive type.
-template <class T>
-struct DistPoint
-{
-  Vec3T<T> m_pos;
-};
-
 } // namespace
 
 TEMPLATE_TEST_CASE("Dodecahedron: all four file formats parse into an identical, watertight DCEL mesh",
@@ -270,7 +260,9 @@ namespace {
 // Bare point primitive with no signedDistance() (or any other) member at all -- used below to
 // prove that PackedBVH::pruneTraverse() imposes no interface requirement on its primitive type,
 // unlike a caller-built signed-distance wrapper (e.g. MeshSDF/TriMeshSDF::signedDistance()),
-// which requires P::signedDistance(Vec3T<T>).
+// which requires P::signedDistance(Vec3T<T>). Also reused by the degenerate-axis
+// bottomUpSortAndPartition test further below, whose nearest-neighbor query likewise goes
+// through pruneTraverse().
 template <class T>
 struct BareTestPoint
 {
@@ -442,7 +434,7 @@ TEMPLATE_TEST_CASE("TreeBVH::bottomUpSortAndPartition handles primitive sets who
   using T    = TestType;
   using AABB = BoundingVolumes::AABBT<T>;
   using Vec3 = Vec3T<T>;
-  using Pnt  = DistPoint<T>;
+  using Pnt  = BareTestPoint<T>;
 
   constexpr size_t K = 4;
 

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -71,20 +71,14 @@ traversalMargin()
   return std::is_same_v<T, float> ? 1.0e-2 : 1.0e-6;
 }
 
-// Bare point primitive (unsigned Euclidean distance stands in for "signedDistance" -- sign is
-// irrelevant for this test, only magnitude agreement with brute force is checked) used below to
-// exercise bottomUpSortAndPartition() on primitive sets whose centroids are degenerate along one
-// or more axes.
+// Bare point primitive -- just a position, with no signedDistance() (or any other) member. Used
+// below to exercise bottomUpSortAndPartition() on primitive sets whose centroids are degenerate
+// along one or more axes; the nearest-neighbor query is done via pruneTraverse(), which imposes
+// no interface requirement on the primitive type.
 template <class T>
 struct DistPoint
 {
   Vec3T<T> m_pos;
-
-  [[nodiscard]] T
-  signedDistance(const Vec3T<T>& a_point) const noexcept
-  {
-    return (m_pos - a_point).length();
-  }
 };
 
 } // namespace
@@ -186,8 +180,8 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
 
   buildAndCheck("TopDown (BinnedSAHPartitioner)", [](auto& a_tree) {
     using Node              = BVH::TreeBVH<T, Face, AABB, K>;
-    using StopFunc          = typename Node::StopFunction;
-    const StopFunc stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
+    using LeafPred          = typename Node::LeafPredicate;
+    const LeafPred stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
 
     a_tree.topDownSortAndPartition(BVH::BinnedSAHPartitioner<T, Face, AABB, K>, stopCrit);
   });
@@ -478,13 +472,31 @@ TEMPLATE_TEST_CASE("TreeBVH::bottomUpSortAndPartition handles primitive sets who
       REQUIRE(packed != nullptr);
       REQUIRE(packed->getPrimitives().size() == a_positions.size());
 
+      const auto& prims = packed->getPrimitives();
+
+      // PackedBVH has no signedDistance() of its own -- do the nearest-neighbor search via
+      // pruneTraverse(), whose State here is the running *squared* distance to the point cloud.
+      const auto pruneDist2 = [](const T& a_state) noexcept -> T { return a_state; };
+
       for (const auto& q : queryPoints<T>()) {
-        T brute = std::numeric_limits<T>::max();
+        T          state    = std::numeric_limits<T>::max();
+        const auto evalLeaf = [&prims, &q](T& a_state, size_t a_offset, size_t a_count) noexcept {
+          for (size_t i = 0; i < a_count; i++) {
+            const T d2 = (prims[a_offset + i]->m_pos - q).length2();
+            if (d2 < a_state) {
+              a_state = d2;
+            }
+          }
+        };
+
+        packed->pruneTraverse(q, state, evalLeaf, pruneDist2);
+
+        T bruteMin2 = std::numeric_limits<T>::max();
         for (const auto& pos : a_positions) {
-          brute = std::min(brute, (pos - q).length());
+          bruteMin2 = std::min(bruteMin2, (pos - q).length2());
         }
 
-        REQUIRE_THAT(packed->signedDistance(q), withinAbsT(brute, traversalMargin<T>()));
+        REQUIRE_THAT(state, withinAbsT(bruteMin2, traversalMargin<T>()));
       }
     }
   };

--- a/Tests/TestOctree.cpp
+++ b/Tests/TestOctree.cpp
@@ -46,8 +46,8 @@ countLeaves(const std::shared_ptr<LevelNode>& a_root)
 {
   size_t count = 0;
 
-  const LevelNode::Updater countingUpdater = [&count](const LevelNode&) -> void { count++; };
-  const LevelNode::Visiter visitAll        = [](const LevelNode&) -> bool { return true; };
+  const LevelNode::LeafEvaluator  countingUpdater = [&count](const LevelNode&) -> void { count++; };
+  const LevelNode::PrunePredicate visitAll        = [](const LevelNode&) -> bool { return true; };
 
   a_root->traverse(countingUpdater, visitAll);
 
@@ -135,7 +135,7 @@ TEST_CASE("Octree::Node: buildDepthFirst and buildBreadthFirst produce trees wit
   REQUIRE(countLeaves(depthFirstRoot) == static_cast<size_t>(std::pow(8, depth)));
 }
 
-TEST_CASE("Octree::Node::traverse: a visiter that prunes a subtree stops that subtree's leaves "
+TEST_CASE("Octree::Node::traverse: a prunePredicate that prunes a subtree stops that subtree's leaves "
           "from being visited",
           "[Octree]")
 {
@@ -143,11 +143,11 @@ TEST_CASE("Octree::Node::traverse: a visiter that prunes a subtree stops that su
 
   size_t visitedCount = 0;
 
-  const LevelNode::Updater counting = [&visitedCount](const LevelNode&) -> void { visitedCount++; };
+  const LevelNode::LeafEvaluator counting = [&visitedCount](const LevelNode&) -> void { visitedCount++; };
 
   // Only descend into the root and its first child (octant 0); every other direct child of the
   // root is pruned outright, so only the first child's 8 grandchildren should ever be visited.
-  const LevelNode::Visiter pruneAllButFirstChild = [&root](const LevelNode& a_node) -> bool {
+  const LevelNode::PrunePredicate pruneAllButFirstChild = [&root](const LevelNode& a_node) -> bool {
     if (&a_node == root.get() || &a_node == root->getChildren()[0].get()) {
       return true;
     }
@@ -166,21 +166,22 @@ TEST_CASE("Octree::Node::traverse: a visiter that prunes a subtree stops that su
   REQUIRE(visitedCount == 8);
 }
 
-TEST_CASE("Octree::Node::traverse: a custom sorter changes the visitation order", "[Octree]")
+TEST_CASE("Octree::Node::traverse: a custom childOrderer changes the visitation order", "[Octree]")
 {
   const auto root = buildUniformTree(1);
 
   std::vector<const void*> defaultOrder;
   std::vector<const void*> reversedOrder;
 
-  const LevelNode::Updater recordDefault = [&defaultOrder](const LevelNode& a_node) -> void {
+  const LevelNode::LeafEvaluator recordDefault = [&defaultOrder](const LevelNode& a_node) -> void {
     defaultOrder.push_back(static_cast<const void*>(&a_node));
   };
-  const LevelNode::Updater recordReversed = [&reversedOrder](const LevelNode& a_node) -> void {
+  const LevelNode::LeafEvaluator recordReversed = [&reversedOrder](const LevelNode& a_node) -> void {
     reversedOrder.push_back(static_cast<const void*>(&a_node));
   };
-  const LevelNode::Visiter visitAll        = [](const LevelNode&) -> bool { return true; };
-  const LevelNode::Sorter  reverseChildren = [](std::array<std::shared_ptr<const LevelNode>, 8>& a_children) -> void {
+  const LevelNode::PrunePredicate visitAll = [](const LevelNode&) -> bool { return true; };
+  const LevelNode::ChildOrderer   reverseChildren =
+    [](std::array<std::shared_ptr<const LevelNode>, 8>& a_children) -> void {
     std::reverse(a_children.begin(), a_children.end());
   };
 

--- a/Tests/TestOctree.cpp
+++ b/Tests/TestOctree.cpp
@@ -46,10 +46,10 @@ countLeaves(const std::shared_ptr<LevelNode>& a_root)
 {
   size_t count = 0;
 
-  const LevelNode::LeafEvaluator  countingUpdater = [&count](const LevelNode&) -> void { count++; };
-  const LevelNode::PrunePredicate visitAll        = [](const LevelNode&) -> bool { return true; };
+  const LevelNode::LeafEvaluator  countingEvaluator = [&count](const LevelNode&) -> void { count++; };
+  const LevelNode::PrunePredicate visitAll          = [](const LevelNode&) -> bool { return true; };
 
-  a_root->traverse(countingUpdater, visitAll);
+  a_root->traverse(countingEvaluator, visitAll);
 
   return count;
 }


### PR DESCRIPTION
# Summary

Renames the BVH/Octree traversal and build **callback role-names** to describe what each callback actually does, replacing names left over from an older design (one of which, `Visiter`, was a typo). Pure rename — no behavior change and no backward-compat aliases.

### Background

The `traverse()` / `topDownSortAndPartition()` callback type aliases were named after an old design. Three names were actively misleading and one was a typo:

- `Visiter` — a typo, and even fixed, "visitor" undersells a prune/descend predicate.
- `Updater` / `PackedUpdater` — never update the tree; they consume a leaf's primitives. The newer SIMD `pruneTraverse()` API already calls this role `LeafEvaluator`.
- `MetaUpdater` — updates nothing; it is a pure `(node) -> key` factory.
- `Meta` — a vague name for the transient per-node key threaded through traversal.

The newer `pruneTraverse` design (`State` / `LeafEvaluator` / `PruneDist2`) is the vocabulary the rest of the library is now aligned to.

### Solution

| Old | New | Why |
|---|---|---|
| `Meta` (traversal key type) | `NodeKey` | The transient per-node sort/prune key. |
| `MetaUpdater` | `NodeKeyFactory` | Pure `(node) -> NodeKey` factory. |
| `Visiter` | `PrunePredicate` | `(node, key) -> bool`; `false` prunes the subtree. |
| `Sorter` / `PackedSorter` | `ChildOrderer` / `PackedChildOrderer` | Reorders children by promise. |
| `Updater` / `PackedUpdater` | `LeafEvaluator` / `PackedLeafEvaluator` | Consumes a leaf's primitives. |
| `StopFunction` / `DefaultStopFunction` | `LeafPredicate` / `DefaultLeafPredicate` | "Should this node become a leaf?" |
| `Partitioner` | *(kept)* | Already accurate. |

A `traverse()` call now reads `traverse(leafEvaluator, prunePredicate, childOrderer, nodeKeyFactory)`. The Sphinx pages (`ImplemBVH.rst`, `ImplemOctree.rst`) and `Docs/mainpage.md` are updated to the new vocabulary in the same PR.

**Deliberately not renamed** (different concepts): the Octree's `Meta` / `MetaConstructor` / `getMetaData` (persistent per-node metadata), and the DCEL/Triangle face-metadata `Meta` template parameter (`FaceT<T, Meta>`, `MeshT<T, Meta>`, `Triangle<T, Meta>`). The `NodeKey` rename was scoped to the BVH traversal context only.

### Side-effects

- **Pre-existing build fix.** `TestBVH.cpp`'s degenerate-axis `bottomUpSortAndPartition` test called `packed->signedDistance()`, which `PackedBVH` does not provide — a build break already on `main` (from #98), independent of the rename. Rewritten to run the nearest-neighbor search via `pruneTraverse()`, mirroring the sibling test.
- The now-unused `DistPoint::signedDistance()` member was removed; that left `DistPoint` byte-identical to `BareTestPoint`, so the two test structs were merged.
- No public runtime behavior changes; the only API surface affected is the (compile-time) callback type names, and no deprecated aliases are kept.

### Alternative solutions

- **Keep deprecated `using` aliases** for the old names (`using Visiter [[deprecated]] = PrunePredicate;` …) for a softer migration — rejected in favor of a clean break, since there are no known external consumers of these names.
- **Also rename the Octree/DCEL `Meta`** for one uniform word everywhere — rejected because that `Meta` is persistent node/face metadata, a genuinely different concept from the transient traversal key, and renaming it would be misleading.

### Reviewer checklist

- [x] The test suite compiles and runs to completion without warnings or errors.
- [x] All relevant new features are documented in the user documentation (Sphinx).
- [x] This contribution does not break existing sections in the user documentation. 
- [x] All relevant APIs are documented in the doxygen documentation.
- [x] Appropriate labels have been assigned to this PR.
- [x] New or revised proper licensing and copyright information is in place.
- [x] A PR review has been run using `@claude review`.
- [x] The continuous integration and testing hooks at GitHub run to completion.