### PR TITLE
Deploy docs via GitHub Pages artifact (drop gh-pages branch)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,19 +4,25 @@ on:
   push:
     branches: main
 
+# Allow the deploy job to publish to GitHub Pages via OIDC (no branch, no stored credentials).
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-docs
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          persist-credentials: false        
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -40,7 +46,7 @@ jobs:
           Scripts/build-doc-figures.sh
 
       - name: Build HTML documentation
-        working-directory: ${{ github.workspace }}/Docs/Sphinx        
+        working-directory: ${{ github.workspace }}/Docs/Sphinx
         run: |
           make html
 
@@ -55,12 +61,19 @@ jobs:
           cp -a Sphinx/build/html/* ./
           mv Sphinx/build/latex/ebgeometry.pdf ./
           rm -rf Sphinx/build
-          
-      - name: Deploy
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'        
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: Docs
-          clean: false
+          path: Docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Docs/Sphinx/source/index.rst
+++ b/Docs/Sphinx/source/index.rst
@@ -27,7 +27,7 @@ Main features:
 .. important::
 
    This is the user documentation for EBGeometry. A
-   `PDF version <https://github.com/rmrsk/EBGeometry/raw/gh-pages/ebgeometry.pdf>`_
+   `PDF version <https://rmrsk.github.io/EBGeometry/ebgeometry.pdf>`_
    of this documentation is also available.
 
    * If you are looking for the source code, it is hosted on

--- a/Docs/mainpage.md
+++ b/Docs/mainpage.md
@@ -43,4 +43,4 @@ integration, the underlying geometric concepts), see the
 
 * Source repository: <https://github.com/rmrsk/EBGeometry>
 * User documentation (HTML): <https://rmrsk.github.io/EBGeometry/>
-* User documentation (PDF): <https://github.com/rmrsk/EBGeometry/raw/gh-pages/ebgeometry.pdf>
+* User documentation (PDF): <https://rmrsk.github.io/EBGeometry/ebgeometry.pdf>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ together with the code. There are three types of documentation available:
 
 * [HTML](https://rmrsk.github.io/EBGeometry/) -- The user guide: concepts, building, testing, and
   examples.
-* [PDF](https://github.com/rmrsk/EBGeometry/raw/gh-pages/ebgeometry.pdf) -- The same user guide, as
+* [PDF](https://rmrsk.github.io/EBGeometry/ebgeometry.pdf) -- The same user guide, as
   a single PDF.
 * [Doxygen](https://rmrsk.github.io/EBGeometry/doxygen/html/index.html) -- The generated API
   reference for every class and function.


### PR DESCRIPTION
# Summary

### Background

The documentation deploy in `.github/workflows/docs.yml` used
`JamesIves/github-pages-deploy-action@3.7.1` to commit the built site to a
`gh-pages` branch with `clean: false`. Every push therefore *appended* the full
Doxygen HTML + LaTeX output and the `ebgeometry.pdf` without ever removing stale
files, and every snapshot was retained in branch history. Over the project's
life this accumulated into ~180 MB on `gh-pages` (92 MB Doxygen HTML, 46 MB
LaTeX, 39 MB PDF, plus theme fonts) — pure bloat that also inflates the GitHub
repo total and any full mirror of it.

### Solution

Deploy the built site as an ephemeral **GitHub Pages artifact** using the
first-party `actions/upload-pages-artifact` + `actions/deploy-pages` flow. The
site is served but **never committed to any git ref**, so the bloat is designed
out rather than periodically cleaned up. The job is split into `build` (existing
Doxygen/Sphinx/PDF steps, unchanged, ending in the artifact upload) and `deploy`
(the `github-pages` environment). A top-level `permissions:` block
(`pages: write`, `id-token: write`) is added for OIDC-authenticated deployment;
no stored `GITHUB_TOKEN`/branch-write credential is needed.

### Side-effects

- Requires a one-time repository setting change:
  **Settings → Pages → Source → "GitHub Actions"** (replacing "Deploy from a
  branch: gh-pages"). Until that switch is made, the site is not redeployed.
- Once the new deploy is verified live at `rmrsk.github.io/EBGeometry`, the
  `gh-pages` branch can be deleted (`git push origin --delete gh-pages`).
- The three PDF links that pointed at `raw/gh-pages/ebgeometry.pdf` (in
  `README.md`, `Docs/mainpage.md`, `Docs/Sphinx/source/index.rst`) are repointed
  to `https://rmrsk.github.io/EBGeometry/ebgeometry.pdf` (the PDF is uploaded at
  the site root), since those links would 404 after `gh-pages` is deleted.
- Published site contents and URL are otherwise unchanged (still the whole
  `Docs/` folder, including the PDF).
- Build steps, dependencies, and the `sphinx==5.3.0` pin are untouched.

### Alternative solutions

- Keep `gh-pages` but deploy with `force_orphan: true` (single-commit branch, no
  accumulated history). Rejected: still stores generated output in a git ref.
- Host the Sphinx guide on Read the Docs. Rejected: changes the docs URL and
  needs separate handling for the Doxygen reference.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation. 
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)