### PR TITLE
Add StoragePolicy to PackedBVH's primitive array

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,16 @@ a documented class/function's behavior, signature, or existence, the correspondi
 `Docs/Sphinx/source/*.rst` page(s) must be updated in the same PR -- an undocumented behavior
 change is not a finished change.
 
+**Never point users to tests (`Tests/*`) to see a functionality demonstrated.** The unit tests
+exist to verify behavior, not to teach it. When the docs (`.rst` files) or a public header comment
+want to show a user how to *use* something, they must point to an `Examples/` program instead --
+and only to one that actually exists as a page in the Sphinx Examples section (the toctree in
+`Docs/Sphinx/source/index.rst`, e.g. `ExampleShapes.rst`). If no such example exists yet, either
+add one (with its `Example*.rst` page wired into that toctree) or describe the capability inline
+without citing any file -- do not fall back to citing a test. (Pointing to `Tests/` is fine only
+in genuinely contribution/testing-oriented docs like `ContributionGuidelines.rst`/
+`TestingLocally.rst`, which are about the tests themselves, not about demonstrating a feature.)
+
 **Claude must begin auditing the `.rst` docs as soon as a PR is marked ready for review (i.e. no
 longer a draft), not only when explicitly asked.** Check the PR's draft status (e.g.
 `gh pr view <number> --json isDraft`); once it is out of draft, treat a documentation audit of

--- a/Docs/Sphinx/source/BVH.rst
+++ b/Docs/Sphinx/source/BVH.rst
@@ -87,7 +87,7 @@ In EBGeometry, bottom-up construction is done by means of space-filling curves (
 
 .. _Fig:CompactBVH:
 .. figure:: /_static/CompactBVH.png
-   :width: 360px
+   :width: 240px
    :align: center
 
    A pointer-based tree (top) and an equivalent, flattened representation of the same tree

--- a/Docs/Sphinx/source/ContinuousIntegration.rst
+++ b/Docs/Sphinx/source/ContinuousIntegration.rst
@@ -21,84 +21,113 @@ the above so branch-protection rules only need to target one required check.
 Jobs overview
 ---------------
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
+Four *setup* jobs run first with no dependencies -- ``Formatting``, ``Codespell``, ``Reuse``, and
+``Doxygen-check``. Every other job depends on all four of them and runs only once they pass; the
+`Dependency graph`_ below shows the full picture. Each job is described in turn.
 
-   * - Job
-     - What it does
-   * - ``Formatting``
-     - Runs ``clang-format`` (version 21) over ``Source/`` and ``Examples/`` (matrix over the
-       two directories) via `jidicula/clang-format-action
-       <https://github.com/jidicula/clang-format-action>`_.  The PR is blocked
-       if any file differs from the formatted output.
-   * - ``Codespell``
-     - Runs the ``codespell`` pre-commit hook over every tracked file.
-   * - ``Reuse``
-     - Runs the ``reuse`` pre-commit hook (REUSE license/copyright header compliance) over
-       every tracked file.
-   * - ``Doxygen-check``
-     - Runs the ``doxygen-check`` pre-commit hook: builds the Doxygen API reference from
-       ``Docs/doxygen.conf`` with warnings treated as errors.
-   * - ``Static-analysis``
-     - Runs ``clang-tidy-18`` (via ``run-clang-tidy-18``) over every ``Tests/*.cpp`` and
-       ``Examples/*.cpp`` translation unit, using a compile-command database exported from the
-       ``debug`` preset built with ``clang++-14``. Marked ``continue-on-error: true`` (there is
-       a known review backlog), so it is advisory and does not gate ``CI-passed``.  Depends on
-       ``Formatting``, ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Linux-GNU``
-     - Compiles and runs every example under ``Examples/`` directly with ``g++`` (matrix over
-       ``{g++-11, g++-12}`` × the six example directories), using ``-std=c++17 -pedantic -Wall
-       -Wextra`` plus a large set of additional diagnostic flags. Depends on ``Formatting``,
-       ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Linux-Intel``
-     - Compiles and runs a subset of examples (``MeshSDF``, ``PackedSpheres``, ``RandomCity``,
-       ``Shapes``) with Intel's ``icpx`` compiler, ``-std=c++17 -Wall -Werror`` plus additional
-       diagnostic flags. Depends on ``Formatting``, ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Examples-GNUMake``
-     - Builds and runs every example (matrix over the six example directories) via its own
-       ``GNUmakefile`` (``make run``). Depends on ``Formatting``, ``Codespell``, ``Reuse``,
-       ``Doxygen-check``.
-   * - ``Examples-CMake``
-     - Configures and builds the top-level project with the ``debug`` preset (assertions on,
-       ``double`` precision) and runs every example via ``ctest --preset examples``. This is
-       the path that exercises the CMake-driven build with assertions enabled, unlike
-       ``Linux-GNU``/``Linux-Intel`` (raw compiler invocation, no assertions) or
-       ``Unit-Tests``/``Sanitizers`` (examples disabled). Depends on ``Formatting``,
-       ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Examples-FloatPrecision``
-     - The same as ``Examples-CMake``, but configured with ``-DEBGEOMETRY_PRECISION=float``
-       (a cache variable shared by every example's own ``CMakeLists.txt``). Depends on
-       ``Formatting``, ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Build-documentation``
-     - Installs Doxygen, Graphviz, a LaTeX toolchain, Poppler (for the documentation figure
-       pipeline), and Sphinx (with ``sphinx_rtd_theme`` and ``sphinxcontrib-bibtex``); builds
-       the Doxygen API reference; renders the documentation figures from their LaTeX/TikZ
-       sources (``Scripts/build-doc-figures.sh``); builds the Sphinx HTML and PDF
-       documentation; uploads the result as a workflow artifact. Depends on ``Formatting``,
-       ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Unit-Tests``
-     - Configures with the ``debug`` preset (examples disabled) across a matrix of compilers
-       ``{g++-12, clang++-14}`` × SIMD levels ``{none, avx, avx512}``, with
-       ``-DEBGEOMETRY_TEST_BOTH_PRECISIONS=ON``, and runs ``ctest --preset debug``. The
-       ``avx512`` configurations always compile (catching ISA-specific errors in the
-       SIMD-accelerated code paths) but only actually run on a runner whose CPU supports
-       AVX-512F. Depends on ``Formatting``, ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Release-Test``
-     - Configures with the ``release-test`` preset (optimised, AVX, examples and tests both
-       enabled) plus ``-DEBGEOMETRY_TEST_BOTH_PRECISIONS=ON``, and runs
-       ``ctest --preset release-test`` (the full unit-test and example suite). Depends on
-       ``Formatting``, ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``Sanitizers``
-     - Configures with the ``debug-san`` preset (examples disabled) across a matrix of
-       compilers ``{g++-12, clang++-14}`` × SIMD levels ``{none, avx}``, with
-       ``-DEBGEOMETRY_TEST_BOTH_PRECISIONS=ON``, and runs ``ctest --preset debug-san`` under
-       AddressSanitizer and UndefinedBehaviorSanitizer. Depends on ``Formatting``,
-       ``Codespell``, ``Reuse``, ``Doxygen-check``.
-   * - ``CI-passed``
-     - Dummy job whose only role is to aggregate every job above -- except the advisory
-       ``Static-analysis`` -- as a single required status check. Branch-protection rules can
-       target this job instead of each individual job.
+Formatting
+~~~~~~~~~~
+
+Runs ``clang-format`` (version 21) over ``Source/`` and ``Examples/`` (matrix over the two
+directories) via `jidicula/clang-format-action
+<https://github.com/jidicula/clang-format-action>`_. The PR is blocked if any file differs from the
+formatted output.
+
+Codespell
+~~~~~~~~~
+
+Runs the ``codespell`` pre-commit hook over every tracked file.
+
+Reuse
+~~~~~
+
+Runs the ``reuse`` pre-commit hook (REUSE license/copyright header compliance) over every tracked
+file.
+
+Doxygen-check
+~~~~~~~~~~~~~
+
+Runs the ``doxygen-check`` pre-commit hook: builds the Doxygen API reference from
+``Docs/doxygen.conf`` with warnings treated as errors.
+
+Static-analysis
+~~~~~~~~~~~~~~~
+
+Runs ``clang-tidy-18`` (via ``run-clang-tidy-18``) over every ``Tests/*.cpp`` and ``Examples/*.cpp``
+translation unit, using a compile-command database exported from the ``debug`` preset built with
+``clang++-14``. Marked ``continue-on-error: true`` (there is a known review backlog), so it is
+advisory and does not gate ``CI-passed``.
+
+Linux-GNU
+~~~~~~~~~
+
+Compiles and runs every example under ``Examples/`` directly with ``g++`` (matrix over
+``{g++-11, g++-12}`` × the six example directories), using ``-std=c++17 -pedantic -Wall -Wextra``
+plus a large set of additional diagnostic flags.
+
+Linux-Intel
+~~~~~~~~~~~
+
+Compiles and runs a subset of examples (``MeshSDF``, ``PackedSpheres``, ``RandomCity``, ``Shapes``)
+with Intel's ``icpx`` compiler, ``-std=c++17 -Wall -Werror`` plus additional diagnostic flags.
+
+Examples-GNUMake
+~~~~~~~~~~~~~~~~
+
+Builds and runs every example (matrix over the six example directories) via its own ``GNUmakefile``
+(``make run``).
+
+Examples-CMake
+~~~~~~~~~~~~~~
+
+Configures and builds the top-level project with the ``debug`` preset (assertions on, ``double``
+precision) and runs every example via ``ctest --preset examples``. This is the path that exercises
+the CMake-driven build with assertions enabled, unlike ``Linux-GNU``/``Linux-Intel`` (raw compiler
+invocation, no assertions) or ``Unit-Tests``/``Sanitizers`` (examples disabled).
+
+Examples-FloatPrecision
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The same as ``Examples-CMake``, but configured with ``-DEBGEOMETRY_PRECISION=float`` (a cache
+variable shared by every example's own ``CMakeLists.txt``).
+
+Build-documentation
+~~~~~~~~~~~~~~~~~~~
+
+Installs Doxygen, Graphviz, a LaTeX toolchain, Poppler (for the documentation figure pipeline), and
+Sphinx (with ``sphinx_rtd_theme`` and ``sphinxcontrib-bibtex``); builds the Doxygen API reference;
+renders the documentation figures from their LaTeX/TikZ sources (``Scripts/build-doc-figures.sh``);
+builds the Sphinx HTML and PDF documentation; uploads the result as a workflow artifact.
+
+Unit-Tests
+~~~~~~~~~~
+
+Configures with the ``debug`` preset (examples disabled) across a matrix of compilers
+``{g++-12, clang++-14}`` × SIMD levels ``{none, avx, avx512}``, with
+``-DEBGEOMETRY_TEST_BOTH_PRECISIONS=ON``, and runs ``ctest --preset debug``. The ``avx512``
+configurations always compile (catching ISA-specific errors in the SIMD-accelerated code paths) but
+only actually run on a runner whose CPU supports AVX-512F.
+
+Release-Test
+~~~~~~~~~~~~
+
+Configures with the ``release-test`` preset (optimised, AVX, examples and tests both enabled) plus
+``-DEBGEOMETRY_TEST_BOTH_PRECISIONS=ON``, and runs ``ctest --preset release-test`` (the full
+unit-test and example suite).
+
+Sanitizers
+~~~~~~~~~~
+
+Configures with the ``debug-san`` preset (examples disabled) across a matrix of compilers
+``{g++-12, clang++-14}`` × SIMD levels ``{none, avx}``, with ``-DEBGEOMETRY_TEST_BOTH_PRECISIONS=ON``,
+and runs ``ctest --preset debug-san`` under AddressSanitizer and UndefinedBehaviorSanitizer.
+
+CI-passed
+~~~~~~~~~
+
+Dummy job whose only role is to aggregate every job above -- except the advisory ``Static-analysis``
+-- as a single required status check. Branch-protection rules can target this job instead of each
+individual job.
 
 Dependency graph
 ------------------

--- a/Docs/Sphinx/source/ExampleNestedBVH.rst
+++ b/Docs/Sphinx/source/ExampleNestedBVH.rst
@@ -1,0 +1,27 @@
+.. _Chap:ExampleNestedBVH:
+
+NestedBVH
+=========
+
+Builds a *nested* bounding volume hierarchy: an outer, BVH-accelerated CSG union whose primitives
+are themselves BVH-backed mesh signed distance functions. Several translated copies of one triangle
+mesh are each loaded as a ``TriMeshSDF`` (which owns an inner ``PackedBVH`` over its triangle
+groups), then combined with ``BVHUnion``, which builds the outer ``PackedBVH`` over those mesh SDFs.
+A single distance query therefore descends two levels of BVH — the outer union hierarchy to locate
+the nearby copy, then that copy's own inner hierarchy to find the nearest triangle (see
+:ref:`Chap:BVH` and :ref:`Chap:ImplemCSG`).
+
+The outer union shares each mesh SDF by pointer (the default ``BVH::SharedPtrStorage``) rather than
+copying it — the recommended way to nest BVHs. See the *Storage policy* section of
+:ref:`Chap:ImplemBVH` for why the outer level must not use ``BVH::ValueStorage`` here.
+
+The source for this example is at :file:`Examples/NestedBVH/main.cpp`. See :ref:`Chap:Building`
+for how to compile it with CMake, GNU Make, or a direct compiler invocation. Unlike the mesh-reading
+examples above, it defaults to the ``dodecahedron.stl`` fixture shipped in the repository, so it
+needs no submodule.
+
+.. code-block:: bash
+
+   cd Examples/NestedBVH
+   ./NestedBVH.ex                       # defaults to ../../Tests/data/dodecahedron.stl
+   ./NestedBVH.ex path/to/mesh.stl      # place copies of your own triangle mesh

--- a/Docs/Sphinx/source/ExampleNestedBVH.rst
+++ b/Docs/Sphinx/source/ExampleNestedBVH.rst
@@ -4,15 +4,17 @@ NestedBVH
 =========
 
 Builds a *nested* bounding volume hierarchy: an outer, BVH-accelerated CSG union whose primitives
-are themselves BVH-backed mesh signed distance functions. Several translated copies of one triangle
-mesh are each loaded as a ``TriMeshSDF`` (which owns an inner ``PackedBVH`` over its triangle
-groups), then combined with ``BVHUnion``, which builds the outer ``PackedBVH`` over those mesh SDFs.
-A single distance query therefore descends two levels of BVH — the outer union hierarchy to locate
-the nearby copy, then that copy's own inner hierarchy to find the nearest triangle (see
-:ref:`Chap:BVH` and :ref:`Chap:ImplemCSG`).
+are themselves BVH-backed mesh signed distance functions. One triangle mesh is loaded once into a
+``TriMeshSDF`` (which owns an inner ``PackedBVH`` over its triangle groups) and then instanced at
+several positions -- each placement a ``Translate`` wrapper sharing a pointer to that same
+``TriMeshSDF`` -- and the placements are combined with ``BVHUnion``, which builds the outer
+``PackedBVH`` over them. A single distance query therefore descends two levels of BVH — the outer
+union hierarchy to locate the nearby placement, then the mesh's own inner hierarchy to find the
+nearest triangle (see :ref:`Chap:BVH` and :ref:`Chap:ImplemCSG`).
 
-The outer union shares each mesh SDF by pointer (the default ``BVH::SharedPtrStorage``) rather than
-copying it — the recommended way to nest BVHs. See the *Storage policy* section of
+The outer union shares each placement by pointer (the default ``BVH::SharedPtrStorage``) rather than
+copying it, so the one inner mesh BVH is built and stored just once — the recommended way to nest
+BVHs. See the *Storage policy* section of
 :ref:`Chap:ImplemBVH` for why the outer level must not use ``BVH::ValueStorage`` here.
 
 The source for this example is at :file:`Examples/NestedBVH/main.cpp`. See :ref:`Chap:Building`

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -213,6 +213,38 @@ storage-sharing question above:
 Both classes' destructors are non-virtual: neither is intended to be subclassed or used
 polymorphically.
 
+When ``ValueStorage`` is the wrong choice
+_________________________________________
+
+There are two situations where ``ValueStorage`` should not be used and ``SharedPtrStorage`` (the
+default) must be kept:
+
+*  **Polymorphic primitives.** ``ValueStorage<P>`` stores ``P`` by value, so it requires ``P`` to
+   be a concrete, copyable value type. If ``P`` is an abstract base (or you rely on virtual
+   dispatch through a base pointer), value storage either fails to compile or slices the object to
+   its static type. This is exactly the situation of the BVH-accelerated CSG unions
+   (:ref:`Chap:ImplemCSG`), whose primitive is ``ImplicitFunction<T>`` and whose leaf evaluator
+   calls a virtual ``value()`` through a ``std::shared_ptr<const ImplicitFunction<T>>``; those
+   classes therefore always use ``SharedPtrStorage`` and do not expose the policy. Use
+   ``ValueStorage`` only when ``P`` is a self-contained value type (a point, a particle, an SoA
+   triangle group), never for a polymorphic hierarchy.
+*  **Nesting a BVH inside a BVH.** A ``PackedBVH`` whose primitive is itself another
+   ``PackedBVH`` (or a mesh SDF that owns one) is a supported construction, and nothing stops it
+   recursing further — ``PackedBVH`` of ``PackedBVH`` of ``PackedBVH``, to any depth. At every
+   level the *outer* ``PackedBVH`` should stay on ``SharedPtrStorage`` so it shares each inner BVH
+   by pointer. Naming ``ValueStorage`` on an outer level instead copies every inner ``PackedBVH``
+   wholesale — its node, SoA, and primitive arrays — into the outer array: packing draws each
+   primitive from the source tree as a ``std::shared_ptr<const P>``, so each inner BVH is *copied*
+   (not moved) into place, even though ``PackedBVH`` is otherwise fully movable (see *Copy and move
+   semantics* above). The cost of that copy is proportional to the *entire* memory footprint
+   reachable below the primitive, so it becomes exceedingly expensive whenever an inner BVH is
+   large, and compounds with nesting depth: each by-value level duplicates everything beneath it,
+   which may itself be duplicating everything beneath *it*. ``SharedPtrStorage`` at every outer
+   level avoids this for no loss of correctness. The common realisation of nesting — a
+   ``BVHUnion`` over several mesh SDFs, each holding its own inner ``PackedBVH`` — is exactly the
+   polymorphic-primitive case above, so it already sits on ``SharedPtrStorage`` at the outer level
+   and shares each mesh SDF by pointer.
+
 Tree traversal
 ---------------
 

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -196,12 +196,17 @@ ________________________
 storage-sharing question above:
 
 *  ``TreeBVH`` deletes its copy constructor and copy assignment operator. It is a recursive
-   structure of ``shared_ptr``-linked children, and no deep-clone is implemented; a naive
-   (compiler-generated) copy would only alias the same child subtrees rather than cloning them,
-   which ``topDownSortAndPartition()``/``bottomUpSortAndPartition()`` could then mutate out from
-   under a supposedly independent "copy". Copying is disallowed outright rather than silently
-   doing the wrong thing. Its move constructor and move assignment operator are explicitly
-   defaulted and fully supported.
+   structure of ``shared_ptr``-linked children, so a naive (compiler-generated) copy would only
+   alias the same child subtrees rather than cloning them, which
+   ``topDownSortAndPartition()``/``bottomUpSortAndPartition()`` could then mutate out from under a
+   supposedly independent "copy". Copying is disallowed outright rather than silently doing the
+   wrong thing. Its move constructor and move assignment operator are explicitly defaulted and
+   fully supported. To *replicate* a tree independently -- e.g. to build once and then partition
+   two copies with different strategies, or to keep a pristine copy alongside one you go on to
+   mutate -- use ``deepCopy()``, which recursively clones the node hierarchy (returning a new
+   ``std::shared_ptr<TreeBVH>``) while still sharing the immutable ``std::shared_ptr<const P>``
+   primitives by handle. (Copying a ``std::shared_ptr<TreeBVH>`` is, of course, always fine -- that
+   is shared ownership of the *same* tree, not a replica.)
 *  ``PackedBVH`` allows both copying and moving. Its members (the flattened node array, the
    primitive array, and the SIMD AABB cache) are all owned value containers with no shared
    mutable substructure, so the compiler-generated deep copy is correct and safe under both

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -14,8 +14,8 @@ There are two representations of a BVH:
 *  ``BVH::TreeBVH<T, P, BV, K>``, a pointer-based tree used while *building* and
    *partitioning* the hierarchy. See `the doxygen page for TreeBVH
    <doxygen/html/classEBGeometry_1_1BVH_1_1TreeBVH.html>`__.
-*  ``BVH::PackedBVH<T, P, K>``, where the nodes are stored in depth-first order in a
-   flat array and contain index offsets to children and primitives rather than pointers. This is
+*  ``BVH::PackedBVH<T, P, K, StoragePolicy>``, where the nodes are stored in depth-first order in
+   a flat array and contain index offsets to children and primitives rather than pointers. This is
    the representation used for fast queries, see :ref:`Chap:PackedBVH`. See `the doxygen page
    for PackedBVH <doxygen/html/classEBGeometry_1_1BVH_1_1PackedBVH.html>`__.
 
@@ -132,9 +132,10 @@ The ``PackedBVH`` can be automatically constructed from a ``TreeBVH`` but not vi
    Each interior node stores index offsets to its children and primitives.
 
 The rationale for the ``PackedBVH`` is its tighter memory footprint and depth-first ordering, which allows more efficient traversal, particularly when primitives are sorted in the same order.
-``PackedBVH<T, P, K>`` is templated on the same ``T``, ``P``, ``K`` as ``TreeBVH`` (its bounding
-volume is always ``AABBT<T>``), and internally stores two things: a flat, depth-first array of
-nodes, and a global primitive array holding every primitive in leaf order.
+``PackedBVH<T, P, K, StoragePolicy>`` is templated on the same ``T``, ``P``, ``K`` as ``TreeBVH``
+(its bounding volume is always ``AABBT<T>``), plus a fourth ``StoragePolicy`` parameter described
+below, and internally stores two things: a flat, depth-first array of nodes, and a global
+primitive array holding every primitive in leaf order.
 
 Each entry of the node array plays the same role a ``TreeBVH`` node plays, but stores offsets
 into the flat arrays rather than pointers to children: a bounding volume for the node's subtree,
@@ -159,6 +160,34 @@ via one of two ``TreeBVH`` member functions:
 
 See `the doxygen page for TreeBVH <doxygen/html/classEBGeometry_1_1BVH_1_1TreeBVH.html>`__ for
 the exact signatures of ``pack()`` and ``packWith()``.
+
+Storage policy
+______________
+
+``pack()``/``packWith()`` both take an optional ``StoragePolicy`` template argument controlling
+*how* the resulting ``PackedBVH``'s global primitive array stores each primitive. A storage
+policy is a stateless struct exposing a ``StorageType`` type alias plus the static methods
+``get()``, ``appendTreeLeaf()``, and ``appendAliased()`` that ``PackedBVH`` calls internally when
+packing and querying; see `the BVH namespace's doxygen page
+<doxygen/html/namespaceEBGeometry_1_1BVH.html>`__ for the exact member list each one must provide.
+Two are provided out of the box:
+
+*  ``BVH::SharedPtrStorage<P>`` (the default for both ``pack()`` and ``packWith()``) stores each
+   primitive as a ``std::shared_ptr<const P>``, matching the pre-existing behavior of every
+   caller that does not name a ``StoragePolicy`` explicitly. Primitives are shared with whatever
+   else still holds a pointer to them (e.g. a ``DCEL::FaceT`` referenced by a ``TreeBVH``), at the
+   cost of one pointer indirection per access during traversal.
+*  ``BVH::ValueStorage<P>`` stores each primitive inline, by value: ``StorageType`` is ``P``
+   itself, with no indirection at all. This trades away sharing (the ``PackedBVH`` now owns an
+   independent copy of every primitive) for a smaller, more cache-friendly primitive array — most
+   useful when ``P`` is a small, cheaply-copyable value type (e.g. a point or particle) rather
+   than something large or already reference-counted elsewhere.
+
+Both policies are drop-in compatible with every existing ``PackedBVH`` consumer: swapping the
+policy only changes the element type of ``getPrimitives()`` and the leaf-primitive vector handed
+to ``LeafEvaluator``/``PackedLeafEvaluator`` callbacks, never the tree structure, traversal order,
+or query results. A caller that wants ``ValueStorage`` instead of the default simply names it
+explicitly, e.g. ``tree->pack<BVH::ValueStorage<P>>()``.
 
 Tree traversal
 ---------------

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -189,6 +189,30 @@ to ``LeafEvaluator``/``PackedLeafEvaluator`` callbacks, never the tree structure
 or query results. A caller that wants ``ValueStorage`` instead of the default simply names it
 explicitly, e.g. ``tree->pack<BVH::ValueStorage<P>>()``.
 
+Copy and move semantics
+________________________
+
+``TreeBVH`` and ``PackedBVH`` differ in whether copying is allowed, precisely because of the
+storage-sharing question above:
+
+*  ``TreeBVH`` deletes its copy constructor and copy assignment operator. It is a recursive
+   structure of ``shared_ptr``-linked children, and no deep-clone is implemented; a naive
+   (compiler-generated) copy would only alias the same child subtrees rather than cloning them,
+   which ``topDownSortAndPartition()``/``bottomUpSortAndPartition()`` could then mutate out from
+   under a supposedly independent "copy". Copying is disallowed outright rather than silently
+   doing the wrong thing. Its move constructor and move assignment operator are explicitly
+   defaulted and fully supported.
+*  ``PackedBVH`` allows both copying and moving. Its members (the flattened node array, the
+   primitive array, and the SIMD AABB cache) are all owned value containers with no shared
+   mutable substructure, so the compiler-generated deep copy is correct and safe under both
+   ``BVH::SharedPtrStorage`` (primitives are aliased ``shared_ptr``, the same sharing model as
+   ``TreeBVH``) and ``BVH::ValueStorage`` (primitives are copied by value -- safe as long as the
+   primitive type's own copy constructor is complete; see the note on ``DCEL::FaceT`` in
+   :ref:`Chap:MeshSDFClasses` for a case where it deliberately is not).
+
+Both classes' destructors are non-virtual: neither is intended to be subclassed or used
+polymorphically.
+
 Tree traversal
 ---------------
 

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -368,12 +368,12 @@ BVH type, and supported geometry:
      - Debug / tiny meshes only; no build cost
    * - ``MeshSDF<T, Meta, K>``
      - DCEL mesh
-     - ``PackedBVH`` over ``DCEL::FaceT``
+     - ``PackedBVH`` over ``DCEL::FaceT`` (always ``BVH::SharedPtrStorage``)
      - ``pruneTraverse()`` (SIMD when ``(K, T)`` matches a compiled ISA path)
      - Any polygon mesh; not restricted to triangles
-   * - ``TriMeshSDF<T, Meta, K, W>``
+   * - ``TriMeshSDF<T, Meta, K, W, StoragePolicy>``
      - DCEL mesh or triangle soup
-     - ``PackedBVH`` over SoA triangle groups
+     - ``PackedBVH`` over SoA triangle groups (``BVH::ValueStorage`` by default)
      - ``pruneTraverse()`` over SoA-packed leaves
      - Triangle meshes only; highest throughput
 
@@ -398,6 +398,39 @@ itself.
 
 What is actually vectorised in ``TriMeshSDF``/``PackedBVH`` is covered in
 :ref:`Chap:SIMDClasses` -- see that page for the full detail rather than repeating it here.
+
+Primitive storage: why MeshSDF and TriMeshSDF default differently
+___________________________________________________________________
+
+Both classes' underlying ``PackedBVH`` accepts the ``StoragePolicy`` axis described above, but
+they default -- and, for ``MeshSDF``, are restricted -- differently:
+
+*  ``MeshSDF`` always uses ``BVH::SharedPtrStorage<DCEL::FaceT<T, Meta>>`` and does not expose a
+   ``StoragePolicy`` template parameter at all. This is not merely a default: ``DCEL::FaceT``'s
+   copy constructor deliberately does *not* copy its cached 2D polygon embedding (used by
+   ``signedDistance()``'s point-in-face test) or its inside/outside algorithm choice, since
+   ``FaceT``'s half-edge back-reference is only topologically meaningful relative to a specific
+   mesh (the same reasoning documented for ``VertexT``/``EdgeT``'s copy constructors). A
+   ``BVH::ValueStorage``-style plain copy would therefore leave every packed face with an
+   uninitialized embedding, crashing on the first query rather than merely losing sharing --
+   so ``MeshSDF`` simply never offers that choice.
+*  ``TriMeshSDF`` defaults to ``BVH::ValueStorage<TriangleSoAT<T, W>>`` instead of
+   ``BVH::SharedPtrStorage``, and *does* expose ``StoragePolicy`` as an overridable template
+   parameter (its 5th, after ``W``). Unlike ``DCEL::FaceT``, each ``TriangleSoAT<T, W>`` group is
+   a plain aggregate of coordinate arrays with no cached derived state or back-references, built
+   fresh by ``groupTrianglesIntoSoA()`` during packing and shared with nothing else -- so storing
+   it inline is both safe and, avoiding one heap allocation and pointer indirection per group,
+   the better default.
+
+Neither default is affected by instancing the same mesh multiple times (e.g. placing several
+``Translate``/``Rotate``/``Scale``-wrapped copies of one mesh into a ``Union``): those wrappers
+hold a ``shared_ptr`` to the whole ``MeshSDF``/``TriMeshSDF`` object (see :ref:`Chap:ImplemCSG`),
+so its packed data is shared once per wrapper regardless of how that one object's own
+``PackedBVH`` stores its primitives internally.
+
+``Parser::readIntoPackedBVH`` mirrors ``MeshSDF`` (no ``StoragePolicy`` parameter);
+``Parser::readIntoTriangleBVH`` mirrors ``TriMeshSDF`` (``StoragePolicy`` as its 5th template
+parameter, defaulting to ``BVH::ValueStorage<TriangleSoAT<T, W>>``). See :ref:`Chap:Parsers`.
 
 SIMD-optimal K and W by ISA
 ______________________________

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -28,8 +28,8 @@ The template parameters shared by both are:
    callback a caller supplies to ``traverse()`` or ``pruneTraverse()`` (see below). Whether
    ``P`` needs a ``signedDistance(Vec3T<T>)`` member (or anything else) is entirely up to that
    callback -- see ``MeshSDF``/``TriMeshSDF::signedDistance()`` in :ref:`Chap:MeshSDFClasses` for
-   the signed-distance case, and the nearest-neighbor example in ``Tests/TestBVH.cpp`` for a
-   primitive with no ``signedDistance()`` at all.
+   the signed-distance case; a callback could equally perform, say, a nearest-neighbor search over
+   a point cloud whose primitive carries no ``signedDistance()`` at all.
 *  ``BV`` Bounding volume type (``TreeBVH`` only — ``PackedBVH`` always uses
    ``BoundingVolumes::AABBT<T>`` internally).
 *  ``K`` BVH degree. ``K=2`` will yield a binary tree, ``K=3`` yields a tertiary tree and so on.
@@ -359,9 +359,8 @@ squaring, no square root anywhere in the hot path) with a pruning rule that retu
 unchanged, whereas ``MeshSDF``/``TriMeshSDF::signedDistance()`` (see :ref:`Chap:MeshSDFClasses`)
 track a signed distance and square its magnitude for the bound -- both are ordinary
 instantiations of the same ``pruneTraverse()``, not special cases hardcoded into ``PackedBVH``.
-``Tests/TestBVH.cpp`` has a worked example of the former: a bare point struct with no
-``signedDistance()`` member at all, searched for its nearest neighbor via ``pruneTraverse()``,
-checked against a brute-force scan.
+The former needs nothing more than a bare point struct with no ``signedDistance()`` member at all,
+searched for its nearest neighbor via ``pruneTraverse()`` against a running squared distance.
 
 For the exact template signature and callback contracts, see `the doxygen page for
 PackedBVH::pruneTraverse <doxygen/html/classEBGeometry_1_1BVH_1_1PackedBVH.html>`__.

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -133,13 +133,16 @@ triangle-only meshes, prefer ``readIntoTriangleBVH`` below.
 Triangle meshes with PackedBVH
 ________________________________
 
-``readIntoTriangleBVH<T, Meta, K, W>(filename, maxLeafGroups, build)`` converts all DCEL polygons
-to triangles, packs them into SoA groups of ``W``, and builds a ``PackedBVH``, returning a
-``shared_ptr<TriMeshSDF<T, Meta, K, W>>`` (or a vector thereof). SIMD intrinsics evaluate up to
-``W`` triangles per leaf visit. ``K`` and ``W`` default to the SIMD-optimal values for ``T`` on the
-current ISA (``BVH::DefaultBranchingRatio<T>()`` and ``TriangleSoA::DefaultWidth<T>()``, see
-:ref:`Chap:MeshSDFClasses`); ``maxLeafGroups`` (default 2) bounds the number of full ``W``-sized
-SoA groups per BVH leaf. The code will raise an error if any face is not a triangle.
+``readIntoTriangleBVH<T, Meta, K, W, StoragePolicy>(filename, maxLeafGroups, build)`` converts all
+DCEL polygons to triangles, packs them into SoA groups of ``W``, and builds a ``PackedBVH``,
+returning a ``shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>`` (or a vector thereof). SIMD
+intrinsics evaluate up to ``W`` triangles per leaf visit. ``K`` and ``W`` default to the
+SIMD-optimal values for ``T`` on the current ISA (``BVH::DefaultBranchingRatio<T>()`` and
+``TriangleSoA::DefaultWidth<T>()``, see :ref:`Chap:MeshSDFClasses`); ``maxLeafGroups`` (default 2)
+bounds the number of full ``W``-sized SoA groups per BVH leaf; ``StoragePolicy`` defaults to
+``BVH::ValueStorage<TriangleSoAT<T, W>>``, matching ``TriMeshSDF``'s own default (see
+:ref:`Chap:MeshSDFClasses` for the rationale, and why ``readIntoPackedBVH``/``MeshSDF`` above has
+no equivalent parameter). The code will raise an error if any face is not a triangle.
 
 Flat triangle list
 ____________________

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -138,7 +138,7 @@ DCEL polygons to triangles, packs them into SoA groups of ``W``, and builds a ``
 returning a ``shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>`` (or a vector thereof). SIMD
 intrinsics evaluate up to ``W`` triangles per leaf visit. ``K`` and ``W`` default to the
 SIMD-optimal values for ``T`` on the current ISA (``BVH::DefaultBranchingRatio<T>()`` and
-``TriangleSoA::DefaultWidth<T>()``, see :ref:`Chap:MeshSDFClasses`); ``maxLeafGroups`` (default 2)
+``TriangleSoA::DefaultWidth<T>()``, see :ref:`Chap:MeshSDFClasses`); ``maxLeafGroups`` (default 4)
 bounds the number of full ``W``-sized SoA groups per BVH leaf; ``StoragePolicy`` defaults to
 ``BVH::ValueStorage<TriangleSoAT<T, W>>``, matching ``TriMeshSDF``'s own default (see
 :ref:`Chap:MeshSDFClasses` for the rationale, and why ``readIntoPackedBVH``/``MeshSDF`` above has

--- a/Docs/Sphinx/source/index.rst
+++ b/Docs/Sphinx/source/index.rst
@@ -26,9 +26,12 @@ Main features:
 
 .. important::
 
-   This is the user documentation for EBGeometry. A
-   `PDF version <https://rmrsk.github.io/EBGeometry/ebgeometry.pdf>`_
-   of this documentation is also available.
+   This is the user documentation for EBGeometry.
+
+   .. only:: html
+
+      A `PDF version <https://rmrsk.github.io/EBGeometry/ebgeometry.pdf>`_ of this documentation is
+      also available.
 
    * If you are looking for the source code, it is hosted on
      `GitHub <https://github.com/rmrsk/EBGeometry>`_.

--- a/Docs/Sphinx/source/index.rst
+++ b/Docs/Sphinx/source/index.rst
@@ -114,6 +114,7 @@ Examples
    ExampleShapes.rst
    ExampleMeshSDF.rst
    ExampleCSGUnion.rst
+   ExampleNestedBVH.rst
    ExamplePackedSpheres.rst
    ExampleRandomCity.rst
    ExampleOctreeBoundingVolume.rst

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -31,6 +31,7 @@ endfunction()
 
 ebgeometry_add_example(CSGUnion)
 ebgeometry_add_example(MeshSDF)
+ebgeometry_add_example(NestedBVH)
 ebgeometry_add_example(OctreeBoundingVolume)
 ebgeometry_add_example(PackedSpheres)
 ebgeometry_add_example(RandomCity)

--- a/Examples/NestedBVH/CMakeLists.txt
+++ b/Examples/NestedBVH/CMakeLists.txt
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Standalone build file for the NestedBVH example. It can be built on its own
+# (e.g. copied out as a template for a new project) or as part of the top-level
+# EBGeometry build.
+cmake_minimum_required(VERSION 3.16)
+project(NestedBVH CXX)
+
+# Locate the header-only library. EBGEOMETRY_HOME is the directory that contains
+# EBGeometry.hpp (the repository root); it defaults to the in-tree location two
+# levels up. When built from the top-level EBGeometry project the
+# EBGeometry::EBGeometry target already exists and is used as-is.
+if(NOT TARGET EBGeometry::EBGeometry)
+  set(EBGEOMETRY_HOME "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH
+      "Path to the directory containing EBGeometry.hpp")
+  add_library(EBGeometry::EBGeometry INTERFACE IMPORTED)
+  target_include_directories(EBGeometry::EBGeometry INTERFACE "${EBGEOMETRY_HOME}")
+  target_compile_features(EBGeometry::EBGeometry INTERFACE cxx_std_17)
+endif()
+
+add_executable(NestedBVH main.cpp)
+
+# Give the binary a .ex extension so it's covered by the repo-wide *.ex .gitignore rule,
+# without needing a per-example ignore entry. Always place it directly in this
+# source directory (not wherever -B/--preset pointed the build tree), so all three
+# documented build methods (direct compile, GNU make, CMake) produce the binary in
+# the same place: ./NestedBVH.ex.
+set_target_properties(NestedBVH PROPERTIES
+  SUFFIX ".ex"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(NestedBVH PRIVATE EBGeometry::EBGeometry)
+target_compile_options(NestedBVH PRIVATE -Wall -Wextra -Wno-unused-parameter)
+
+# Examples are meant to be fast to run, not to match the enclosing project's build
+# type (which may be an unoptimised Debug build, e.g. under the top-level project's
+# debug preset). Always build optimized for the local machine's ISA.
+target_compile_options(NestedBVH PRIVATE -O3 -march=native)
+
+# ---------------------------------------------------------------------------
+# Floating-point precision for this example.
+#
+# Cache variable, overridable at configure time with
+# -DEBGEOMETRY_PRECISION=float. It is handed to the compiler as
+# EBGEOMETRY_PRECISION and picked up in main.cpp by `using T = EBGEOMETRY_PRECISION`.
+# ---------------------------------------------------------------------------
+set(EBGEOMETRY_PRECISION double CACHE STRING "Floating-point precision (float or double)")
+set_property(CACHE EBGEOMETRY_PRECISION PROPERTY STRINGS float double)
+target_compile_definitions(NestedBVH PRIVATE EBGEOMETRY_PRECISION=${EBGEOMETRY_PRECISION})
+
+# ---------------------------------------------------------------------------
+# EBGEOMETRY_EXPECT() runtime assertions for this example.
+#
+# OFF by default. Enable at configure time with -DEBGEOMETRY_ENABLE_ASSERTIONS=ON.
+# When built from the top-level EBGeometry project, this option already exists
+# (defined by the root CMakeLists.txt) and its value is inherited as-is.
+# ---------------------------------------------------------------------------
+option(EBGEOMETRY_ENABLE_ASSERTIONS "Enable EBGEOMETRY_EXPECT() runtime assertion checks" OFF)
+if(EBGEOMETRY_ENABLE_ASSERTIONS)
+  target_compile_definitions(NestedBVH PRIVATE EBGEOMETRY_ENABLE_ASSERTIONS)
+endif()

--- a/Examples/NestedBVH/GNUmakefile
+++ b/Examples/NestedBVH/GNUmakefile
@@ -1,0 +1,32 @@
+# GNU makefile for building this EBGeometry example on its own.
+#
+# EBGEOMETRY_HOME must point at the directory that contains EBGeometry.hpp (the
+# EBGeometry repository root); it defaults to the in-tree location two levels up.
+# PRECISION selects the floating-point type (float or double). ASSERTIONS
+# (ON/OFF) toggles EBGEOMETRY_EXPECT() runtime assertion checks. Override any
+# of these on the command line, e.g.:
+#
+#   make PRECISION=float ASSERTIONS=ON EBGEOMETRY_HOME=/path/to/EBGeometry
+
+EBGEOMETRY_HOME ?= ../..
+PRECISION       ?= double
+ASSERTIONS      ?= OFF
+
+CXX      ?= g++
+CXXFLAGS ?= -std=c++17 -O3 -march=native -Wall -Wextra
+
+ifeq ($(ASSERTIONS),ON)
+  CXXFLAGS += -DEBGEOMETRY_ENABLE_ASSERTIONS
+endif
+
+TARGET := NestedBVH.ex
+
+$(TARGET): main.cpp
+	$(CXX) $(CXXFLAGS) -I$(EBGEOMETRY_HOME) -DEBGEOMETRY_PRECISION=$(PRECISION) $< -o $@
+
+.PHONY: run clean
+run: $(TARGET)
+	./$(TARGET)
+
+clean:
+	$(RM) $(TARGET)

--- a/Examples/NestedBVH/README.md
+++ b/Examples/NestedBVH/README.md
@@ -1,0 +1,70 @@
+Examples/NestedBVH
+------------------
+
+This folder shows how to build a *nested* bounding volume hierarchy (BVH): an outer,
+BVH-accelerated CSG union whose primitives are themselves BVH-backed mesh signed distance
+functions.
+
+Each mesh is loaded as a `TriMeshSDF`, which stores the mesh triangles in its own inner
+`PackedBVH`. Several translated copies of the mesh are then combined with `BVHUnion`, which builds
+an *outer* `PackedBVH` over those mesh SDFs. A single distance query therefore descends two levels
+of BVH: first the outer union hierarchy, to find which mesh copy (or copies) is near the query
+point, then that mesh's own inner hierarchy, to find the nearest triangle. The union's value is the
+minimum signed distance over all copies -- negative inside any copy, positive outside all of them.
+
+The outer union stores its primitives as `std::shared_ptr<const ImplicitFunction<T>>` (the default
+`SharedPtrStorage`), so it *shares* each mesh SDF by pointer rather than copying it. This is the
+recommended way to nest BVHs. See the "Storage policy" section of the
+[BVH implementation](https://rmrsk.github.io/EBGeometry/ImplemBVH.html) documentation for why the
+outer level should not use `ValueStorage` here: it would deep-copy every inner BVH, and because the
+union primitive is the polymorphic base `ImplicitFunction<T>` it cannot be stored by value at all.
+
+By default the example uses the small `dodecahedron.stl` fixture shipped in the repository
+(`Tests/data/`), so it needs no submodule. Pass a different triangle mesh (STL/PLY/VTK/OBJ) on the
+command line to place copies of your own geometry instead.
+
+Building
+--------
+
+This example is standalone and can be built in three ways. Each needs the path
+to the EBGeometry root -- the directory that contains `EBGeometry.hpp` -- which
+is two levels up from this folder (`../..`) when building in place. See
+[Direct compilation](https://rmrsk.github.io/EBGeometry/BuildingDirectCompile.html),
+[Building with GNU Make](https://rmrsk.github.io/EBGeometry/BuildingGNUMake.html), and
+[Building with CMake](https://rmrsk.github.io/EBGeometry/BuildingCMake.html) in the user
+documentation for more detail on each approach.
+
+**CMake**
+
+    cmake -S . -B build
+    cmake --build build
+
+The binary is `NestedBVH.ex`, in this same directory (same as the other two methods below). Build
+in single precision, against a library in a different location, or with `EBGEOMETRY_EXPECT()`
+runtime assertions enabled, with cache variables:
+
+    cmake -S . -B build -DEBGEOMETRY_PRECISION=float -DEBGEOMETRY_HOME=/path/to/EBGeometry -DEBGEOMETRY_ENABLE_ASSERTIONS=ON
+
+**GNU make**
+
+    make
+
+This produces `./NestedBVH.ex`. Override the defaults on the command line:
+
+    make PRECISION=float EBGEOMETRY_HOME=/path/to/EBGeometry ASSERTIONS=ON
+
+**Directly with a compiler**
+
+    g++ -std=c++17 -O3 -march=native -I../.. main.cpp -o NestedBVH.ex
+
+Add `-DEBGEOMETRY_PRECISION=float` for single precision, or `-DEBGEOMETRY_ENABLE_ASSERTIONS` to enable
+`EBGEOMETRY_EXPECT()` runtime assertion checks.
+
+Running
+-------
+
+    ./NestedBVH.ex                       # uses ../../Tests/data/dodecahedron.stl
+    ./NestedBVH.ex path/to/mesh.stl      # uses your own triangle mesh
+
+The program prints the number of mesh copies combined and evaluates the nested union's signed
+distance at a few sample points (inside a copy, between copies, and far outside everything).

--- a/Examples/NestedBVH/README.md
+++ b/Examples/NestedBVH/README.md
@@ -5,16 +5,19 @@ This folder shows how to build a *nested* bounding volume hierarchy (BVH): an ou
 BVH-accelerated CSG union whose primitives are themselves BVH-backed mesh signed distance
 functions.
 
-Each mesh is loaded as a `TriMeshSDF`, which stores the mesh triangles in its own inner
-`PackedBVH`. Several translated copies of the mesh are then combined with `BVHUnion`, which builds
-an *outer* `PackedBVH` over those mesh SDFs. A single distance query therefore descends two levels
-of BVH: first the outer union hierarchy, to find which mesh copy (or copies) is near the query
-point, then that mesh's own inner hierarchy, to find the nearest triangle. The union's value is the
-minimum signed distance over all copies -- negative inside any copy, positive outside all of them.
+The mesh is loaded once into a `TriMeshSDF`, which stores the mesh triangles in its own inner
+`PackedBVH`. That single mesh SDF is then instanced at several positions -- each placement is a
+`Translate` wrapper holding a shared pointer to the *same* `TriMeshSDF` -- and the placements are
+combined with `BVHUnion`, which builds an *outer* `PackedBVH` over them. A single distance query
+therefore descends two levels of BVH: first the outer union hierarchy, to find which placement (or
+placements) is near the query point, then the mesh's own inner hierarchy, to find the nearest
+triangle. The union's value is the minimum signed distance over all placements -- negative inside
+any of them, positive outside all of them.
 
 The outer union stores its primitives as `std::shared_ptr<const ImplicitFunction<T>>` (the default
-`SharedPtrStorage`), so it *shares* each mesh SDF by pointer rather than copying it. This is the
-recommended way to nest BVHs. See the "Storage policy" section of the
+`SharedPtrStorage`), so it *shares* each placement by pointer rather than copying it -- and because
+the placements all point at one `TriMeshSDF`, the inner packed BVH is built and stored just once.
+This is the recommended way to nest BVHs. See the "Storage policy" section of the
 [BVH implementation](https://rmrsk.github.io/EBGeometry/ImplemBVH.html) documentation for why the
 outer level should not use `ValueStorage` here: it would deep-copy every inner BVH, and because the
 union primitive is the polymorphic base `ImplicitFunction<T>` it cannot be stored by value at all.

--- a/Examples/NestedBVH/main.cpp
+++ b/Examples/NestedBVH/main.cpp
@@ -16,14 +16,15 @@
 
 using namespace EBGeometry;
 
-// BVH branching factor, used at both levels of the hierarchy.
-constexpr size_t K = 4;
+using T    = EBGEOMETRY_PRECISION;
+using Meta = short;
 
-// SoA triangle-group width for each inner mesh BVH.
-constexpr size_t W = 4;
+// BVH branching factor (used at both levels of the hierarchy) and SoA triangle-group width for the
+// inner mesh BVHs. Default to the SIMD-optimal values for T on the compiled ISA -- the same
+// defaults Parser::readIntoTriangleBVH picks internally.
+constexpr size_t K = BVH::DefaultBranchingRatio<T>();
+constexpr size_t W = TriangleSoA::DefaultWidth<T>();
 
-using T       = EBGEOMETRY_PRECISION;
-using Meta    = short;
 using Vec3    = EBGeometry::Vec3T<T>;
 using BV      = EBGeometry::BoundingVolumes::AABBT<T>;
 using IF      = EBGeometry::ImplicitFunction<T>;
@@ -41,8 +42,8 @@ main(int argc, char* argv[])
   // The outer union stores its primitives as std::shared_ptr<const ImplicitFunction<T>> (the default
   // SharedPtrStorage): it shares each mesh SDF by pointer rather than copying it. This is the
   // recommended way to nest BVHs -- and nesting can recurse to any depth (a BVH of BVHs of BVHs...).
-  // See the "Storage policy" section of the BVH implementation docs (Docs/Sphinx/source/ImplemBVH.rst)
-  // for why the outer level must not use ValueStorage here: ImplicitFunction<T> is polymorphic so it
+  // See the "Storage policy" section in the user documentation of the BVH implementation for why the
+  // outer level must not use ValueStorage here: ImplicitFunction<T> is polymorphic so it
   // cannot be stored by value at all, and even for a concrete primitive by-value storage copies each
   // inner BVH's entire memory footprint, which becomes exceedingly expensive for large inner BVHs and
   // compounds with nesting depth.

--- a/Examples/NestedBVH/main.cpp
+++ b/Examples/NestedBVH/main.cpp
@@ -19,16 +19,13 @@ using namespace EBGeometry;
 using T    = EBGEOMETRY_PRECISION;
 using Meta = short;
 
-// BVH branching factor (used at both levels of the hierarchy) and SoA triangle-group width for the
-// inner mesh BVHs. Default to the SIMD-optimal values for T on the compiled ISA -- the same
-// defaults Parser::readIntoTriangleBVH picks internally.
+// Branching factor for the outer union BVH. Defaults to the SIMD-optimal value for T on the
+// compiled ISA -- the same default readIntoTriangleBVH uses for the inner mesh BVHs.
 constexpr size_t K = BVH::DefaultBranchingRatio<T>();
-constexpr size_t W = TriangleSoA::DefaultWidth<T>();
 
-using Vec3    = EBGeometry::Vec3T<T>;
-using BV      = EBGeometry::BoundingVolumes::AABBT<T>;
-using IF      = EBGeometry::ImplicitFunction<T>;
-using TriMesh = EBGeometry::TriMeshSDF<T, Meta, K, W>;
+using Vec3 = EBGeometry::Vec3T<T>;
+using BV   = EBGeometry::BoundingVolumes::AABBT<T>;
+using IF   = EBGeometry::ImplicitFunction<T>;
 
 int
 main(int argc, char* argv[])
@@ -48,7 +45,7 @@ main(int argc, char* argv[])
   // inner BVH's entire memory footprint, which becomes exceedingly expensive for large inner BVHs and
   // compounds with nesting depth.
 
-  // Mesh to place several copies of. Pass a path on the command line, or fall back to the
+  // Mesh to place at several positions. Pass a path on the command line, or fall back to the
   // dodecahedron fixture shipped in the repository (Tests/data), so this example needs no
   // submodule. The path is relative to this example's own folder, which is the working directory
   // when the example is run.
@@ -61,16 +58,15 @@ main(int argc, char* argv[])
               << "Usage: ./NestedBVH.ex <mesh-file>  (STL/PLY/VTK/OBJ, triangles only)\n";
   }
 
-  // Read the triangle mesh once into a DCEL representation.
-  const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(file);
-
-  // Build the BVH-backed mesh SDF *once*, then instance it at several positions. Because every
-  // placement is the same mesh, they should all share a single TriMeshSDF: its (value-stored) inner
-  // packed BVH is built and stored exactly once, and each placement is just an EBGeometry::Translate
-  // wrapper holding a shared_ptr to that same object -- shared by pointer, never rebuilt or copied
-  // per placement. This is the idiomatic way to replicate one mesh across a scene. (To place
-  // genuinely different meshes instead, build one TriMeshSDF per mesh file and translate each.)
-  const auto tri   = std::make_shared<TriMesh>(mesh, BVH::Build::SAH, 2);
+  // Read the mesh directly into a BVH-backed TriMeshSDF using the library's default parameters
+  // (SIMD-optimal branching factor and SoA width, ValueStorage, SAH build). Build it *once*, then
+  // instance it at several positions below: because every placement is the same mesh, they all
+  // share this single TriMeshSDF -- its (value-stored) inner packed BVH is built and stored exactly
+  // once, and each placement is just an EBGeometry::Translate wrapper holding a shared_ptr to that
+  // same object, shared by pointer and never rebuilt or copied per placement. This is the idiomatic
+  // way to replicate one mesh across a scene. (To place genuinely different meshes instead, read one
+  // TriMeshSDF per mesh file and translate each.)
+  const auto tri   = EBGeometry::Parser::readIntoTriangleBVH<T, Meta>(file);
   const BV   triBV = tri->computeBoundingVolume();
 
   const std::vector<Vec3> shifts = {

--- a/Examples/NestedBVH/main.cpp
+++ b/Examples/NestedBVH/main.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <EBGeometry.hpp>
+
+// Floating-point precision. Overridable from CMake (-DEBGEOMETRY_PRECISION=float).
+#ifndef EBGEOMETRY_PRECISION
+#define EBGEOMETRY_PRECISION double
+#endif
+
+using namespace EBGeometry;
+
+// BVH branching factor, used at both levels of the hierarchy.
+constexpr size_t K = 4;
+
+// SoA triangle-group width for each inner mesh BVH.
+constexpr size_t W = 4;
+
+using T       = EBGEOMETRY_PRECISION;
+using Meta    = short;
+using Vec3    = EBGeometry::Vec3T<T>;
+using BV      = EBGeometry::BoundingVolumes::AABBT<T>;
+using IF      = EBGeometry::ImplicitFunction<T>;
+using TriMesh = EBGeometry::TriMeshSDF<T, Meta, K, W>;
+
+int
+main(int argc, char* argv[])
+{
+  // This example builds a *nested* bounding volume hierarchy: an outer BVH-accelerated CSG union
+  // (BVHUnionIF) whose primitives are themselves BVH-backed mesh signed distance functions
+  // (TriMeshSDF). Each TriMeshSDF owns an inner PackedBVH over its SoA triangle groups, so a single
+  // distance query descends the outer union BVH to locate the nearby mesh(es), then descends each of
+  // those meshes' own inner BVH -- two levels of BVH traversal for one query.
+  //
+  // The outer union stores its primitives as std::shared_ptr<const ImplicitFunction<T>> (the default
+  // SharedPtrStorage): it shares each mesh SDF by pointer rather than copying it. This is the
+  // recommended way to nest BVHs -- and nesting can recurse to any depth (a BVH of BVHs of BVHs...).
+  // See the "Storage policy" section of the BVH implementation docs (Docs/Sphinx/source/ImplemBVH.rst)
+  // for why the outer level must not use ValueStorage here: ImplicitFunction<T> is polymorphic so it
+  // cannot be stored by value at all, and even for a concrete primitive by-value storage copies each
+  // inner BVH's entire memory footprint, which becomes exceedingly expensive for large inner BVHs and
+  // compounds with nesting depth.
+
+  // Mesh to place several copies of. Pass a path on the command line, or fall back to the
+  // dodecahedron fixture shipped in the repository (Tests/data), so this example needs no
+  // submodule. The path is relative to this example's own folder, which is the working directory
+  // when the example is run.
+  std::string file = "../../Tests/data/dodecahedron.stl";
+  if (argc >= 2) {
+    file = std::string(argv[1]);
+  }
+  else {
+    std::cout << "No mesh file given; defaulting to the in-repo dodecahedron.stl fixture.\n"
+              << "Usage: ./NestedBVH.ex <mesh-file>  (STL/PLY/VTK/OBJ, triangles only)\n";
+  }
+
+  // Read the triangle mesh once into a DCEL representation.
+  const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(file);
+
+  // Place several translated copies of the mesh. Each copy is an independent TriMeshSDF (its own
+  // inner PackedBVH), translated into position and exposed through the common base type. Its
+  // bounding volume for the outer union is the mesh's own AABB shifted by the same offset.
+  const std::vector<Vec3> shifts = {
+    Vec3(0, 0, 0),
+    Vec3(4, 0, 0),
+    Vec3(0, 4, 0),
+    Vec3(4, 4, 0),
+    Vec3(2, 2, 4),
+  };
+
+  std::vector<std::shared_ptr<IF>> primitives;
+  std::vector<BV>                  boundingVolumes;
+  primitives.reserve(shifts.size());
+  boundingVolumes.reserve(shifts.size());
+
+  for (const Vec3& shift : shifts) {
+    const auto tri = std::make_shared<TriMesh>(mesh, BVH::Build::SAH, 2);
+    const BV   bv  = tri->computeBoundingVolume();
+
+    primitives.emplace_back(EBGeometry::Translate<T>(tri, shift));
+    boundingVolumes.emplace_back(bv.getLowCorner() + shift, bv.getHighCorner() + shift);
+  }
+
+  // Outer BVH: a BVH-accelerated union over the mesh SDFs. This is the nested (two-level) BVH.
+  const auto nestedUnion = EBGeometry::BVHUnion<T, IF, BV, K>(primitives, boundingVolumes);
+
+  std::cout << "Built a BVH union over " << primitives.size() << " BVH-backed mesh SDFs (a nested, two-level BVH).\n";
+
+  // Evaluate at a few points: on the first copy, between copies, and far outside everything.
+  for (const Vec3& p : {Vec3(0, 0, 0), Vec3(2, 2, 0), Vec3(20, 20, 20)}) {
+    std::cout << "value(" << p << ") = " << nestedUnion->value(p) << "\n";
+  }
+
+  return 0;
+}

--- a/Examples/NestedBVH/main.cpp
+++ b/Examples/NestedBVH/main.cpp
@@ -64,9 +64,15 @@ main(int argc, char* argv[])
   // Read the triangle mesh once into a DCEL representation.
   const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(file);
 
-  // Place several translated copies of the mesh. Each copy is an independent TriMeshSDF (its own
-  // inner PackedBVH), translated into position and exposed through the common base type. Its
-  // bounding volume for the outer union is the mesh's own AABB shifted by the same offset.
+  // Build the BVH-backed mesh SDF *once*, then instance it at several positions. Because every
+  // placement is the same mesh, they should all share a single TriMeshSDF: its (value-stored) inner
+  // packed BVH is built and stored exactly once, and each placement is just an EBGeometry::Translate
+  // wrapper holding a shared_ptr to that same object -- shared by pointer, never rebuilt or copied
+  // per placement. This is the idiomatic way to replicate one mesh across a scene. (To place
+  // genuinely different meshes instead, build one TriMeshSDF per mesh file and translate each.)
+  const auto tri   = std::make_shared<TriMesh>(mesh, BVH::Build::SAH, 2);
+  const BV   triBV = tri->computeBoundingVolume();
+
   const std::vector<Vec3> shifts = {
     Vec3(0, 0, 0),
     Vec3(4, 0, 0),
@@ -80,20 +86,20 @@ main(int argc, char* argv[])
   primitives.reserve(shifts.size());
   boundingVolumes.reserve(shifts.size());
 
+  // Each placement shares the one inner mesh BVH; only its translation -- and its bounding volume
+  // for the outer union (the mesh's own AABB shifted by the same offset) -- differs.
   for (const Vec3& shift : shifts) {
-    const auto tri = std::make_shared<TriMesh>(mesh, BVH::Build::SAH, 2);
-    const BV   bv  = tri->computeBoundingVolume();
-
     primitives.emplace_back(EBGeometry::Translate<T>(tri, shift));
-    boundingVolumes.emplace_back(bv.getLowCorner() + shift, bv.getHighCorner() + shift);
+    boundingVolumes.emplace_back(triBV.getLowCorner() + shift, triBV.getHighCorner() + shift);
   }
 
-  // Outer BVH: a BVH-accelerated union over the mesh SDFs. This is the nested (two-level) BVH.
+  // Outer BVH: a BVH-accelerated union over the placements. This is the nested (two-level) BVH.
   const auto nestedUnion = EBGeometry::BVHUnion<T, IF, BV, K>(primitives, boundingVolumes);
 
-  std::cout << "Built a BVH union over " << primitives.size() << " BVH-backed mesh SDFs (a nested, two-level BVH).\n";
+  std::cout << "Built a BVH union over " << primitives.size()
+            << " placements of one BVH-backed mesh SDF (a nested, two-level BVH).\n";
 
-  // Evaluate at a few points: on the first copy, between copies, and far outside everything.
+  // Evaluate at a few points: on a placement, between placements, and far outside everything.
   for (const Vec3& p : {Vec3(0, 0, 0), Vec3(2, 2, 0), Vec3(20, 20, 20)}) {
     std::cout << "value(" << p << ") = " << nestedUnion->value(p) << "\n";
   }

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -3,6 +3,7 @@ third-party dependencies):
 
 * `CSGUnion` For merging a surface mesh with an analytic sphere using a BVH-accelerated CSG union.
 * `MeshSDF` For reading a surface mesh and evaluating it with the DCEL/BVH signed-distance representations.
+* `NestedBVH` For a nested BVH: a BVH-accelerated union over several BVH-backed mesh SDFs.
 * `OctreeBoundingVolume` For using the octree bounding-volume functionality.
 * `PackedSpheres` For a scene composed of many analytic spheres.
 * `RandomCity` For procedurally building a scene of many objects.

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -776,10 +776,11 @@ public:
   /**
    * @brief Deleted copy constructor.
    * @details A TreeBVH is a recursive structure of shared_ptr-linked children (m_children);
-   * copying it would only alias the same child subtrees rather than cloning them, since no
-   * deep-clone is implemented. topDownSortAndPartition()/bottomUpSortAndPartition() mutate a
-   * node's children in place, so such a "copy" could silently share mutable state with the
-   * original instead of being independent. Disallowed outright rather than doing the wrong thing.
+   * a compiler-generated copy would only alias the same child subtrees rather than cloning them.
+   * topDownSortAndPartition()/bottomUpSortAndPartition() mutate a node's children in place, so such
+   * a "copy" could silently share mutable state with the original instead of being independent.
+   * Disallowed outright rather than doing the wrong thing; use deepCopy() to replicate a tree
+   * independently.
    * @param[in] a_other Other instance (unused; deleted).
    */
   TreeBVH(const TreeBVH& a_other) = delete;
@@ -883,6 +884,21 @@ public:
    */
   [[nodiscard]] inline const std::array<std::shared_ptr<TreeBVH<T, P, BV, K>>, K>&
   getChildren() const noexcept;
+
+  /**
+   * @brief Produce an independent deep copy of this tree.
+   * @details Recursively clones the node hierarchy: the returned tree owns brand-new nodes, so it
+   * can be partitioned or otherwise mutated without affecting this tree (and vice versa). The
+   * copy constructor is deleted precisely because a shallow copy would instead alias these mutable
+   * child nodes; this is the explicit, correct way to replicate a tree. Primitives are *shared*,
+   * not cloned -- each node's std::shared_ptr<const P> entries are copied by handle, matching how a
+   * TreeBVH normally references its (immutable) primitives, e.g. faces shared with a DCEL mesh.
+   * Works in either state: an unpartitioned tree clones to an unpartitioned leaf (build once, then
+   * partition the copies differently), and a partitioned tree clones its full sub-structure.
+   * @return Shared pointer to an independent clone of this tree.
+   */
+  [[nodiscard]] inline std::shared_ptr<TreeBVH<T, P, BV, K>>
+  deepCopy() const;
 
   /**
    * @brief Recursion-free BVH traversal using an explicit LIFO stack (depth-first order).

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <type_traits>
@@ -114,8 +115,11 @@ using PrimitiveList = std::vector<std::shared_ptr<const P>>;
  * (@c StorageType) with the handful of operations PackedBVH needs to build and read it: @c get()
  * (per-element access, used by every leaf-visit callback), @c appendTreeLeaf() (copying a TreeBVH
  * leaf's primitives into PackedBVH's flat array during the identity pack() constructor), and
- * @c appendAliased() (materialising a converting packWith() constructor's single contiguous
- * conversion buffer into PackedBVH's flat array). Swapping the policy changes nothing about tree
+ * @c appendAliased() (appending a converting packWith() constructor's single contiguous
+ * conversion buffer to PackedBVH's flat array). Both @c appendTreeLeaf() and @c appendAliased()
+ * are appenders: they add to whatever @p a_dst already holds rather than replacing it, so every
+ * policy behaves identically no matter how many times PackedBVH calls them. Swapping the policy
+ * changes nothing about tree
  * construction or traversal -- TreeBVH itself always stores primitives as shared_ptr, regardless
  * of which policy the PackedBVH built from it uses -- only what PackedBVH's own primitive array
  * holds.
@@ -224,16 +228,23 @@ struct ValueStorage
   /**
    * @brief Materialise a converting packWith() constructor's single contiguous conversion buffer
    * into PackedBVH's flat primitive array.
-   * @details Cheaper than SharedPtrStorage<P>'s equivalent: no aliasing shared_ptr machinery (and
-   * its control-block allocation) is needed at all -- the already-contiguous buffer is simply
-   * moved into place.
+   * @details Like SharedPtrStorage<P>'s equivalent, this *appends* @p a_block to @p a_dst, so the
+   * two policies honour the same contract regardless of how many times it is called. When @p a_dst
+   * is still empty (the case for PackedBVH's single-call converting constructor) it takes the fast
+   * path of stealing the already-contiguous buffer wholesale -- no aliasing shared_ptr machinery,
+   * no control-block allocation, and no per-element move; otherwise it move-appends each element.
    * @param[in,out] a_dst   PackedBVH's flat primitive array.
    * @param[in]     a_block Single contiguous buffer holding every converted primitive.
    */
   static void
   appendAliased(std::vector<StorageType>& a_dst, const std::shared_ptr<std::vector<P>>& a_block)
   {
-    a_dst = std::move(*a_block);
+    if (a_dst.empty()) {
+      a_dst = std::move(*a_block);
+    }
+    else {
+      a_dst.insert(a_dst.end(), std::make_move_iterator(a_block->begin()), std::make_move_iterator(a_block->end()));
+    }
   }
 };
 

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -763,6 +763,42 @@ public:
   ~TreeBVH() noexcept;
 
   /**
+   * @brief Deleted copy constructor.
+   * @details A TreeBVH is a recursive structure of shared_ptr-linked children (m_children);
+   * copying it would only alias the same child subtrees rather than cloning them, since no
+   * deep-clone is implemented. topDownSortAndPartition()/bottomUpSortAndPartition() mutate a
+   * node's children in place, so such a "copy" could silently share mutable state with the
+   * original instead of being independent. Disallowed outright rather than doing the wrong thing.
+   * @param[in] a_other Other instance (unused; deleted).
+   */
+  TreeBVH(const TreeBVH& a_other) = delete;
+
+  /**
+   * @brief Deleted copy assignment operator.
+   * @details See the copy constructor for why copying is disallowed.
+   * @param[in] a_other Other instance (unused; deleted).
+   * @return Reference to *this (unused; deleted).
+   */
+  TreeBVH&
+  operator=(const TreeBVH& a_other) = delete;
+
+  /**
+   * @brief Move constructor.
+   * @details Explicitly defaulted: the user-declared destructor above would otherwise suppress
+   * the implicitly-generated move constructor.
+   * @param[in,out] a_other Other instance to move from.
+   */
+  TreeBVH(TreeBVH&& a_other) noexcept = default;
+
+  /**
+   * @brief Move assignment operator.
+   * @param[in,out] a_other Other instance to move from.
+   * @return Reference to *this.
+   */
+  TreeBVH&
+  operator=(TreeBVH&& a_other) noexcept = default;
+
+  /**
    * @brief Recursively partition this node top-down.
    * @details The stop criterion and partitioner determine the tree shape.
    * @param[in] a_partitioner Partitioning function. Divides a (primitive, BV) list into K sub-lists.
@@ -1182,9 +1218,48 @@ public:
   inline PackedBVH(const TreeBVH<T, Q, BV, K>& a_tree, Converter&& a_converter);
 
   /**
-   * @brief Virtual destructor.
+   * @brief Destructor.
+   * @details Not virtual: PackedBVH is not intended to be subclassed or used polymorphically.
    */
-  inline virtual ~PackedBVH() = default;
+  inline ~PackedBVH() = default;
+
+  /**
+   * @brief Copy constructor.
+   * @details Explicitly defaulted for documentation purposes: unlike TreeBVH, PackedBVH's
+   * members (m_linearNodes, m_primitives, m_childAabbSoA) are all owned value containers with no
+   * shared mutable substructure, so the implicitly-generated deep copy is correct and safe under
+   * both BVH::SharedPtrStorage (primitives are aliased shared_ptr, the same sharing model as
+   * TreeBVH) and BVH::ValueStorage (primitives are copied by value -- safe as long as the
+   * primitive type's own copy constructor is complete; see DCEL::FaceT's copy-constructor
+   * documentation for a case where it deliberately is not, which is why MeshSDF never uses
+   * BVH::ValueStorage).
+   * @param[in] a_other Other instance to copy.
+   */
+  PackedBVH(const PackedBVH& a_other) = default;
+
+  /**
+   * @brief Copy assignment operator.
+   * @param[in] a_other Other instance to copy.
+   * @return Reference to *this.
+   */
+  PackedBVH&
+  operator=(const PackedBVH& a_other) = default;
+
+  /**
+   * @brief Move constructor.
+   * @details Explicitly defaulted: the user-declared destructor above would otherwise suppress
+   * the implicitly-generated move constructor.
+   * @param[in,out] a_other Other instance to move from.
+   */
+  PackedBVH(PackedBVH&& a_other) noexcept = default;
+
+  /**
+   * @brief Move assignment operator.
+   * @param[in,out] a_other Other instance to move from.
+   * @return Reference to *this.
+   */
+  PackedBVH&
+  operator=(PackedBVH&& a_other) noexcept = default;
 
   /**
    * @brief Get the global primitive list (in leaf-traversal order).

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -101,18 +101,150 @@ template <class T, class P, class BV, size_t K>
 class TreeBVH;
 
 /**
- * @brief Forward declaration of the linearised BVH. Needed so that TreeBVH::pack() and
- * TreeBVH::packWith() can name their return types before PackedBVH is fully defined.
- */
-template <class T, class P, size_t K>
-class PackedBVH;
-
-/**
  * @brief Convenience alias for a list of shared primitive pointers.
  * @tparam P Primitive type bounded by the BVH.
  */
 template <class P>
 using PrimitiveList = std::vector<std::shared_ptr<const P>>;
+
+/**
+ * @brief Default storage policy for PackedBVH: primitives stored as std::shared_ptr<const P>,
+ * exactly as PackedBVH has always stored them.
+ * @details A storage policy is a stateless struct bundling an associated storage representation
+ * (@c StorageType) with the handful of operations PackedBVH needs to build and read it: @c get()
+ * (per-element access, used by every leaf-visit callback), @c appendTreeLeaf() (copying a TreeBVH
+ * leaf's primitives into PackedBVH's flat array during the identity pack() constructor), and
+ * @c appendAliased() (materialising a converting packWith() constructor's single contiguous
+ * conversion buffer into PackedBVH's flat array). Swapping the policy changes nothing about tree
+ * construction or traversal -- TreeBVH itself always stores primitives as shared_ptr, regardless
+ * of which policy the PackedBVH built from it uses -- only what PackedBVH's own primitive array
+ * holds.
+ * @tparam P Primitive type.
+ */
+template <class P>
+struct SharedPtrStorage
+{
+  /**
+   * @brief Storage representation: a shared pointer to a const primitive, as PackedBVH has
+   * always stored it.
+   */
+  using StorageType = std::shared_ptr<const P>;
+
+  /**
+   * @brief Dereference stored element to the primitive it refers to.
+   * @param[in] a_stored Stored element.
+   * @return Reference to the underlying primitive.
+   */
+  [[nodiscard]] static const P&
+  get(const StorageType& a_stored) noexcept
+  {
+    return *a_stored;
+  }
+
+  /**
+   * @brief Append one TreeBVH leaf's primitives to PackedBVH's flat primitive array.
+   * @details Used by PackedBVH's identity pack() constructor. Trivial for this policy: the source
+   * leaf's shared_ptrs are copied in as-is.
+   * @param[in,out] a_dst       PackedBVH's flat primitive array.
+   * @param[in]     a_leafPrims One TreeBVH leaf's primitive list.
+   */
+  static void
+  appendTreeLeaf(std::vector<StorageType>& a_dst, const PrimitiveList<P>& a_leafPrims)
+  {
+    a_dst.insert(a_dst.end(), a_leafPrims.begin(), a_leafPrims.end());
+  }
+
+  /**
+   * @brief Materialise a converting packWith() constructor's single contiguous conversion buffer
+   * into PackedBVH's flat primitive array.
+   * @details Uses the shared_ptr aliasing constructor so every element shares one control block
+   * (one allocation for the whole buffer) while still presenting as an independent
+   * shared_ptr<const P> per element.
+   * @param[in,out] a_dst   PackedBVH's flat primitive array.
+   * @param[in]     a_block Single contiguous buffer holding every converted primitive.
+   */
+  static void
+  appendAliased(std::vector<StorageType>& a_dst, const std::shared_ptr<std::vector<P>>& a_block)
+  {
+    a_dst.reserve(a_dst.size() + a_block->size());
+
+    for (size_t i = 0; i < a_block->size(); i++) {
+      a_dst.emplace_back(a_block, &(*a_block)[i]);
+    }
+  }
+};
+
+/**
+ * @brief Storage policy that stores primitives directly by value, with no pointer indirection at
+ * all.
+ * @details Removes the per-primitive heap allocation and pointer-chasing that
+ * SharedPtrStorage<P> pays on every leaf visit -- worthwhile when P is a self-contained value type
+ * (no shared ownership needed) and leaves are visited often, e.g. a nearest-neighbor search over a
+ * point cloud.
+ * @tparam P Primitive type.
+ */
+template <class P>
+struct ValueStorage
+{
+  /**
+   * @brief Storage representation: the primitive itself, stored by value.
+   */
+  using StorageType = P;
+
+  /**
+   * @brief Identity access -- the stored element already is the primitive.
+   * @param[in] a_stored Stored element.
+   * @return Reference to the primitive.
+   */
+  [[nodiscard]] static const P&
+  get(const StorageType& a_stored) noexcept
+  {
+    return a_stored;
+  }
+
+  /**
+   * @brief Append one TreeBVH leaf's primitives to PackedBVH's flat primitive array.
+   * @details Used by PackedBVH's identity pack() constructor. TreeBVH's own leaf primitives are
+   * always shared_ptr<const P> (TreeBVH itself is unaffected by the packed BVH's storage policy),
+   * so this policy dereferences and copies each one by value; unavoidable here, since the source
+   * is shared_ptr-based regardless of the destination policy.
+   * @param[in,out] a_dst       PackedBVH's flat primitive array.
+   * @param[in]     a_leafPrims One TreeBVH leaf's primitive list.
+   */
+  static void
+  appendTreeLeaf(std::vector<StorageType>& a_dst, const PrimitiveList<P>& a_leafPrims)
+  {
+    a_dst.reserve(a_dst.size() + a_leafPrims.size());
+
+    for (const auto& p : a_leafPrims) {
+      a_dst.push_back(*p);
+    }
+  }
+
+  /**
+   * @brief Materialise a converting packWith() constructor's single contiguous conversion buffer
+   * into PackedBVH's flat primitive array.
+   * @details Cheaper than SharedPtrStorage<P>'s equivalent: no aliasing shared_ptr machinery (and
+   * its control-block allocation) is needed at all -- the already-contiguous buffer is simply
+   * moved into place.
+   * @param[in,out] a_dst   PackedBVH's flat primitive array.
+   * @param[in]     a_block Single contiguous buffer holding every converted primitive.
+   */
+  static void
+  appendAliased(std::vector<StorageType>& a_dst, const std::shared_ptr<std::vector<P>>& a_block)
+  {
+    a_dst = std::move(*a_block);
+  }
+};
+
+/**
+ * @brief Forward declaration of the linearised BVH. Needed so that TreeBVH::pack() and
+ * TreeBVH::packWith() can name their return types before PackedBVH is fully defined.
+ * @details StoragePolicy defaults to SharedPtrStorage<P>, preserving today's exact behaviour for
+ * every existing 3-argument PackedBVH<T, P, K> instantiation.
+ */
+template <class T, class P, size_t K, class StoragePolicy = SharedPtrStorage<P>>
+class PackedBVH;
 
 /**
  * @brief Convenience alias for a (primitive, bounding-volume) pair.
@@ -165,14 +297,19 @@ using LeafEvaluator = std::function<void(const PrimitiveList<P>& a_primitives)>;
 /**
  * @brief Leaf-evaluation callback for PackedBVH::traverse.
  * @details Receives a view into the global primitive array (offset + count) rather than a
- * temporary sub-list, avoiding a heap allocation per leaf visit.
- * @tparam P Primitive type.
- * @param[in] a_primitives Global primitive list.
+ * temporary sub-list, avoiding a heap allocation per leaf visit. The primitive array's element
+ * type depends on the PackedBVH's storage policy (StorageType), not necessarily
+ * std::shared_ptr<const P> -- see SharedPtrStorage/ValueStorage.
+ * @tparam P             Primitive type.
+ * @tparam StoragePolicy PackedBVH storage policy (default: SharedPtrStorage<P>, matching every
+ * PackedBVH<T, P, K> that does not name a storage policy explicitly).
+ * @param[in] a_primitives Global primitive array (element type StoragePolicy::StorageType).
  * @param[in] a_offset     Index of the first primitive belonging to this leaf.
  * @param[in] a_count      Number of primitives in this leaf.
  */
-template <class P>
-using PackedLeafEvaluator = std::function<void(const PrimitiveList<P>& a_primitives, size_t a_offset, size_t a_count)>;
+template <class P, class StoragePolicy = SharedPtrStorage<P>>
+using PackedLeafEvaluator = std::function<void(
+  const std::vector<typename StoragePolicy::StorageType>& a_primitives, size_t a_offset, size_t a_count)>;
 
 /**
  * @brief Node-visit predicate for BVH traversal.
@@ -740,9 +877,12 @@ public:
   /**
    * @brief Flatten this tree into a cache-friendly PackedBVH with the same primitive type.
    * @details Requires BV == AABBT<T>; enforced by static_assert at instantiation.
+   * @tparam StoragePolicy Storage policy for the resulting PackedBVH's primitive array (default:
+   * BVH::SharedPtrStorage<P>, matching every existing caller that does not name one explicitly).
    * @return Shared pointer to the resulting PackedBVH.
    */
-  [[nodiscard]] inline std::shared_ptr<PackedBVH<T, P, K>>
+  template <class StoragePolicy = BVH::SharedPtrStorage<P>>
+  [[nodiscard]] inline std::shared_ptr<PackedBVH<T, P, K, StoragePolicy>>
   pack() const;
 
   /**
@@ -750,15 +890,17 @@ public:
    * @details a_converter is called once per leaf:
    * a_converter(leafPrims, 0, count) → std::vector<Q>
    * All returned values are accumulated into a single contiguous buffer, then exposed
-   * through aliased shared_ptrs to preserve cache locality.
+   * through the resulting PackedBVH's storage policy (StorageType) to preserve cache locality.
    * Requires BV == AABBT<T>; enforced by static_assert at instantiation.
-   * @tparam Q         Destination primitive type.
-   * @tparam Converter Callable: (PrimitiveList<P>, uint32_t offset, uint32_t count) → std::vector<Q>.
+   * @tparam Q             Destination primitive type.
+   * @tparam Converter     Callable: (PrimitiveList<P>, uint32_t offset, uint32_t count) → std::vector<Q>.
+   * @tparam StoragePolicy Storage policy for the resulting PackedBVH's primitive array (default:
+   * BVH::SharedPtrStorage<Q>, matching every existing caller that does not name one explicitly).
    * @param[in] a_converter Leaf-conversion function.
-   * @return Shared pointer to the resulting PackedBVH<T, Q, K>.
+   * @return Shared pointer to the resulting PackedBVH<T, Q, K, StoragePolicy>.
    */
-  template <class Q, class Converter>
-  [[nodiscard]] inline std::shared_ptr<PackedBVH<T, Q, K>>
+  template <class Q, class Converter, class StoragePolicy = BVH::SharedPtrStorage<Q>>
+  [[nodiscard]] inline std::shared_ptr<PackedBVH<T, Q, K, StoragePolicy>>
   packWith(Converter&& a_converter) const;
 
 protected:
@@ -831,11 +973,17 @@ protected:
  * - K==8, T==double → AVX    (two __m256d passes)
  * All other combinations fall back to scalar traversal.
  *
- * @tparam T Floating-point precision.
- * @tparam P Primitive type.
- * @tparam K BVH branching factor.
+ * What StoragePolicy governs: purely the representation of PackedBVH's own primitive array
+ * (StorageType -- std::shared_ptr<const P> by default, or a raw P with ValueStorage<P>). It has
+ * no effect on TreeBVH (always shared_ptr-based) or on tree construction/traversal -- see
+ * SharedPtrStorage/ValueStorage above for the exact operations a storage policy provides.
+ *
+ * @tparam T             Floating-point precision.
+ * @tparam P             Primitive type.
+ * @tparam K             BVH branching factor.
+ * @tparam StoragePolicy Governs how the primitive array is stored (default: SharedPtrStorage<P>).
  */
-template <class T, class P, size_t K>
+template <class T, class P, size_t K, class StoragePolicy>
 class PackedBVH
 {
   static_assert(std::is_floating_point_v<T>, "PackedBVH: T must be a floating-point type");
@@ -846,6 +994,13 @@ public:
    * @brief AABB type used for all bounding volumes in this BVH.
    */
   using BV = EBGeometry::BoundingVolumes::AABBT<T>;
+
+  /**
+   * @brief Storage representation of one entry in the primitive array, as determined by
+   * StoragePolicy (std::shared_ptr<const P> for the default SharedPtrStorage<P>, or P itself for
+   * ValueStorage<P>).
+   */
+  using StorageType = typename StoragePolicy::StorageType;
 
   /**
    * @brief Compact BVH node stored in the flat node array.
@@ -1010,8 +1165,10 @@ public:
    *
    * where @p leafPrims is the leaf's @c PrimitiveList<Q>, @p offset is the index of
    * the first primitive in the global list, and @p count is the number of primitives in
-   * the leaf.  All returned vectors are stored contiguously; the resulting PackedBVH holds
-   * aliased @c shared_ptr into that buffer so no extra copies are made during traversal.
+   * the leaf.  All returned vectors are stored contiguously in one buffer, which this
+   * PackedBVH's storage policy then materialises into its own primitive array -- via aliased
+   * @c shared_ptr (no extra copies) for the default SharedPtrStorage<P>, or by taking ownership
+   * of the buffer directly for ValueStorage<P>.
    *
    * The source tree must have been built with BV == AABBT<T>; bounding volumes are reused
    * without conversion.
@@ -1033,7 +1190,7 @@ public:
    * @brief Get the global primitive list (in leaf-traversal order).
    * @return Reference to m_primitives.
    */
-  [[nodiscard]] inline const std::vector<std::shared_ptr<const P>>&
+  [[nodiscard]] inline const std::vector<StorageType>&
   getPrimitives() const noexcept;
 
   /**
@@ -1093,10 +1250,10 @@ public:
    */
   template <class NodeKey>
   inline void
-  traverse(const BVH::PackedLeafEvaluator<P>&         a_leafEvaluator,
-           const BVH::PrunePredicate<Node, NodeKey>&  a_prunePredicate,
-           const BVH::PackedChildOrderer<NodeKey, K>& a_childOrderer,
-           const BVH::NodeKeyFactory<Node, NodeKey>&  a_nodeKeyFactory) const noexcept;
+  traverse(const BVH::PackedLeafEvaluator<P, StoragePolicy>& a_leafEvaluator,
+           const BVH::PrunePredicate<Node, NodeKey>&         a_prunePredicate,
+           const BVH::PackedChildOrderer<NodeKey, K>&        a_childOrderer,
+           const BVH::NodeKeyFactory<Node, NodeKey>&         a_nodeKeyFactory) const noexcept;
 
   /**
    * @brief Generic SIMD-accelerated, distance-pruned traversal.
@@ -1150,7 +1307,7 @@ protected:
   /**
    * @brief Global primitive list in leaf-traversal order.
    */
-  std::vector<std::shared_ptr<const P>> m_primitives;
+  std::vector<StorageType> m_primitives;
 
   /**
    * @brief SoA layout of K children's AABBs for a single interior node.

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -351,27 +351,28 @@ TreeBVH<T, P, BV, K>::traverse(const BVH::LeafEvaluator<P>&               a_leaf
 }
 
 template <class T, class P, class BV, size_t K>
-inline std::shared_ptr<PackedBVH<T, P, K>>
+template <class StoragePolicy>
+inline std::shared_ptr<PackedBVH<T, P, K, StoragePolicy>>
 TreeBVH<T, P, BV, K>::pack() const
 {
   static_assert(std::is_same_v<BV, EBGeometry::BoundingVolumes::AABBT<T>>, "TreeBVH::pack requires BV == AABBT<T>");
 
-  return std::make_shared<PackedBVH<T, P, K>>(*this);
+  return std::make_shared<PackedBVH<T, P, K, StoragePolicy>>(*this);
 }
 
 template <class T, class P, class BV, size_t K>
-template <class Q, class Converter>
-inline std::shared_ptr<PackedBVH<T, Q, K>>
+template <class Q, class Converter, class StoragePolicy>
+inline std::shared_ptr<PackedBVH<T, Q, K, StoragePolicy>>
 TreeBVH<T, P, BV, K>::packWith(Converter&& a_converter) const
 {
   static_assert(std::is_same_v<BV, EBGeometry::BoundingVolumes::AABBT<T>>, "TreeBVH::packWith requires BV == AABBT<T>");
 
-  return std::make_shared<PackedBVH<T, Q, K>>(*this, std::forward<Converter>(a_converter));
+  return std::make_shared<PackedBVH<T, Q, K, StoragePolicy>>(*this, std::forward<Converter>(a_converter));
 }
 
-template <class T, class P, size_t K>
+template <class T, class P, size_t K, class StoragePolicy>
 inline void
-PackedBVH<T, P, K>::buildSoA()
+PackedBVH<T, P, K, StoragePolicy>::buildSoA()
 {
   m_childAabbSoA.resize(m_linearNodes.size());
 
@@ -399,8 +400,9 @@ PackedBVH<T, P, K>::buildSoA()
   }
 }
 
-template <class T, class P, size_t K>
-inline PackedBVH<T, P, K>::PackedBVH(const TreeBVH<T, P, EBGeometry::BoundingVolumes::AABBT<T>, K>& a_tree)
+template <class T, class P, size_t K, class StoragePolicy>
+inline PackedBVH<T, P, K, StoragePolicy>::PackedBVH(
+  const TreeBVH<T, P, EBGeometry::BoundingVolumes::AABBT<T>, K>& a_tree)
 {
   using AABBType = EBGeometry::BoundingVolumes::AABBT<T>;
 
@@ -421,7 +423,7 @@ inline PackedBVH<T, P, K>::PackedBVH(const TreeBVH<T, P, EBGeometry::BoundingVol
       m_linearNodes[idx].m_primOff  = static_cast<uint32_t>(m_primitives.size());
       m_linearNodes[idx].m_numPrims = static_cast<uint32_t>(prims.size());
 
-      m_primitives.insert(m_primitives.end(), prims.begin(), prims.end());
+      StoragePolicy::appendTreeLeaf(m_primitives, prims);
     }
     else {
       m_linearNodes[idx].m_numPrims = 0U;
@@ -440,15 +442,16 @@ inline PackedBVH<T, P, K>::PackedBVH(const TreeBVH<T, P, EBGeometry::BoundingVol
   buildSoA();
 }
 
-template <class T, class P, size_t K>
+template <class T, class P, size_t K, class StoragePolicy>
 template <class Q, class Converter>
-inline PackedBVH<T, P, K>::PackedBVH(const TreeBVH<T, Q, EBGeometry::BoundingVolumes::AABBT<T>, K>& a_tree,
-                                     Converter&&                                                    a_converter)
+inline PackedBVH<T, P, K, StoragePolicy>::PackedBVH(
+  const TreeBVH<T, Q, EBGeometry::BoundingVolumes::AABBT<T>, K>& a_tree, Converter&& a_converter)
 {
   using AABBType = EBGeometry::BoundingVolumes::AABBT<T>;
 
-  // Accumulate converted P-values into a single contiguous buffer; aliased
-  // shared_ptrs are created after all push_backs so no dangling pointers.
+  // Accumulate converted P-values into a single contiguous buffer; StoragePolicy::appendAliased
+  // materialises it into m_primitives once every push_back below has completed (aliased
+  // shared_ptrs, for the default SharedPtrStorage<P>, so no dangling pointers).
   auto dstStorage = std::make_shared<std::vector<P>>();
 
   std::function<uint32_t(const TreeBVH<T, Q, AABBType, K>&)> dfs =
@@ -487,43 +490,39 @@ inline PackedBVH<T, P, K>::PackedBVH(const TreeBVH<T, Q, EBGeometry::BoundingVol
 
   dfs(a_tree);
 
-  m_primitives.reserve(dstStorage->size());
-
-  for (size_t i = 0; i < dstStorage->size(); i++) {
-    m_primitives.emplace_back(dstStorage, &(*dstStorage)[i]);
-  }
+  StoragePolicy::appendAliased(m_primitives, dstStorage);
 
   this->buildSoA();
 }
 
-template <class T, class P, size_t K>
-inline const std::vector<std::shared_ptr<const P>>&
-PackedBVH<T, P, K>::getPrimitives() const noexcept
+template <class T, class P, size_t K, class StoragePolicy>
+inline const std::vector<typename PackedBVH<T, P, K, StoragePolicy>::StorageType>&
+PackedBVH<T, P, K, StoragePolicy>::getPrimitives() const noexcept
 {
   return m_primitives;
 }
 
-template <class T, class P, size_t K>
+template <class T, class P, size_t K, class StoragePolicy>
 inline const EBGeometry::BoundingVolumes::AABBT<T>&
-PackedBVH<T, P, K>::getBoundingVolume() const noexcept
+PackedBVH<T, P, K, StoragePolicy>::getBoundingVolume() const noexcept
 {
   return m_linearNodes.front().getBoundingVolume();
 }
 
-template <class T, class P, size_t K>
+template <class T, class P, size_t K, class StoragePolicy>
 inline EBGeometry::BoundingVolumes::AABBT<T>
-PackedBVH<T, P, K>::computeBoundingVolume() const noexcept
+PackedBVH<T, P, K, StoragePolicy>::computeBoundingVolume() const noexcept
 {
   return m_linearNodes.front().getBoundingVolume();
 }
 
-template <class T, class P, size_t K>
+template <class T, class P, size_t K, class StoragePolicy>
 template <class NodeKey>
 inline void
-PackedBVH<T, P, K>::traverse(const BVH::PackedLeafEvaluator<P>&         a_leafEvaluator,
-                             const BVH::PrunePredicate<Node, NodeKey>&  a_prunePredicate,
-                             const BVH::PackedChildOrderer<NodeKey, K>& a_childOrderer,
-                             const BVH::NodeKeyFactory<Node, NodeKey>&  a_nodeKeyFactory) const noexcept
+PackedBVH<T, P, K, StoragePolicy>::traverse(const BVH::PackedLeafEvaluator<P, StoragePolicy>& a_leafEvaluator,
+                                            const BVH::PrunePredicate<Node, NodeKey>&         a_prunePredicate,
+                                            const BVH::PackedChildOrderer<NodeKey, K>&        a_childOrderer,
+                                            const BVH::NodeKeyFactory<Node, NodeKey>& a_nodeKeyFactory) const noexcept
 {
   std::array<std::pair<uint32_t, NodeKey>, K> children;
 
@@ -561,13 +560,13 @@ PackedBVH<T, P, K>::traverse(const BVH::PackedLeafEvaluator<P>&         a_leafEv
   }
 }
 
-template <class T, class P, size_t K>
+template <class T, class P, size_t K, class StoragePolicy>
 template <class State, class LeafEvaluator, class PruneDistSquared>
 inline void
-PackedBVH<T, P, K>::pruneTraverse(const Vec3T<T>&    a_point,
-                                  State&             a_state,
-                                  LeafEvaluator&&    a_evalLeaf,
-                                  PruneDistSquared&& a_pruneDist2) const noexcept
+PackedBVH<T, P, K, StoragePolicy>::pruneTraverse(const Vec3T<T>&    a_point,
+                                                 State&             a_state,
+                                                 LeafEvaluator&&    a_evalLeaf,
+                                                 PruneDistSquared&& a_pruneDist2) const noexcept
 {
   struct StackEntry
   {
@@ -1045,10 +1044,10 @@ PackedBVH<T, P, K>::pruneTraverse(const Vec3T<T>&    a_point,
 #endif
 
   // Scalar fallback for all other (T, K) combinations.
-  const BVH::PackedLeafEvaluator<P> leafEvaluator =
-    [&a_state, &a_evalLeaf](const std::vector<std::shared_ptr<const P>>&,
-                            size_t offset,
-                            size_t count) noexcept -> void { a_evalLeaf(a_state, offset, count); };
+  const BVH::PackedLeafEvaluator<P, StoragePolicy> leafEvaluator =
+    [&a_state, &a_evalLeaf](const std::vector<StorageType>&, size_t offset, size_t count) noexcept -> void {
+    a_evalLeaf(a_state, offset, count);
+  };
 
   const BVH::PrunePredicate<Node, T> prunePredicate = [&a_state, &a_pruneDist2](const Node& /*n*/,
                                                                                 const T& d) noexcept -> bool {

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -119,6 +119,31 @@ TreeBVH<T, P, BV, K>::getChildren() const noexcept
 }
 
 template <class T, class P, class BV, size_t K>
+inline std::shared_ptr<TreeBVH<T, P, BV, K>>
+TreeBVH<T, P, BV, K>::deepCopy() const
+{
+  auto copy = std::make_shared<TreeBVH<T, P, BV, K>>();
+
+  // Copy this node's own state. m_primitives holds shared_ptr<const P>, copied by handle: the
+  // primitives are immutable and intentionally shared (e.g. with a DCEL mesh), so they are not
+  // cloned -- only the node hierarchy is.
+  copy->m_boundingVolume  = m_boundingVolume;
+  copy->m_primitives      = m_primitives;
+  copy->m_boundingVolumes = m_boundingVolumes;
+  copy->m_partitioned     = m_partitioned;
+
+  // Recursively clone children so the returned tree owns independent nodes rather than aliasing
+  // this tree's mutable sub-structure.
+  for (size_t k = 0; k < K; k++) {
+    if (m_children[k] != nullptr) {
+      copy->m_children[k] = m_children[k]->deepCopy();
+    }
+  }
+
+  return copy;
+}
+
+template <class T, class P, class BV, size_t K>
 inline void
 TreeBVH<T, P, BV, K>::topDownSortAndPartition(const Partitioner& a_partitioner, const LeafPredicate& a_stopCrit)
 {

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -137,8 +137,8 @@ protected:
  * default -- DCEL::FaceT's copy constructor deliberately does not copy its cached 2D polygon
  * embedding (m_poly2, used by signedDistance()'s point-in-face test), so a naive by-value copy
  * (as BVH::ValueStorage would produce) is left with a null embedding and crashes on first query;
- * see FaceT's copy-constructor documentation. See :ref:`Chap:MeshSDFClasses` in the Sphinx docs
- * for the full rationale, including why TriMeshSDF's SoA groups do not have this restriction.
+ * see FaceT's copy-constructor documentation. See the user documentation for the full rationale,
+ * including why TriMeshSDF's SoA groups do not have this restriction.
  * @tparam T    Floating-point precision type (float or double).
  * @tparam Meta Triangle metadata type stored on each DCEL face.
  * @tparam K    BVH branching factor (number of children per internal node).
@@ -298,8 +298,7 @@ protected:
  * no aliasing benefit to give up. Note that instancing the same mesh multiple times (e.g. via
  * Translate/Rotate/Scale or a CSG union) is unaffected either way: those wrappers hold a
  * shared_ptr to the whole TriMeshSDF, so its packed data -- however StoragePolicy stores it -- is
- * never duplicated per placement. See :ref:`Chap:MeshSDFClasses` in the Sphinx docs for the full
- * rationale.
+ * never duplicated per placement. See the user documentation for the full rationale.
  */
 template <class T,
           class Meta,

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -99,7 +99,14 @@ protected:
  * @brief Signed distance function for a DCEL mesh. Stores the mesh in a PackedBVH for
  * SIMD-accelerated traversal. Accepts any polygon, not just triangles.
  * @details The mesh faces are packed into a flat-array PackedBVH. SIMD traversal
- * is used when T and K match an available ISA path.
+ * is used when T and K match an available ISA path. Unlike TriMeshSDF, MeshSDF does not expose a
+ * PackedBVH StoragePolicy choice: its PackedBVH always uses BVH::SharedPtrStorage<Face>, sharing
+ * each packed face with the DCEL mesh's own face list rather than copying it. This is not just a
+ * default -- DCEL::FaceT's copy constructor deliberately does not copy its cached 2D polygon
+ * embedding (m_poly2, used by signedDistance()'s point-in-face test), so a naive by-value copy
+ * (as BVH::ValueStorage would produce) is left with a null embedding and crashes on first query;
+ * see FaceT's copy-constructor documentation. See :ref:`Chap:MeshSDFClasses` in the Sphinx docs
+ * for the full rationale, including why TriMeshSDF's SoA groups do not have this restriction.
  * @tparam T    Floating-point precision type (float or double).
  * @tparam Meta Triangle metadata type stored on each DCEL face.
  * @tparam K    BVH branching factor (number of children per internal node).
@@ -220,8 +227,21 @@ protected:
  * @tparam Meta Triangle metadata type.
  * @tparam K    BVH branching factor (number of children per internal node). Must be >= 2.
  * @tparam W    SoA width: number of triangles per SIMD group. Must be > 0.
+ * @tparam StoragePolicy PackedBVH primitive storage policy (see BVH::SharedPtrStorage /
+ * BVH::ValueStorage). Defaults to BVH::ValueStorage<TriangleSoAT<T, W>>, storing each SoA group
+ * inline with no pointer indirection -- unlike MeshSDF's faces, these groups are freshly
+ * constructed by groupTrianglesIntoSoA() during packing and shared with nothing else, so there is
+ * no aliasing benefit to give up. Note that instancing the same mesh multiple times (e.g. via
+ * Translate/Rotate/Scale or a CSG union) is unaffected either way: those wrappers hold a
+ * shared_ptr to the whole TriMeshSDF, so its packed data -- however StoragePolicy stores it -- is
+ * never duplicated per placement. See :ref:`Chap:MeshSDFClasses` in the Sphinx docs for the full
+ * rationale.
  */
-template <class T, class Meta, size_t K, size_t W>
+template <class T,
+          class Meta,
+          size_t K,
+          size_t W,
+          class StoragePolicy = BVH::ValueStorage<EBGeometry::TriangleSoAT<T, W>>>
 class TriMeshSDF : public SignedDistanceFunction<T>
 {
   static_assert(std::is_floating_point_v<T>, "TriMeshSDF<T,Meta,K,W> requires a floating-point T");
@@ -247,7 +267,7 @@ public:
   /**
    * @brief Alias for which BVH root node
    */
-  using Root = typename EBGeometry::BVH::PackedBVH<T, TriSoA, K>;
+  using Root = typename EBGeometry::BVH::PackedBVH<T, TriSoA, K, StoragePolicy>;
 
   /**
    * @brief Default disallowed constructor

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -65,6 +65,38 @@ public:
   ~FlatMeshSDF() override = default;
 
   /**
+   * @brief Copy constructor.
+   * @details Explicitly defaulted for documentation purposes: FlatMeshSDF's only member (m_mesh)
+   * is a shared_ptr, so the implicitly-generated copy is a cheap, correct handle-copy.
+   * @param[in] a_other Other instance to copy.
+   */
+  FlatMeshSDF(const FlatMeshSDF& a_other) = default;
+
+  /**
+   * @brief Copy assignment operator.
+   * @param[in] a_other Other instance to copy.
+   * @return Reference to *this.
+   */
+  FlatMeshSDF&
+  operator=(const FlatMeshSDF& a_other) = default;
+
+  /**
+   * @brief Move constructor.
+   * @details Explicitly defaulted: the user-declared destructor above would otherwise suppress
+   * the implicitly-generated move constructor.
+   * @param[in,out] a_other Other instance to move from.
+   */
+  FlatMeshSDF(FlatMeshSDF&& a_other) noexcept = default;
+
+  /**
+   * @brief Move assignment operator.
+   * @param[in,out] a_other Other instance to move from.
+   * @return Reference to *this.
+   */
+  FlatMeshSDF&
+  operator=(FlatMeshSDF&& a_other) noexcept = default;
+
+  /**
    * @brief Compute the signed distance from a_point to the mesh.
    * @param[in] a_point Query point.
    * @return Signed distance to the nearest face; negative inside the mesh.
@@ -157,6 +189,38 @@ public:
    * @brief Destructor
    */
   ~MeshSDF() override = default;
+
+  /**
+   * @brief Copy constructor.
+   * @details Explicitly defaulted for documentation purposes: MeshSDF's members (m_bvh, m_mesh)
+   * are both shared_ptr, so the implicitly-generated copy is a cheap, correct handle-copy.
+   * @param[in] a_other Other instance to copy.
+   */
+  MeshSDF(const MeshSDF& a_other) = default;
+
+  /**
+   * @brief Copy assignment operator.
+   * @param[in] a_other Other instance to copy.
+   * @return Reference to *this.
+   */
+  MeshSDF&
+  operator=(const MeshSDF& a_other) = default;
+
+  /**
+   * @brief Move constructor.
+   * @details Explicitly defaulted: the user-declared destructor above would otherwise suppress
+   * the implicitly-generated move constructor.
+   * @param[in,out] a_other Other instance to move from.
+   */
+  MeshSDF(MeshSDF&& a_other) noexcept = default;
+
+  /**
+   * @brief Move assignment operator.
+   * @param[in,out] a_other Other instance to move from.
+   * @return Reference to *this.
+   */
+  MeshSDF&
+  operator=(MeshSDF&& a_other) noexcept = default;
 
   /**
    * @brief Compute the signed distance from a_point to the mesh.
@@ -309,6 +373,38 @@ public:
    * @brief Destructor
    */
   ~TriMeshSDF() override = default;
+
+  /**
+   * @brief Copy constructor.
+   * @details Explicitly defaulted for documentation purposes: TriMeshSDF's only member (m_bvh)
+   * is a shared_ptr, so the implicitly-generated copy is a cheap, correct handle-copy.
+   * @param[in] a_other Other instance to copy.
+   */
+  TriMeshSDF(const TriMeshSDF& a_other) = default;
+
+  /**
+   * @brief Copy assignment operator.
+   * @param[in] a_other Other instance to copy.
+   * @return Reference to *this.
+   */
+  TriMeshSDF&
+  operator=(const TriMeshSDF& a_other) = default;
+
+  /**
+   * @brief Move constructor.
+   * @details Explicitly defaulted: the user-declared destructor above would otherwise suppress
+   * the implicitly-generated move constructor.
+   * @param[in,out] a_other Other instance to move from.
+   */
+  TriMeshSDF(TriMeshSDF&& a_other) noexcept = default;
+
+  /**
+   * @brief Move assignment operator.
+   * @param[in,out] a_other Other instance to move from.
+   * @return Reference to *this.
+   */
+  TriMeshSDF&
+  operator=(TriMeshSDF&& a_other) noexcept = default;
 
   /**
    * @brief Compute the signed distance from a_point to the triangle mesh.

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -383,11 +383,10 @@ MeshSDF<T, Meta, K>::computeBoundingVolume() const noexcept
   return m_bvh->getBoundingVolume();
 };
 
-template <class T, class Meta, size_t K, size_t W>
-std::vector<typename TriMeshSDF<T, Meta, K, W>::TriSoA>
-TriMeshSDF<T, Meta, K, W>::groupTrianglesIntoSoA(const std::vector<std::shared_ptr<const Tri>>& a_triangles,
-                                                 uint32_t                                       a_offset,
-                                                 uint32_t                                       a_count)
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
+std::vector<typename TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriSoA>
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::groupTrianglesIntoSoA(
+  const std::vector<std::shared_ptr<const Tri>>& a_triangles, uint32_t a_offset, uint32_t a_count)
 {
   constexpr uint32_t soaWidth = static_cast<uint32_t>(W);
 
@@ -415,10 +414,10 @@ TriMeshSDF<T, Meta, K, W>::groupTrianglesIntoSoA(const std::vector<std::shared_p
   return groups;
 }
 
-template <class T, class Meta, size_t K, size_t W>
-TriMeshSDF<T, Meta, K, W>::TriMeshSDF(const std::shared_ptr<Mesh>& a_mesh,
-                                      const BVH::Build             a_build,
-                                      const size_t                 a_maxLeafGroups) noexcept
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>& a_mesh,
+                                                     const BVH::Build             a_build,
+                                                     const size_t                 a_maxLeafGroups) noexcept
 {
   EBGEOMETRY_EXPECT(a_mesh != nullptr);
   EBGEOMETRY_EXPECT(a_maxLeafGroups > 0);
@@ -454,14 +453,16 @@ TriMeshSDF<T, Meta, K, W>::TriMeshSDF(const std::shared_ptr<Mesh>& a_mesh,
 
   const size_t maxLeafSize = a_maxLeafGroups * W;
 
+  using Converter = decltype(&TriMeshSDF::groupTrianglesIntoSoA);
+
   m_bvh = EBGeometry::MeshDistanceFunctionsDetail::buildTriTreeBVH<T, Meta, AABB, K>(triangles, a_build, maxLeafSize)
-            ->template packWith<TriSoA>(&TriMeshSDF::groupTrianglesIntoSoA);
+            ->template packWith<TriSoA, Converter, StoragePolicy>(&TriMeshSDF::groupTrianglesIntoSoA);
 }
 
-template <class T, class Meta, size_t K, size_t W>
-TriMeshSDF<T, Meta, K, W>::TriMeshSDF(const std::vector<std::shared_ptr<Tri>>& a_triangles,
-                                      const BVH::Build                         a_build,
-                                      const size_t                             a_maxLeafGroups) noexcept
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::vector<std::shared_ptr<Tri>>& a_triangles,
+                                                     const BVH::Build                         a_build,
+                                                     const size_t                             a_maxLeafGroups) noexcept
 {
   EBGEOMETRY_EXPECT(!a_triangles.empty());
   EBGEOMETRY_EXPECT(a_maxLeafGroups > 0);
@@ -470,13 +471,15 @@ TriMeshSDF<T, Meta, K, W>::TriMeshSDF(const std::vector<std::shared_ptr<Tri>>& a
 
   const size_t maxLeafSize = a_maxLeafGroups * W;
 
+  using Converter = decltype(&TriMeshSDF::groupTrianglesIntoSoA);
+
   m_bvh = EBGeometry::MeshDistanceFunctionsDetail::buildTriTreeBVH<T, Meta, AABB, K>(a_triangles, a_build, maxLeafSize)
-            ->template packWith<TriSoA>(&TriMeshSDF::groupTrianglesIntoSoA);
+            ->template packWith<TriSoA, Converter, StoragePolicy>(&TriMeshSDF::groupTrianglesIntoSoA);
 }
 
-template <class T, class Meta, size_t K, size_t W>
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
 T
-TriMeshSDF<T, Meta, K, W>::signedDistance(const Vec3T<T>& a_point) const noexcept
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::signedDistance(const Vec3T<T>& a_point) const noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
   EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
@@ -488,7 +491,7 @@ TriMeshSDF<T, Meta, K, W>::signedDistance(const Vec3T<T>& a_point) const noexcep
 
   const auto evalLeaf = [&groups, &a_point](T& a_state, size_t a_offset, size_t a_count) noexcept {
     for (size_t i = a_offset; i < a_offset + a_count; i++) {
-      const T d = groups[i]->signedDistance(a_point);
+      const T d = StoragePolicy::get(groups[i]).signedDistance(a_point);
 
       EBGEOMETRY_EXPECT(!std::isnan(d));
 
@@ -505,27 +508,27 @@ TriMeshSDF<T, Meta, K, W>::signedDistance(const Vec3T<T>& a_point) const noexcep
   return minDist;
 }
 
-template <class T, class Meta, size_t K, size_t W>
-std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleSoAT<T, W>, K>>&
-TriMeshSDF<T, Meta, K, W>::getRoot() noexcept
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
+std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleSoAT<T, W>, K, StoragePolicy>>&
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::getRoot() noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
 
   return m_bvh;
 }
 
-template <class T, class Meta, size_t K, size_t W>
-const std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleSoAT<T, W>, K>>&
-TriMeshSDF<T, Meta, K, W>::getRoot() const noexcept
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
+const std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleSoAT<T, W>, K, StoragePolicy>>&
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::getRoot() const noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
 
   return m_bvh;
 }
 
-template <class T, class Meta, size_t K, size_t W>
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
 EBGeometry::BoundingVolumes::AABBT<T>
-TriMeshSDF<T, Meta, K, W>::computeBoundingVolume() const noexcept
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::computeBoundingVolume() const noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
 

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -248,7 +248,7 @@ readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Build a_bu
  * @param[in] a_filename      File name (STL, PLY, or VTK).
  * @param[in] a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf; the
  * actual raw-triangle leaf-size bound used is a_maxLeafGroups * W (see TriMeshSDF's mesh-based
- * constructor for the tree-quality/SIMD-occupancy trade-off). Defaults to 2.
+ * constructor for the tree-quality/SIMD-occupancy trade-off). Defaults to 4.
  * @param[in] a_build         BVH build strategy. SAH is the default and recommended choice.
  * @return Shared pointer to the TriMeshSDF enclosing the mesh.
  */
@@ -272,7 +272,7 @@ readIntoTriangleBVH(const std::string a_filename,
  * single-file overload).
  * @param[in] a_files         List of file names (STL, PLY, or VTK).
  * @param[in] a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf (see
- * the single-file overload for details). Defaults to 2.
+ * the single-file overload for details). Defaults to 4.
  * @param[in] a_build         BVH build strategy. SAH is the default and recommended choice.
  * @return Vector of shared pointers to TriMeshSDF objects, one per file.
  */
@@ -283,7 +283,7 @@ template <typename T,
           class StoragePolicy = BVH::ValueStorage<TriangleSoAT<T, W>>>
 [[nodiscard]] inline static std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>>
 readIntoTriangleBVH(const std::vector<std::string>& a_files,
-                    const size_t                    a_maxLeafGroups = 2,
+                    const size_t                    a_maxLeafGroups = 4,
                     const BVH::Build                a_build         = BVH::Build::SAH);
 
 /**

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -242,6 +242,9 @@ readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Build a_bu
  * on AVX; K=4 otherwise). Override only when benchmarking or using non-SIMD builds.
  * @tparam W    SIMD lane width: triangles per SoA group. Defaults to TriangleSoA::DefaultWidth<T>()
  * (8/float or 4/double on AVX; 4 otherwise).
+ * @tparam StoragePolicy PackedBVH primitive storage policy forwarded to TriMeshSDF (see
+ * BVH::SharedPtrStorage / BVH::ValueStorage). Defaults to
+ * BVH::ValueStorage<TriangleSoAT<T, W>>, matching TriMeshSDF's own default.
  * @param[in] a_filename      File name (STL, PLY, or VTK).
  * @param[in] a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf; the
  * actual raw-triangle leaf-size bound used is a_maxLeafGroups * W (see TriMeshSDF's mesh-based
@@ -250,10 +253,11 @@ readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Build a_bu
  * @return Shared pointer to the TriMeshSDF enclosing the mesh.
  */
 template <typename T,
-          typename Meta = DCEL::DefaultMetaData,
-          size_t K      = BVH::DefaultBranchingRatio<T>(),
-          size_t W      = TriangleSoA::DefaultWidth<T>()>
-[[nodiscard]] inline static std::shared_ptr<TriMeshSDF<T, Meta, K, W>>
+          typename Meta       = DCEL::DefaultMetaData,
+          size_t K            = BVH::DefaultBranchingRatio<T>(),
+          size_t W            = TriangleSoA::DefaultWidth<T>(),
+          class StoragePolicy = BVH::ValueStorage<TriangleSoAT<T, W>>>
+[[nodiscard]] inline static std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>
 readIntoTriangleBVH(const std::string a_filename,
                     const size_t      a_maxLeafGroups = 4,
                     const BVH::Build  a_build         = BVH::Build::SAH);
@@ -264,6 +268,8 @@ readIntoTriangleBVH(const std::string a_filename,
  * @tparam Meta Per-face metadata type.
  * @tparam K    BVH branching factor. Defaults to BVH::DefaultBranchingRatio<T>() (see single-file overload).
  * @tparam W    SIMD lane width: triangles per SoA group. Defaults to TriangleSoA::DefaultWidth<T>().
+ * @tparam StoragePolicy PackedBVH primitive storage policy forwarded to TriMeshSDF (see the
+ * single-file overload).
  * @param[in] a_files         List of file names (STL, PLY, or VTK).
  * @param[in] a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf (see
  * the single-file overload for details). Defaults to 2.
@@ -271,10 +277,11 @@ readIntoTriangleBVH(const std::string a_filename,
  * @return Vector of shared pointers to TriMeshSDF objects, one per file.
  */
 template <typename T,
-          typename Meta = DCEL::DefaultMetaData,
-          size_t K      = BVH::DefaultBranchingRatio<T>(),
-          size_t W      = TriangleSoA::DefaultWidth<T>()>
-[[nodiscard]] inline static std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W>>>
+          typename Meta       = DCEL::DefaultMetaData,
+          size_t K            = BVH::DefaultBranchingRatio<T>(),
+          size_t W            = TriangleSoA::DefaultWidth<T>(),
+          class StoragePolicy = BVH::ValueStorage<TriangleSoAT<T, W>>>
+[[nodiscard]] inline static std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>>
 readIntoTriangleBVH(const std::vector<std::string>& a_files,
                     const size_t                    a_maxLeafGroups = 2,
                     const BVH::Build                a_build         = BVH::Build::SAH);

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -1888,8 +1888,8 @@ Parser::readIntoTriangles(const std::vector<std::string>& a_files)
   return triangles;
 }
 
-template <typename T, typename Meta, size_t K, size_t W>
-[[nodiscard]] inline std::shared_ptr<TriMeshSDF<T, Meta, K, W>>
+template <typename T, typename Meta, size_t K, size_t W, class StoragePolicy>
+[[nodiscard]] inline std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>
 Parser::readIntoTriangleBVH(const std::string a_filename, const size_t a_maxLeafGroups, const BVH::Build a_build)
 {
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoTriangleBVH requires T to be a floating-point type");
@@ -1897,11 +1897,11 @@ Parser::readIntoTriangleBVH(const std::string a_filename, const size_t a_maxLeaf
   static_assert(W > 0, "Parser::readIntoTriangleBVH requires W > 0");
   const auto mesh = EBGeometry::Parser::readIntoTriangles<T, Meta>(a_filename);
 
-  return std::make_shared<TriMeshSDF<T, Meta, K, W>>(mesh, a_build, a_maxLeafGroups);
+  return std::make_shared<TriMeshSDF<T, Meta, K, W, StoragePolicy>>(mesh, a_build, a_maxLeafGroups);
 }
 
-template <typename T, typename Meta, size_t K, size_t W>
-[[nodiscard]] inline std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W>>>
+template <typename T, typename Meta, size_t K, size_t W, class StoragePolicy>
+[[nodiscard]] inline std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>>
 Parser::readIntoTriangleBVH(const std::vector<std::string>& a_files,
                             const size_t                    a_maxLeafGroups,
                             const BVH::Build                a_build)
@@ -1909,11 +1909,12 @@ Parser::readIntoTriangleBVH(const std::vector<std::string>& a_files,
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoTriangleBVH requires T to be a floating-point type");
   static_assert(K > 0, "Parser::readIntoTriangleBVH requires K > 0");
   static_assert(W > 0, "Parser::readIntoTriangleBVH requires W > 0");
-  std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W>>> implicitFunctions;
+  std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>> implicitFunctions;
 
   implicitFunctions.reserve(a_files.size());
   for (const auto& file : a_files) {
-    implicitFunctions.emplace_back(Parser::readIntoTriangleBVH<T, Meta, K, W>(file, a_maxLeafGroups, a_build));
+    implicitFunctions.emplace_back(
+      Parser::readIntoTriangleBVH<T, Meta, K, W, StoragePolicy>(file, a_maxLeafGroups, a_build));
   }
 
   return implicitFunctions;

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -612,6 +612,48 @@ TEMPLATE_TEST_CASE("PackedBVH: BVH::ValueStorage stores primitives inline with n
   static_assert(sizeof(typename BVH::SharedPtrStorage<Pnt>::StorageType) == sizeof(std::shared_ptr<const Pnt>));
 }
 
+TEMPLATE_TEST_CASE("StoragePolicy: appendAliased genuinely appends for both policies (not only on the "
+                   "single-call packWith path)",
+                   "[BVH][StoragePolicy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+  using Pnt  = BareTestPoint<T>;
+
+  // Build a fresh contiguous conversion buffer of three points offset by a_base.
+  const auto makeBlock = [](T a_base) {
+    auto block = std::make_shared<std::vector<Pnt>>();
+    for (int i = 0; i < 3; i++) {
+      block->push_back(Pnt{Vec3(a_base + T(i), a_base, a_base)});
+    }
+    return block;
+  };
+
+  // Two calls: the first into an empty destination (the fast path), the second into a non-empty
+  // one. appendAliased must add to what is already there, not replace it -- the two policies have
+  // to agree on this regardless of call count, or a future second call site would silently lose
+  // the first block under ValueStorage while working under SharedPtrStorage.
+  {
+    std::vector<Pnt> dst;
+    BVH::ValueStorage<Pnt>::appendAliased(dst, makeBlock(T(0)));
+    BVH::ValueStorage<Pnt>::appendAliased(dst, makeBlock(T(10)));
+
+    REQUIRE(dst.size() == 6);
+    REQUIRE(dst[0].m_pos == Vec3(0, 0, 0));
+    REQUIRE(dst[3].m_pos == Vec3(10, 10, 10));
+  }
+  {
+    std::vector<std::shared_ptr<const Pnt>> dst;
+    BVH::SharedPtrStorage<Pnt>::appendAliased(dst, makeBlock(T(0)));
+    BVH::SharedPtrStorage<Pnt>::appendAliased(dst, makeBlock(T(10)));
+
+    REQUIRE(dst.size() == 6);
+    REQUIRE(dst[0]->m_pos == Vec3(0, 0, 0));
+    REQUIRE(dst[3]->m_pos == Vec3(10, 10, 10));
+  }
+}
+
 TEMPLATE_TEST_CASE("TriMeshSDF: default StoragePolicy is BVH::ValueStorage<TriSoA>; MeshSDF has no "
                    "StoragePolicy choice at all",
                    "[BVH][StoragePolicy]",

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -13,6 +13,7 @@
 
 #include <cmath>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <catch2/catch_template_test_macros.hpp>
@@ -898,5 +899,113 @@ TEMPLATE_TEST_CASE("Nested BVH: a BVHUnion over several TriMeshSDF objects nests
     }
 
     REQUIRE_THAT(nestedUnion->value(p), withinAbsT(bruteMin, traversalMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shared primitives, "
+                   "identical queries; the copies partition independently",
+                   "[BVH][Dodecahedron]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using AABB = BoundingVolumes::AABBT<T>;
+  using Face = DCEL::FaceT<T, Meta>;
+
+  constexpr size_t K = 4;
+
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
+  REQUIRE(mesh != nullptr);
+
+  BVH::PrimAndBVList<Face, AABB> primsAndBVs;
+  for (const auto& f : mesh->getFaces()) {
+    primsAndBVs.emplace_back(f, AABB(f->getAllVertexCoordinates()));
+  }
+
+  const FlatMeshSDF<T, Meta> flat(mesh);
+  const auto                 brute = [&flat](const Vec3T<T>& a_point) -> T { return flat.signedDistance(a_point); };
+
+  // Pack a (partitioned) tree and query it the way MeshSDF does, comparing to the brute-force scan.
+  const auto packAndCheck = [&](const auto& a_tree) {
+    const auto  packed = a_tree->pack();
+    const auto& faces  = packed->getPrimitives();
+
+    for (const auto& p : queryPoints<T>()) {
+      T          state    = std::numeric_limits<T>::max();
+      const auto evalLeaf = [&faces, &p](T& a_state, size_t a_offset, size_t a_count) noexcept {
+        for (size_t i = 0; i < a_count; i++) {
+          const T d = faces[a_offset + i]->signedDistance(p);
+          if (std::abs(d) < std::abs(a_state)) {
+            a_state = d;
+          }
+        }
+      };
+      const auto pruneDist2 = [](const T& a_state) noexcept -> T { return a_state * a_state; };
+
+      packed->pruneTraverse(p, state, evalLeaf, pruneDist2);
+
+      REQUIRE_THAT(state, withinAbsT(brute(p), traversalMargin<T>()));
+    }
+  };
+
+  SECTION("clone of an unpartitioned tree shares primitives; the copies then partition independently")
+  {
+    auto tree = std::make_shared<BVH::TreeBVH<T, Face, AABB, K>>(primsAndBVs);
+    REQUIRE_FALSE(tree->isPartitioned());
+
+    const auto clone = tree->deepCopy();
+    REQUIRE(clone != nullptr);
+    REQUIRE(clone.get() != tree.get());
+    REQUIRE(clone->isPartitioned() == tree->isPartitioned());
+
+    // Primitives are shared by handle, not cloned: same underlying Face objects, same order.
+    // (std::as_const selects the public const getPrimitives() overload; the mutable one is protected.)
+    const auto& treePrims  = std::as_const(*tree).getPrimitives();
+    const auto& clonePrims = std::as_const(*clone).getPrimitives();
+    REQUIRE(clonePrims.size() == treePrims.size());
+    for (size_t i = 0; i < treePrims.size(); i++) {
+      REQUIRE(clonePrims[i].get() == treePrims[i].get());
+    }
+
+    // Partition the two copies with different strategies. Each must build correctly, and neither
+    // may disturb the other -- the guarantee the deleted shallow copy could not provide.
+    tree->topDownSortAndPartition();
+    clone->template bottomUpSortAndPartition<SFC::Morton>();
+
+    REQUIRE(tree->isPartitioned());
+    REQUIRE(clone->isPartitioned());
+    packAndCheck(tree);
+    packAndCheck(clone);
+  }
+
+  SECTION("clone of a partitioned tree duplicates the node hierarchy but shares primitives")
+  {
+    auto tree = std::make_shared<BVH::TreeBVH<T, Face, AABB, K>>(primsAndBVs);
+    tree->topDownSortAndPartition();
+    REQUIRE(tree->isPartitioned());
+
+    const auto clone = tree->deepCopy();
+    REQUIRE(clone != nullptr);
+    REQUIRE(clone->isPartitioned());
+
+    // Interior child nodes are brand-new objects, not aliases of the original's -- this is exactly
+    // what a shallow copy would have failed to do (36 faces guarantee the root is interior).
+    bool anyInterior = false;
+    for (size_t k = 0; k < K; k++) {
+      if (tree->getChildren()[k] != nullptr) {
+        anyInterior = true;
+        REQUIRE(clone->getChildren()[k] != nullptr);
+        REQUIRE(clone->getChildren()[k].get() != tree->getChildren()[k].get());
+      }
+      else {
+        REQUIRE(clone->getChildren()[k] == nullptr);
+      }
+    }
+    REQUIRE(anyInterior);
+
+    // Behaviorally identical, and independent: destroying the original leaves the clone fully valid
+    // (its nodes are its own; the shared faces are kept alive by the mesh).
+    packAndCheck(clone);
+    tree.reset();
+    packAndCheck(clone);
   }
 }

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -519,3 +519,95 @@ TEMPLATE_TEST_CASE("TreeBVH::bottomUpSortAndPartition handles primitive sets who
     buildAndCheck(positions);
   }
 }
+
+TEMPLATE_TEST_CASE("PackedBVH: BVH::ValueStorage and the default BVH::SharedPtrStorage agree exactly",
+                   "[BVH][StoragePolicy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using AABB = BoundingVolumes::AABBT<T>;
+  using Vec3 = Vec3T<T>;
+  using Pnt  = BareTestPoint<T>;
+
+  constexpr size_t K = 4;
+
+  std::vector<Vec3> positions;
+  for (int i = 0; i < 5; i++) {
+    for (int j = 0; j < 5; j++) {
+      for (int k = 0; k < 5; k++) {
+        positions.emplace_back(T(i) + T(0.3) * T(j), T(j) - T(0.2) * T(k), T(k) + T(0.1) * T(i));
+      }
+    }
+  }
+
+  BVH::PrimAndBVList<Pnt, AABB> primsAndBVs;
+  for (const auto& pos : positions) {
+    primsAndBVs.emplace_back(std::make_shared<Pnt>(Pnt{pos}), AABB(pos, pos));
+  }
+
+  auto tree = std::make_shared<BVH::TreeBVH<T, Pnt, AABB, K>>(primsAndBVs);
+  tree->topDownSortAndPartition();
+
+  const auto sharedPacked = tree->pack();
+  const auto valuePacked  = tree->template pack<BVH::ValueStorage<Pnt>>();
+
+  REQUIRE(sharedPacked != nullptr);
+  REQUIRE(valuePacked != nullptr);
+  REQUIRE(sharedPacked->getPrimitives().size() == positions.size());
+  REQUIRE(valuePacked->getPrimitives().size() == positions.size());
+
+  const auto& sharedPrims = sharedPacked->getPrimitives();
+  const auto& valuePrims  = valuePacked->getPrimitives();
+
+  // Both policies were built from the same TreeBVH, so a leaf's primitives must land in the same
+  // order regardless of how they are stored -- not just agree as sets.
+  for (size_t i = 0; i < positions.size(); i++) {
+    REQUIRE(sharedPrims[i]->m_pos == valuePrims[i].m_pos);
+  }
+
+  const auto pruneDist2 = [](const T& a_state) noexcept -> T { return a_state; };
+
+  for (const auto& q : queryPoints<T>()) {
+    T sharedState = std::numeric_limits<T>::max();
+    T valueState  = std::numeric_limits<T>::max();
+
+    const auto sharedEval = [&sharedPrims, &q](T& a_state, size_t a_offset, size_t a_count) noexcept {
+      for (size_t i = 0; i < a_count; i++) {
+        const T d2 = (sharedPrims[a_offset + i]->m_pos - q).length2();
+        if (d2 < a_state) {
+          a_state = d2;
+        }
+      }
+    };
+    const auto valueEval = [&valuePrims, &q](T& a_state, size_t a_offset, size_t a_count) noexcept {
+      for (size_t i = 0; i < a_count; i++) {
+        const T d2 = (valuePrims[a_offset + i].m_pos - q).length2();
+        if (d2 < a_state) {
+          a_state = d2;
+        }
+      }
+    };
+
+    sharedPacked->pruneTraverse(q, sharedState, sharedEval, pruneDist2);
+    valuePacked->pruneTraverse(q, valueState, valueEval, pruneDist2);
+
+    REQUIRE(sharedState == valueState);
+  }
+}
+
+TEMPLATE_TEST_CASE("PackedBVH: BVH::ValueStorage stores primitives inline with no pointer indirection",
+                   "[BVH][StoragePolicy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T   = TestType;
+  using Pnt = BareTestPoint<T>;
+
+  // BVH::ValueStorage<P>::StorageType is P itself -- packing must not add any indirection.
+  static_assert(std::is_same_v<typename BVH::ValueStorage<Pnt>::StorageType, Pnt>);
+  static_assert(sizeof(typename BVH::ValueStorage<Pnt>::StorageType) == sizeof(Pnt));
+
+  // BVH::SharedPtrStorage<P>::StorageType is a shared_ptr<const P>, matching pre-StoragePolicy
+  // behavior -- this is the "no behavior change for existing callers" guarantee made concrete.
+  static_assert(std::is_same_v<typename BVH::SharedPtrStorage<Pnt>::StorageType, std::shared_ptr<const Pnt>>);
+  static_assert(sizeof(typename BVH::SharedPtrStorage<Pnt>::StorageType) == sizeof(std::shared_ptr<const Pnt>));
+}

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -611,3 +611,73 @@ TEMPLATE_TEST_CASE("PackedBVH: BVH::ValueStorage stores primitives inline with n
   static_assert(std::is_same_v<typename BVH::SharedPtrStorage<Pnt>::StorageType, std::shared_ptr<const Pnt>>);
   static_assert(sizeof(typename BVH::SharedPtrStorage<Pnt>::StorageType) == sizeof(std::shared_ptr<const Pnt>));
 }
+
+TEMPLATE_TEST_CASE("TriMeshSDF: default StoragePolicy is BVH::ValueStorage<TriSoA>; MeshSDF has no "
+                   "StoragePolicy choice at all",
+                   "[BVH][StoragePolicy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  constexpr size_t K = 4;
+  constexpr size_t W = 4;
+
+  using Face   = DCEL::FaceT<T, Meta>;
+  using TriSoA = TriangleSoAT<T, W>;
+
+  // MeshSDF always shares each packed face with the DCEL mesh's own face list (no copy, and no
+  // StoragePolicy template parameter to override it): DCEL::FaceT's copy constructor deliberately
+  // does not copy its cached 2D polygon embedding (m_poly2, needed by signedDistance()'s
+  // point-in-face test), so a naive by-value copy is unsafe -- see FaceT's copy-constructor
+  // documentation. TriMeshSDF's SoA groups have no such restriction (freshly built by packing,
+  // shared with nothing else), so it defaults to storing them inline with no indirection. See
+  // ImplemBVH.rst's "Storage policy" section for the full rationale.
+  static_assert(std::is_same_v<typename MeshSDF<T, Meta, K>::Root::StorageType, std::shared_ptr<const Face>>);
+  static_assert(std::is_same_v<typename TriMeshSDF<T, Meta, K, W>::Root::StorageType, TriSoA>);
+}
+
+TEMPLATE_TEST_CASE("TriMeshSDF: explicit BVH::SharedPtrStorage<TriSoA> agrees with the default "
+                   "BVH::ValueStorage<TriSoA>",
+                   "[BVH][Dodecahedron][StoragePolicy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  constexpr size_t K = 4;
+  constexpr size_t W = 4;
+
+  using TriSoA = TriangleSoAT<T, W>;
+
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
+  REQUIRE(mesh != nullptr);
+
+  const TriMeshSDF<T, Meta, K, W>                                defaultStorage(mesh, BVH::Build::SAH, 2);
+  const TriMeshSDF<T, Meta, K, W, BVH::SharedPtrStorage<TriSoA>> sharedStorage(mesh, BVH::Build::SAH, 2);
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(sharedStorage.signedDistance(p), withinAbsT(defaultStorage.signedDistance(p), traversalMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Parser::readIntoTriangleBVH accepts an explicit StoragePolicy override",
+                   "[BVH][Parser][StoragePolicy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  constexpr size_t K = 4;
+  constexpr size_t W = 4;
+
+  using TriSoA = TriangleSoAT<T, W>;
+
+  const auto defaultTri = Parser::readIntoTriangleBVH<T, Meta, K, W>(dataPath("dodecahedron.stl"));
+  const auto sharedTri =
+    Parser::readIntoTriangleBVH<T, Meta, K, W, BVH::SharedPtrStorage<TriSoA>>(dataPath("dodecahedron.stl"));
+
+  REQUIRE(defaultTri != nullptr);
+  REQUIRE(sharedTri != nullptr);
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(sharedTri->signedDistance(p), withinAbsT(defaultTri->signedDistance(p), formatMargin<T>()));
+  }
+}

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -794,3 +794,67 @@ TEMPLATE_TEST_CASE("FlatMeshSDF/MeshSDF/TriMeshSDF: move constructor/assignment 
   static_assert(std::is_move_constructible_v<TriMeshSDF<T, Meta, K, W>>);
   static_assert(std::is_move_assignable_v<TriMeshSDF<T, Meta, K, W>>);
 }
+
+TEMPLATE_TEST_CASE("Nested BVH: a BVHUnion over several TriMeshSDF objects nests each mesh's inner "
+                   "PackedBVH inside the outer union PackedBVH and matches a brute-force min",
+                   "[BVH][CSG][BVHUnion][Nested]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+  using BV   = BoundingVolumes::AABBT<T>;
+  using IF   = ImplicitFunction<T>;
+
+  constexpr size_t K = 4;
+  constexpr size_t W = 4;
+
+  // Two distinct triangle meshes read from the in-repo fixtures. Each TriMeshSDF owns an inner
+  // PackedBVH over SoA triangle groups (ValueStorage by default) -- these are the inner BVHs that
+  // the outer union BVH nests over.
+  const auto dodec = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
+  const auto tetra = Parser::readIntoDCEL<T, Meta>(dataPath("tetrahedron.stl"));
+  REQUIRE(dodec != nullptr);
+  REQUIRE(tetra != nullptr);
+
+  // Spread several translated mesh SDFs out so the outer union BVH has real structure to partition
+  // and prune, rather than collapsing to a single leaf.
+  const std::vector<std::pair<std::shared_ptr<DCEL::MeshT<T, Meta>>, Vec3>> placements = {
+    {dodec, Vec3(0, 0, 0)},
+    {dodec, Vec3(4, 0, 0)},
+    {tetra, Vec3(0, 4, 0)},
+    {tetra, Vec3(-4, -4, 2)},
+  };
+
+  std::vector<std::shared_ptr<IF>> primitives;
+  std::vector<BV>                  boundingVolumes;
+  primitives.reserve(placements.size());
+  boundingVolumes.reserve(placements.size());
+
+  for (const auto& [mesh, shift] : placements) {
+    // Inner BVH: a TriMeshSDF holds its own PackedBVH over the mesh's SoA triangle groups.
+    const auto tri = std::make_shared<TriMeshSDF<T, Meta, K, W>>(mesh, BVH::Build::SAH, 2);
+    const BV   bv  = tri->computeBoundingVolume();
+
+    // Store each mesh SDF as the common base type, translated into place. Its bounding volume for
+    // the outer union is the mesh's own AABB shifted by the same amount.
+    primitives.emplace_back(Translate<T>(tri, shift));
+    boundingVolumes.emplace_back(bv.getLowCorner() + shift, bv.getHighCorner() + shift);
+  }
+
+  // Outer BVH: a PackedBVH over std::shared_ptr<const ImplicitFunction<T>>, each element pointing
+  // at a TriMeshSDF that owns an inner PackedBVH -- a genuine two-level BVH hierarchy.
+  const auto nestedUnion = BVHUnion<T, IF, BV, K>(primitives, boundingVolumes);
+  REQUIRE(nestedUnion != nullptr);
+
+  // The union value is the minimum over all primitives; BVH pruning can never discard the actual
+  // nearest one, so the nested traversal must agree exactly with a brute-force min over the same
+  // translated primitives.
+  for (const auto& p : queryPoints<T>()) {
+    T bruteMin = std::numeric_limits<T>::infinity();
+    for (const auto& prim : primitives) {
+      bruteMin = std::min(bruteMin, prim->value(p));
+    }
+
+    REQUIRE_THAT(nestedUnion->value(p), withinAbsT(bruteMin, traversalMargin<T>()));
+  }
+}

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -681,3 +681,116 @@ TEMPLATE_TEST_CASE("Parser::readIntoTriangleBVH accepts an explicit StoragePolic
     REQUIRE_THAT(sharedTri->signedDistance(p), withinAbsT(defaultTri->signedDistance(p), formatMargin<T>()));
   }
 }
+
+TEMPLATE_TEST_CASE("TreeBVH: copy is disallowed (would alias mutable child subtrees); move is allowed",
+                   "[BVH]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using AABB = BoundingVolumes::AABBT<T>;
+  using Pnt  = BareTestPoint<T>;
+  using Tree = BVH::TreeBVH<T, Pnt, AABB, 4>;
+
+  static_assert(!std::is_copy_constructible_v<Tree>);
+  static_assert(!std::is_copy_assignable_v<Tree>);
+  static_assert(std::is_move_constructible_v<Tree>);
+  static_assert(std::is_move_assignable_v<Tree>);
+}
+
+TEMPLATE_TEST_CASE("PackedBVH: copy is allowed and produces an independent deep copy under both "
+                   "StoragePolicy choices; move is allowed too",
+                   "[BVH]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using AABB = BoundingVolumes::AABBT<T>;
+  using Vec3 = Vec3T<T>;
+  using Pnt  = BareTestPoint<T>;
+
+  constexpr size_t K = 4;
+
+  using Packed      = BVH::PackedBVH<T, Pnt, K>;
+  using PackedValue = BVH::PackedBVH<T, Pnt, K, BVH::ValueStorage<Pnt>>;
+
+  static_assert(std::is_copy_constructible_v<Packed>);
+  static_assert(std::is_copy_assignable_v<Packed>);
+  static_assert(std::is_move_constructible_v<Packed>);
+  static_assert(std::is_move_assignable_v<Packed>);
+  static_assert(std::is_copy_constructible_v<PackedValue>);
+  static_assert(std::is_copy_assignable_v<PackedValue>);
+  static_assert(std::is_move_constructible_v<PackedValue>);
+  static_assert(std::is_move_assignable_v<PackedValue>);
+
+  std::vector<Vec3> positions;
+  positions.reserve(5);
+  for (int i = 0; i < 5; i++) {
+    positions.emplace_back(T(i), T(i) * T(0.5), T(-i));
+  }
+
+  BVH::PrimAndBVList<Pnt, AABB> primsAndBVs;
+  primsAndBVs.reserve(positions.size());
+  for (const auto& pos : positions) {
+    primsAndBVs.emplace_back(std::make_shared<Pnt>(Pnt{pos}), AABB(pos, pos));
+  }
+
+  auto tree = std::make_shared<BVH::TreeBVH<T, Pnt, AABB, K>>(primsAndBVs);
+  tree->topDownSortAndPartition();
+
+  auto original = tree->template pack<BVH::ValueStorage<Pnt>>();
+  REQUIRE(original != nullptr);
+
+  const PackedValue copy(*original); // copy constructor
+  REQUIRE(copy.getPrimitives().size() == original->getPrimitives().size());
+
+  // Destroy the source entirely -- the copy must remain fully valid and independent, proving the
+  // copy constructor performed a real deep copy rather than aliasing the source's storage.
+  original.reset();
+
+  const Vec3  q(0, 0, 0);
+  T           state    = std::numeric_limits<T>::max();
+  const auto& prims    = copy.getPrimitives();
+  const auto  evalLeaf = [&prims, &q](T& a_state, size_t a_offset, size_t a_count) noexcept {
+    for (size_t i = 0; i < a_count; i++) {
+      const T d2 = (prims[a_offset + i].m_pos - q).length2();
+      if (d2 < a_state) {
+        a_state = d2;
+      }
+    }
+  };
+  const auto pruneDist2 = [](const T& a_state) noexcept -> T { return a_state; };
+
+  copy.pruneTraverse(q, state, evalLeaf, pruneDist2);
+
+  T bruteMin2 = std::numeric_limits<T>::max();
+  for (const auto& pos : positions) {
+    bruteMin2 = std::min(bruteMin2, (pos - q).length2());
+  }
+
+  REQUIRE_THAT(state, withinAbsT(bruteMin2, traversalMargin<T>()));
+}
+
+TEMPLATE_TEST_CASE("FlatMeshSDF/MeshSDF/TriMeshSDF: move constructor/assignment are usable (no "
+                   "longer implicitly suppressed by the user-declared destructor)",
+                   "[BVH]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  constexpr size_t K = 4;
+  constexpr size_t W = 4;
+
+  static_assert(std::is_copy_constructible_v<FlatMeshSDF<T, Meta>>);
+  static_assert(std::is_copy_assignable_v<FlatMeshSDF<T, Meta>>);
+  static_assert(std::is_move_constructible_v<FlatMeshSDF<T, Meta>>);
+  static_assert(std::is_move_assignable_v<FlatMeshSDF<T, Meta>>);
+
+  static_assert(std::is_copy_constructible_v<MeshSDF<T, Meta, K>>);
+  static_assert(std::is_copy_assignable_v<MeshSDF<T, Meta, K>>);
+  static_assert(std::is_move_constructible_v<MeshSDF<T, Meta, K>>);
+  static_assert(std::is_move_assignable_v<MeshSDF<T, Meta, K>>);
+
+  static_assert(std::is_copy_constructible_v<TriMeshSDF<T, Meta, K, W>>);
+  static_assert(std::is_copy_assignable_v<TriMeshSDF<T, Meta, K, W>>);
+  static_assert(std::is_move_constructible_v<TriMeshSDF<T, Meta, K, W>>);
+  static_assert(std::is_move_assignable_v<TriMeshSDF<T, Meta, K, W>>);
+}


### PR DESCRIPTION
# Summary

### Background

Issue #92 (PointCloudSoA) wants `PackedBVH` to be usable efficiently over small
value-type primitives (points/particles), not just the mesh-oriented types
(`DCEL::FaceT`, SoA triangle groups) it was originally designed around. Today,
`PackedBVH`'s global primitive array always stores each primitive as a
`std::shared_ptr<const P>`, adding a heap allocation and a pointer indirection
per primitive that isn't worth it for small, cheaply-copyable value types —
and isn't needed, since nothing else typically holds a pointer to a point or
particle the way a `DCEL::FaceT` is shared with its owning mesh. This is the
second of three PRs implementing the plan from that issue (PR1, generic
`pruneTraverse()`, is already merged as #95).

### Solution

Introduce a `StoragePolicy` template parameter on `PackedBVH` (and on
`TreeBVH::pack()`/`packWith()`, which produce a `PackedBVH`), controlling how
the primitive array stores each element:

* `BVH::SharedPtrStorage<P>` — stores `std::shared_ptr<const P>`, identical to
  the pre-existing behavior. This is the default for `PackedBVH`, `pack()`, and
  `packWith()`, so every direct caller that does not name a policy is unchanged.
* `BVH::ValueStorage<P>` — stores `P` inline, by value, with no indirection.
  Trades away sharing (the `PackedBVH` now owns an independent copy of each
  primitive) for a smaller, more cache-friendly array.

A storage policy is a stateless struct exposing a `StorageType` alias plus
`get()`/`appendTreeLeaf()`/`appendAliased()` static methods that `PackedBVH`
calls internally when packing and querying. Both `appendTreeLeaf()` and
`appendAliased()` are appenders under either policy — they add to whatever the
destination already holds regardless of call count (`ValueStorage` keeps an O(1)
buffer-steal fast path for the empty single-call packing path, but genuinely
appends otherwise), so the two policies' contracts cannot silently diverge at a
future second call site. Swapping the policy changes only what `PackedBVH`'s own
primitive array holds — never `TreeBVH` (always shared_ptr-based), tree
construction, traversal order, or query results.

The new axis is then wired through the mesh SDFs and the parser, with each
defaulting to the policy that actually fits its primitive type:

* **`TriMeshSDF<T, Meta, K, W, StoragePolicy>`** gains `StoragePolicy` as a
  fifth template parameter and **now defaults to
  `BVH::ValueStorage<TriangleSoAT<T, W>>`** rather than the shared-pointer
  storage it used before. Its SoA groups are freshly built by
  `groupTrianglesIntoSoA()` during packing and shared with nothing else, so
  storing them inline is both safe and cheaper (one fewer heap allocation and
  pointer indirection per group). A caller can still name
  `BVH::SharedPtrStorage<TriangleSoAT<T, W>>` explicitly.
* **`MeshSDF<T, Meta, K>` stays pointer-only** and deliberately does *not*
  expose a `StoragePolicy` parameter: its `PackedBVH` always uses
  `BVH::SharedPtrStorage<DCEL::FaceT>`. This is a correctness constraint, not
  merely a default — `DCEL::FaceT`'s copy constructor intentionally does not
  copy its cached 2D polygon embedding (`m_poly2`, used by `signedDistance()`'s
  point-in-face test), so a by-value copy (as `ValueStorage` would produce)
  would leave every packed face with a null embedding and crash on the first
  query rather than merely lose sharing.
* **`Parser::readIntoTriangleBVH`** forwards a `StoragePolicy` (its fifth
  template parameter) through to `TriMeshSDF`, defaulting to
  `BVH::ValueStorage<TriangleSoAT<T, W>>` to match. `Parser::readIntoPackedBVH`
  mirrors `MeshSDF` and has no such parameter.

CSG and the `Translate`/`Rotate`/`Scale`/`Union` wrappers are unaffected: they
hold a `shared_ptr` to the whole `MeshSDF`/`TriMeshSDF`, so a mesh's packed
data is never duplicated per placement regardless of how that one object's
`PackedBVH` stores its primitives internally.

Added tests (`Tests/TestBVH.cpp`):

* `SharedPtrStorage`/`ValueStorage` equivalence over a point cloud — identical
  primitive order and identical `pruneTraverse()` nearest-neighbor results
  across both policies.
* A compile-time `StorageType`/layout sanity check for both policies.
* A static assertion that `MeshSDF`'s packed storage is
  `std::shared_ptr<const Face>` while `TriMeshSDF`'s default is the inline SoA
  value type.
* `TriMeshSDF` and `Parser::readIntoTriangleBVH` behavioral equivalence between
  the default `ValueStorage` and an explicit `SharedPtrStorage` override, over
  the `dodecahedron.stl` fixture.
* An `appendAliased` append-contract test: calling it twice (empty → non-empty)
  for both policies must preserve every element in order, guarding against the
  two policies diverging if a second call site is ever added.
* A nested-BVH test: a `BVHUnion` over several translated `TriMeshSDF` objects,
  each owning its own inner `PackedBVH`, exercises a genuine two-level BVH
  hierarchy (outer union BVH → inner mesh BVH) and is checked against a
  brute-force min over the same primitives, over both precisions, using the
  in-repo `dodecahedron.stl`/`tetrahedron.stl` fixtures.

Documented the new axis in `Docs/Sphinx/source/ImplemBVH.rst` (a "Storage
policy" section, plus a "why MeshSDF and TriMeshSDF default differently"
section, and two "when `ValueStorage` is the wrong choice" notes — one for
polymorphic primitives such as the CSG unions' `ImplicitFunction<T>` base, one
for nesting a BVH inside a BVH, where naming `ValueStorage` on an outer level
deep-copies each inner BVH's entire memory footprint and compounds with nesting
depth) and updated `Docs/Sphinx/source/Parsers.rst` (`readIntoTriangleBVH`'s
new parameter).

Added a standalone `Examples/NestedBVH` example (with its
`Docs/Sphinx/source/ExampleNestedBVH.rst` page and the corresponding
index/README entries) that builds exactly this nested hierarchy — a `BVHUnion`
over BVH-backed mesh SDFs — defaulting to the in-repo dodecahedron fixture so it
needs no submodule. It reads the mesh straight into a `TriMeshSDF` via
`Parser::readIntoTriangleBVH` with default parameters (SIMD-optimal `K`/`W`,
`ValueStorage`, SAH), builds that mesh SDF once, and then instances it at several
positions — each placement a `Translate` wrapper sharing a `shared_ptr` to the
same `TriMeshSDF`, so the inner packed BVH is built and stored a single time
rather than per placement. That is the idiomatic instancing model, and it keeps
the example on the recommended high-level entry points.

Also made the BVHs' copy/move semantics explicit (and `PackedBVH`'s destructor
non-virtual, since nothing subclasses it): `TreeBVH` now deletes copy — a
compiler-generated copy would only alias its mutable `shared_ptr`-linked child
subtrees — while defaulting move, and `PackedBVH` explicitly defaults both copy
and move (its members are owned value containers, so the deep copy is correct
under either storage policy). `FlatMeshSDF`/`MeshSDF`/`TriMeshSDF` get the same
treatment. Documented in a new "Copy and move semantics" section of
`ImplemBVH.rst`, with `static_assert` coverage in `Tests/TestBVH.cpp`.

Because deleting `TreeBVH`'s copy left no way to replicate a built tree, added
an explicit `TreeBVH::deepCopy()` that recursively clones the node hierarchy
(returning an independent `std::shared_ptr<TreeBVH>`) while sharing the
immutable `std::shared_ptr<const P>` primitives by handle — mirroring
`DCEL::MeshT::deepCopy()`. It works in either state: an unpartitioned tree
clones to a leaf (build once, then partition the copies with different
strategies), a partitioned tree clones its full sub-structure. Covered by a
round-trip test (distinct node pointers, shared primitives, identical packed
queries, and independent partitioning of the two copies) over both precisions,
and documented in the same "Copy and move semantics" section.

Drive-by fix uncovered along the way: the single- and multi-file
`Parser::readIntoTriangleBVH` overloads defaulted `a_maxLeafGroups` to 4 and 2
respectively (and the single-file doc comment said 2 while its code said 4).
Since it is a per-mesh tree-quality knob, both overloads now default to 4, with
the doc comments and `Parsers.rst` corrected to match.

Verified: `ctest` under `debug`, `debug-san` (ASan/UBSan), `release-test`
(AVX), and `debug` with `-DEBGEOMETRY_TEST_BOTH_PRECISIONS=ON` (float+double)
all pass; the new `NestedBVH` example builds and runs via all three build
methods (direct compile, GNU make, standalone CMake) and via
`ctest --preset examples`; Doxygen and Sphinx HTML build clean; REUSE lint and
`clang-tidy` report no new warnings.

### Side-effects

* `PackedBVH`, `TreeBVH::pack()`, and `TreeBVH::packWith()` default to
  `SharedPtrStorage`, so direct users of those are unchanged.
* **`TriMeshSDF`'s default primitive storage changes from shared-pointer to
  inline value.** Query results are identical (verified across the local matrix
  above), but the element type exposed by `TriMeshSDF::getRoot()` /
  `getPrimitives()` — and by `Parser::readIntoTriangleBVH`'s result — is now
  `TriangleSoAT<T, W>` rather than `std::shared_ptr<const TriangleSoAT<T, W>>`.
  Code that named those pointer types explicitly, or relied on sharing the
  packed SoA groups, would opt back in with
  `BVH::SharedPtrStorage<TriangleSoAT<T, W>>`. The SoA groups are internal to
  `TriMeshSDF` (built during packing, shared with nothing else), so no existing
  consumer in this tree depends on the old representation.
* `MeshSDF` and `Parser::readIntoPackedBVH` are unchanged — still
  `SharedPtrStorage`, no new parameter.
* **`TreeBVH`'s copy constructor and copy assignment are now deleted** (move is
  supported). No in-tree code copied a `TreeBVH`; any caller that did was
  silently aliasing the same mutable child subtrees, which is now a compile
  error instead — use the new `TreeBVH::deepCopy()` to replicate a tree
  independently.
* **The multi-file `Parser::readIntoTriangleBVH`'s `a_maxLeafGroups` default
  changes from 2 to 4** (now matching the single-file overload). A caller
  relying on the old multi-file default gets larger leaf groups (`4*W` vs `2*W`
  triangles); pass `2` explicitly to keep the previous behavior.

### Alternative solutions

Could have hardcoded a value-storage variant of `PackedBVH` as a separate class
rather than a policy parameter, but that would duplicate the packing/traversal
logic that's otherwise identical between the two storage strategies. A
policy-based design (in the spirit of `std::allocator`) keeps `PackedBVH`
itself storage-agnostic and leaves room for future policies.

Could also have left `TriMeshSDF` defaulting to `SharedPtrStorage` and required
callers to opt into `ValueStorage`, but for its freshly-built, unshared SoA
groups value storage is strictly cheaper with no downside, so it is the
sensible default; `MeshSDF`'s faces genuinely cannot be copied by value (see
above), so the two mesh SDFs correctly default differently.

### Reviewer checklist (to be completed by a human)

- [x] The test suite compiles and runs to completion without warnings or errors.
- [x] All relevant new features are documented in the user documentation (Sphinx).
- [x] This contribution does not break existing sections in the user documentation. 
- [x] All relevant APIs are documented in the doxygen documentation.
- [x] Appropriate labels have been assigned to this PR.
- [x] New or revised proper licensing and copyright information is in place.
- [x] A PR review has been run using `@claude review`.
- [x] The continuous integration and testing hooks at GitHub run to completion.





