### PR TITLE
Per-triangle metadata in the SoA path: TriangleAoSoA + TriMeshSDF::getClosestTriangle

### DIFF
--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -262,7 +262,7 @@ via one of two ``TreeBVH`` member functions:
    source tree holds primitives of type ``P``, and a user-supplied ``Converter`` is called once
    per leaf to produce the ``Q`` values that the resulting ``PackedBVH<T, Q, K>`` will store.
    This is how ``TriMeshSDF`` turns a tree of individual ``Triangle<T, Meta>`` primitives into a
-   ``PackedBVH`` whose leaves hold SIMD-width ``TriangleSoAT<T, W>`` groups instead — see
+   ``PackedBVH`` whose leaves hold SIMD-width ``TriangleAoSoA<T, Meta, W>`` groups instead — see
    :ref:`Chap:MeshSDFClasses`.
 
 See `the doxygen page for TreeBVH <doxygen/html/classEBGeometry_1_1BVH_1_1TreeBVH.html>`__ for
@@ -540,9 +540,9 @@ BVH type, and supported geometry:
      - Any polygon mesh; not restricted to triangles
    * - ``TriMeshSDF<T, Meta, K, W, StoragePolicy>``
      - DCEL mesh or triangle soup
-     - ``PackedBVH`` over SoA triangle groups (``BVH::ValueStorage`` by default)
+     - ``PackedBVH`` over ``TriangleAoSoA`` groups (``BVH::ValueStorage`` by default)
      - ``pruneTraverse()`` over SoA-packed leaves
-     - Triangle meshes only; highest throughput
+     - Triangle meshes only; highest throughput; metadata via ``getClosestTriangle()``
 
 ``FlatMeshSDF`` is useful for correctness checks and tiny meshes. See `its doxygen page
 <doxygen/html/classEBGeometry_1_1FlatMeshSDF.html>`__.
@@ -555,13 +555,23 @@ whenever ``(K, T)`` matches a compiled ISA path and falling back to the generic,
 
 ``TriMeshSDF`` is the recommended default for triangle meshes: it packs triangles into
 Structure-of-Arrays groups of width ``W`` (via ``TreeBVH::packWith()``, see above) and builds the
-same kind of thin ``pruneTraverse()`` wrapper as ``MeshSDF``, over ``TriangleSoAT<T, W>`` leaves
-instead of individual faces, so that on a matching ``(K, T)`` combination each BVH leaf evaluates
-``W`` triangles with a single SIMD register operation, and even the AABB-vs-running-best
+same kind of thin ``pruneTraverse()`` wrapper as ``MeshSDF``, over ``TriangleAoSoA<T, Meta, W>``
+leaves instead of individual faces, so that on a matching ``(K, T)`` combination each BVH leaf
+evaluates ``W`` triangles with a single SIMD register operation, and even the AABB-vs-running-best
 comparisons during descent are done on squared distances (no square root) until the very last
 step. See `its doxygen page <doxygen/html/classEBGeometry_1_1TriMeshSDF.html>`__, and `the doxygen
 page for TriangleSoAT <doxygen/html/structEBGeometry_1_1TriangleSoAT.html>`__ for the SoA storage
 itself.
+
+Just as ``MeshSDF::getClosestFaces()`` recovers the nearest face (and its ``Meta``) for a DCEL mesh,
+``TriMeshSDF::getClosestTriangle()`` recovers the nearest triangle's signed distance *and* its
+metadata through the SIMD SoA path -- the supported route when you need both maximum SIMD throughput
+and per-triangle metadata retrieval. Each leaf group is a ``TriangleAoSoA<T, Meta, W>``: a
+geometry-only ``TriangleSoAT<T, W>`` plus a physically-separate per-lane ``std::array<Meta, W>`` (the
+same metadata-carrying wrapper relationship ``PointAoSoA`` has with ``PointSoAT``). The hot
+``signedDistance()`` path never reads the metadata array; only ``getClosestTriangle()`` does, taking a
+scalar per-lane step to recover the winning lane. See `the doxygen page for TriangleAoSoA
+<doxygen/html/structEBGeometry_1_1TriangleAoSoA.html>`__.
 
 What is actually vectorised in ``TriMeshSDF``/``PackedBVH`` is covered in
 :ref:`Chap:SIMDClasses` -- see that page for the full detail rather than repeating it here.
@@ -581,13 +591,13 @@ they default -- and, for ``MeshSDF``, are restricted -- differently:
    ``BVH::ValueStorage``-style plain copy would therefore leave every packed face with an
    uninitialized embedding, crashing on the first query rather than merely losing sharing --
    so ``MeshSDF`` simply never offers that choice.
-*  ``TriMeshSDF`` defaults to ``BVH::ValueStorage<TriangleSoAT<T, W>>`` instead of
+*  ``TriMeshSDF`` defaults to ``BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>`` instead of
    ``BVH::SharedPtrStorage``, and *does* expose ``StoragePolicy`` as an overridable template
-   parameter (its 5th, after ``W``). Unlike ``DCEL::FaceT``, each ``TriangleSoAT<T, W>`` group is
-   a plain aggregate of coordinate arrays with no cached derived state or back-references, built
-   fresh by ``groupTrianglesIntoSoA()`` during packing and shared with nothing else -- so storing
-   it inline is both safe and, avoiding one heap allocation and pointer indirection per group,
-   the better default.
+   parameter (its 5th, after ``W``). Unlike ``DCEL::FaceT``, each ``TriangleAoSoA<T, Meta, W>`` group
+   is a plain aggregate of coordinate arrays plus a per-lane metadata array, with no cached derived
+   state or back-references, built fresh by ``groupTrianglesIntoSoA()`` during packing and shared
+   with nothing else -- so storing it inline is both safe and, avoiding one heap allocation and
+   pointer indirection per group, the better default.
 
 Neither default is affected by instancing the same mesh multiple times (e.g. placing several
 ``Translate``/``Rotate``/``Scale``-wrapped copies of one mesh into a ``Union``): those wrappers
@@ -597,7 +607,7 @@ so its packed data is shared once per wrapper regardless of how that one object'
 
 ``Parser::readIntoPackedBVH`` mirrors ``MeshSDF`` (no ``StoragePolicy`` parameter);
 ``Parser::readIntoTriangleBVH`` mirrors ``TriMeshSDF`` (``StoragePolicy`` as its 5th template
-parameter, defaulting to ``BVH::ValueStorage<TriangleSoAT<T, W>>``). See :ref:`Chap:Parsers`.
+parameter, defaulting to ``BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>``). See :ref:`Chap:Parsers`.
 
 SIMD-optimal K and W by ISA
 ______________________________

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -140,7 +140,7 @@ intrinsics evaluate up to ``W`` triangles per leaf visit. ``K`` and ``W`` defaul
 SIMD-optimal values for ``T`` on the current ISA (``BVH::DefaultBranchingRatio<T>()`` and
 ``TriangleSoA::DefaultWidth<T>()``, see :ref:`Chap:MeshSDFClasses`); ``maxLeafGroups`` (default 4)
 bounds the number of full ``W``-sized SoA groups per BVH leaf; ``StoragePolicy`` defaults to
-``BVH::ValueStorage<TriangleSoAT<T, W>>``, matching ``TriMeshSDF``'s own default (see
+``BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>``, matching ``TriMeshSDF``'s own default (see
 :ref:`Chap:MeshSDFClasses` for the rationale, and why ``readIntoPackedBVH``/``MeshSDF`` above has
 no equivalent parameter). The code will raise an error if any face is not a triangle.
 

--- a/Docs/Sphinx/source/SIMDClasses.rst
+++ b/Docs/Sphinx/source/SIMDClasses.rst
@@ -15,25 +15,39 @@ and explains precisely what gets vectorised in each.
    :local:
    :depth: 1
 
-Per-triangle signed-distance evaluation: ``TriangleSoAT<T, W>``
--------------------------------------------------------------------
+Per-triangle signed-distance evaluation: ``TriangleSoAT<T, W>`` / ``TriangleAoSoA<T, Meta, W>``
+-----------------------------------------------------------------------------------------------
 
-:file:`Source/EBGeometry_TriangleSoA.hpp` / :file:`EBGeometry_TriangleSoAImplem.hpp`
+:file:`Source/EBGeometry_TriangleSoA.hpp` / :file:`EBGeometry_TriangleSoAImplem.hpp` (and the
+metadata-carrying wrapper :file:`EBGeometry_TriangleAoSoA.hpp` /
+:file:`EBGeometry_TriangleAoSoAImplem.hpp`)
 
 See :ref:`Chap:Triangles` for the conceptual picture of why triangles are packed this way.
 
 **What it stores:** the vertex positions, vertex normals, edge normals, and face normal of
 :math:`W` triangles, laid out as a *structure of arrays* (one flat, ``alignas``-aligned array
-per coordinate/component, rather than :math:`W` separate ``Triangle`` objects). See
-:ref:`Chap:MeshSDFClasses` for the rest of the ``TriMeshSDF`` machinery this is packed into.
+per coordinate/component, rather than :math:`W` separate ``Triangle`` objects). ``TriangleSoAT``
+is geometry-only; ``TriangleAoSoA<T, Meta, W>`` adds a physically separate ``std::array<Meta, W>``
+of per-triangle metadata alongside it, never interleaved with the coordinates, so the
+signed-distance kernel touches exactly the same bytes either way -- metadata is read only afterward,
+via ``getMetaData(lane)``. This is the exact same relationship ``PointAoSoA`` has with ``PointSoAT``
+below, and it is what lets ``TriMeshSDF`` answer "which triangle (and its metadata) is closest" (see
+``TriMeshSDF::getClosestTriangle()`` in :ref:`Chap:MeshSDFClasses`) at no cost to the throughput
+path. See :ref:`Chap:MeshSDFClasses` for the rest of the ``TriMeshSDF`` machinery this is packed
+into.
 
 **What is vectorised:** the entire closest-point-on-triangle signed-distance query,
-``TriangleSoAT::signedDistance(point)``. This is the full algorithm -- classifying the
+``TriangleSoAT::signedDistance(point)`` (and, via delegation, ``TriangleAoSoA::signedDistance(point)``).
+This is the full algorithm -- classifying the
 projection of the query point against the triangle's three edge regions and interior region,
 computing the squared distance and sign for whichever region applies, per triangle -- executed
 for all :math:`W` triangles in the block *simultaneously*, one SIMD lane per triangle. The
 result is the minimum signed distance over the whole block, found with vectorised compare/blend
-instructions rather than a loop.
+instructions rather than a loop. The metadata-retrieving companion --
+``TriangleSoAT::signedDistances(point)`` (the per-lane array) and
+``TriangleAoSoA::signedDistance(point, Meta&)`` (which reports the winning lane's metadata) -- instead
+takes a scalar per-lane path, since recovering *which* lane won is the one thing the SIMD horizontal
+reduction discards; it is used only by the (non-throughput) closest-triangle query.
 
 **What this means in practice:** evaluating a ``TriangleSoAT<T, W>`` block costs roughly the
 same number of instructions as evaluating a *single* triangle scalar, but produces the answer

--- a/Docs/Sphinx/source/TestingLocally.rst
+++ b/Docs/Sphinx/source/TestingLocally.rst
@@ -243,7 +243,9 @@ Test coverage
    * - ``TestTriangleSoA``
      - :cpp:class:`TriangleSoAT`: ``signedDistance`` agreement with the minimum over the
        individual packed :cpp:class:`Triangle` instances (including padding when fewer than
-       ``W`` triangles are packed), and bounding-volume construction from the packed data.
+       ``W`` triangles are packed), per-lane ``signedDistances`` consistency, and bounding-volume
+       construction from the packed data; :cpp:class:`TriangleAoSoA`: closest-triangle metadata
+       retrieval (``signedDistance(point, Meta&)``) and per-lane ``getMetaData`` with padding.
    * - ``TestSimpleTimer``
      - ``SimpleTimer``: near-zero elapsed time on construction, measured duration against a
        requested sleep, restart-on-``start()`` semantics, and relative ordering of two

--- a/EBGeometry.hpp
+++ b/EBGeometry.hpp
@@ -39,6 +39,7 @@
 #include "Source/EBGeometry_Soup.hpp"
 #include "Source/EBGeometry_Transform.hpp"
 #include "Source/EBGeometry_Triangle.hpp"
+#include "Source/EBGeometry_TriangleAoSoA.hpp"
 #include "Source/EBGeometry_TriangleSoA.hpp"
 #include "Source/EBGeometry_VTK.hpp"
 #include "Source/EBGeometry_Vec.hpp"

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -295,8 +295,8 @@ protected:
  * @tparam W    SoA width: number of triangles per SIMD group. Must be > 0.
  * Each leaf primitive is a TriangleAoSoA<T, Meta, W>: an SoA triangle block for SIMD signed-distance
  * evaluation, plus a physically-separate per-lane metadata array. The hot signedDistance() path
- * never reads the metadata; getClosestTriangle() does, returning the closest triangle's Meta -- the
- * SIMD analogue of MeshSDF::getClosestFaces() (see issue #105).
+ * never reads the metadata; getClosestTriangle() does, returning the closest triangle's signed
+ * distance together with its Meta (see issue #105).
  * @tparam StoragePolicy PackedBVH primitive storage policy (see BVH::SharedPtrStorage /
  * BVH::ValueStorage). Defaults to BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>, storing each group
  * inline with no pointer indirection -- unlike MeshSDF's faces, these groups are freshly
@@ -341,9 +341,8 @@ public:
   /**
    * @brief Result of getClosestTriangle(): the signed distance to the closest triangle and that
    * triangle's metadata.
-   * @details Mirrors the purpose of MeshSDF::getClosestFaces() -- recovering per-primitive metadata
-   * for the nearest primitive -- but through the SIMD SoA path, and for the single closest triangle
-   * rather than a candidate list. @c m_signedDistance equals what signedDistance() returns.
+   * @details Recovers per-triangle metadata for the single nearest triangle through the SIMD SoA
+   * path. @c signedDistance equals what signedDistance() returns for the same point.
    */
   struct ClosestTriangle
   {
@@ -434,13 +433,12 @@ public:
 
   /**
    * @brief Signed distance to the closest triangle, together with that triangle's metadata.
-   * @details The metadata-retrieving companion to signedDistance(): it drives the same
-   * SIMD-pruned BVH traversal (PackedBVH::pruneTraverse), but each visited leaf group reports the
-   * winning triangle's metadata via TriangleAoSoA::signedDistance(point, Meta&), so the result
-   * carries both the signed distance and the Meta of the nearest triangle. This is the SIMD SoA
-   * analogue of MeshSDF::getClosestFaces() -- the supported path for callers who need both maximum
-   * SIMD throughput and per-triangle metadata retrieval (see issue #105). @c m_signedDistance in the
-   * result equals what signedDistance() would return for the same point.
+   * @details The metadata-retrieving companion to signedDistance(): it drives the same SIMD-pruned
+   * BVH traversal (PackedBVH::pruneTraverse), but each visited leaf group reports the winning
+   * triangle's metadata via TriangleAoSoA::signedDistance(point, Meta&), so the result carries both
+   * the signed distance and the Meta of the nearest triangle -- the supported path for callers who
+   * need both maximum SIMD throughput and per-triangle metadata retrieval (see issue #105). The
+   * result's @c signedDistance equals what signedDistance() would return for the same point.
    * @param[in] a_point Query point. Must be finite.
    * @return The closest triangle's signed distance and metadata.
    */

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -14,6 +14,7 @@
 // Std includes
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -25,6 +26,7 @@
 #include "EBGeometry_DCEL_Mesh.hpp"
 #include "EBGeometry_SignedDistanceFunction.hpp"
 #include "EBGeometry_Triangle.hpp"
+#include "EBGeometry_TriangleAoSoA.hpp"
 #include "EBGeometry_TriangleSoA.hpp"
 #include "EBGeometry_Vec.hpp"
 
@@ -281,8 +283,8 @@ protected:
 /**
  * @brief Signed distance function for a pure triangle mesh using SoA-grouped primitives
  * in a compact (linearized) BVH.
- * @details Triangles are packed into SoA groups of W triangles each (TriangleSoAT<T,W>),
- * enabling SIMD evaluation of up to W signed distances simultaneously.
+ * @details Triangles are packed into metadata-carrying SoA groups of W triangles each
+ * (TriangleAoSoA<T,Meta,W>), enabling SIMD evaluation of up to W signed distances simultaneously.
  *
  * No default arguments: this is a low-level constructor, and callers who excavate down to it
  * must consciously choose K and W. Use Parser::readIntoTriangleBVH for sensible ISA-tuned
@@ -291,8 +293,12 @@ protected:
  * @tparam Meta Triangle metadata type.
  * @tparam K    BVH branching factor (number of children per internal node). Must be >= 2.
  * @tparam W    SoA width: number of triangles per SIMD group. Must be > 0.
+ * Each leaf primitive is a TriangleAoSoA<T, Meta, W>: an SoA triangle block for SIMD signed-distance
+ * evaluation, plus a physically-separate per-lane metadata array. The hot signedDistance() path
+ * never reads the metadata; getClosestTriangle() does, returning the closest triangle's Meta -- the
+ * SIMD analogue of MeshSDF::getClosestFaces() (see issue #105).
  * @tparam StoragePolicy PackedBVH primitive storage policy (see BVH::SharedPtrStorage /
- * BVH::ValueStorage). Defaults to BVH::ValueStorage<TriangleSoAT<T, W>>, storing each SoA group
+ * BVH::ValueStorage). Defaults to BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>, storing each group
  * inline with no pointer indirection -- unlike MeshSDF's faces, these groups are freshly
  * constructed by groupTrianglesIntoSoA() during packing and shared with nothing else, so there is
  * no aliasing benefit to give up. Note that instancing the same mesh multiple times (e.g. via
@@ -304,7 +310,7 @@ template <class T,
           class Meta,
           size_t K,
           size_t W,
-          class StoragePolicy = BVH::ValueStorage<EBGeometry::TriangleSoAT<T, W>>>
+          class StoragePolicy = BVH::ValueStorage<EBGeometry::TriangleAoSoA<T, Meta, W>>>
 class TriMeshSDF : public SignedDistanceFunction<T>
 {
   static_assert(std::is_floating_point_v<T>, "TriMeshSDF<T,Meta,K,W> requires a floating-point T");
@@ -323,14 +329,27 @@ public:
   using Tri = typename EBGeometry::Triangle<T, Meta>;
 
   /**
-   * @brief Alias for the SoA triangle group type
+   * @brief Alias for the metadata-carrying SoA triangle group type (the BVH leaf primitive).
    */
-  using TriSoA = TriangleSoAT<T, W>;
+  using TriAoSoA = TriangleAoSoA<T, Meta, W>;
 
   /**
    * @brief Alias for which BVH root node
    */
-  using Root = typename EBGeometry::BVH::PackedBVH<T, TriSoA, K, StoragePolicy>;
+  using Root = typename EBGeometry::BVH::PackedBVH<T, TriAoSoA, K, StoragePolicy>;
+
+  /**
+   * @brief Result of getClosestTriangle(): the signed distance to the closest triangle and that
+   * triangle's metadata.
+   * @details Mirrors the purpose of MeshSDF::getClosestFaces() -- recovering per-primitive metadata
+   * for the nearest primitive -- but through the SIMD SoA path, and for the single closest triangle
+   * rather than a candidate list. @c m_signedDistance equals what signedDistance() returns.
+   */
+  struct ClosestTriangle
+  {
+    T    m_signedDistance = std::numeric_limits<T>::max(); ///< Signed distance to the closest triangle.
+    Meta m_metaData{};                                     ///< Metadata of the closest triangle.
+  };
 
   /**
    * @brief Default disallowed constructor
@@ -414,6 +433,21 @@ public:
   signedDistance(const Vec3T<T>& a_point) const noexcept override;
 
   /**
+   * @brief Signed distance to the closest triangle, together with that triangle's metadata.
+   * @details The metadata-retrieving companion to signedDistance(): it drives the same
+   * SIMD-pruned BVH traversal (PackedBVH::pruneTraverse), but each visited leaf group reports the
+   * winning triangle's metadata via TriangleAoSoA::signedDistance(point, Meta&), so the result
+   * carries both the signed distance and the Meta of the nearest triangle. This is the SIMD SoA
+   * analogue of MeshSDF::getClosestFaces() -- the supported path for callers who need both maximum
+   * SIMD throughput and per-triangle metadata retrieval (see issue #105). @c m_signedDistance in the
+   * result equals what signedDistance() would return for the same point.
+   * @param[in] a_point Query point. Must be finite.
+   * @return The closest triangle's signed distance and metadata.
+   */
+  [[nodiscard]] ClosestTriangle
+  getClosestTriangle(const Vec3T<T>& a_point) const noexcept;
+
+  /**
    * @brief Get the PackedBVH storing SoA triangle groups.
    * @return Mutable reference to the shared-pointer owning the packed BVH root.
    */
@@ -450,7 +484,7 @@ protected:
    * @param[in] a_count     Number of triangles in this leaf to convert.
    * @return SoA-packed triangle groups covering [a_offset, a_offset + a_count).
    */
-  [[nodiscard]] static std::vector<TriSoA>
+  [[nodiscard]] static std::vector<TriAoSoA>
   groupTrianglesIntoSoA(const std::vector<std::shared_ptr<const Tri>>& a_triangles,
                         uint32_t                                       a_offset,
                         uint32_t                                       a_count);

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -347,8 +347,8 @@ public:
    */
   struct ClosestTriangle
   {
-    T    m_signedDistance = std::numeric_limits<T>::max(); ///< Signed distance to the closest triangle.
-    Meta m_metaData{};                                     ///< Metadata of the closest triangle.
+    T    signedDistance = std::numeric_limits<T>::max(); ///< Signed distance to the closest triangle.
+    Meta metaData{};                                     ///< Metadata of the closest triangle.
   };
 
   /**

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -384,13 +384,13 @@ MeshSDF<T, Meta, K>::computeBoundingVolume() const noexcept
 };
 
 template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
-std::vector<typename TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriSoA>
+std::vector<typename TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriAoSoA>
 TriMeshSDF<T, Meta, K, W, StoragePolicy>::groupTrianglesIntoSoA(
   const std::vector<std::shared_ptr<const Tri>>& a_triangles, uint32_t a_offset, uint32_t a_count)
 {
   constexpr uint32_t soaWidth = static_cast<uint32_t>(W);
 
-  std::vector<TriSoA> groups;
+  std::vector<TriAoSoA> groups;
 
   const uint32_t numGroups = (a_count + soaWidth - 1U) / soaWidth;
   groups.reserve(numGroups);
@@ -406,7 +406,7 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::groupTrianglesIntoSoA(
       trisArr[i] = *a_triangles[groupOffset + i];
     }
 
-    TriSoA soa;
+    TriAoSoA soa;
     soa.pack(trisArr.data(), groupCount);
     groups.push_back(std::move(soa));
   }
@@ -456,7 +456,7 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>
   using Converter = decltype(&TriMeshSDF::groupTrianglesIntoSoA);
 
   m_bvh = EBGeometry::MeshDistanceFunctionsDetail::buildTriTreeBVH<T, Meta, AABB, K>(triangles, a_build, maxLeafSize)
-            ->template packWith<TriSoA, Converter, StoragePolicy>(&TriMeshSDF::groupTrianglesIntoSoA);
+            ->template packWith<TriAoSoA, Converter, StoragePolicy>(&TriMeshSDF::groupTrianglesIntoSoA);
 }
 
 template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
@@ -474,7 +474,7 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::vector<std::shar
   using Converter = decltype(&TriMeshSDF::groupTrianglesIntoSoA);
 
   m_bvh = EBGeometry::MeshDistanceFunctionsDetail::buildTriTreeBVH<T, Meta, AABB, K>(a_triangles, a_build, maxLeafSize)
-            ->template packWith<TriSoA, Converter, StoragePolicy>(&TriMeshSDF::groupTrianglesIntoSoA);
+            ->template packWith<TriAoSoA, Converter, StoragePolicy>(&TriMeshSDF::groupTrianglesIntoSoA);
 }
 
 template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
@@ -509,7 +509,47 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::signedDistance(const Vec3T<T>& a_point
 }
 
 template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
-std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleSoAT<T, W>, K, StoragePolicy>>&
+typename TriMeshSDF<T, Meta, K, W, StoragePolicy>::ClosestTriangle
+TriMeshSDF<T, Meta, K, W, StoragePolicy>::getClosestTriangle(const Vec3T<T>& a_point) const noexcept
+{
+  EBGEOMETRY_EXPECT(m_bvh != nullptr);
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
+
+  // Same SIMD-pruned traversal as signedDistance(), but the running state also carries the winning
+  // triangle's metadata: each visited leaf group reports both its closest signed distance and that
+  // triangle's Meta via TriangleAoSoA::signedDistance(point, Meta&). The pruning bound is still the
+  // squared running distance, so node pruning is identical to signedDistance()'s.
+  ClosestTriangle closest;
+
+  const auto& groups = m_bvh->getPrimitives();
+
+  const auto evalLeaf = [&groups, &a_point](ClosestTriangle& a_state, size_t a_offset, size_t a_count) noexcept {
+    for (size_t i = a_offset; i < a_offset + a_count; i++) {
+      Meta    groupMeta{};
+      const T d = StoragePolicy::get(groups[i]).signedDistance(a_point, groupMeta);
+
+      EBGEOMETRY_EXPECT(!std::isnan(d));
+
+      if (std::abs(d) < std::abs(a_state.m_signedDistance)) {
+        a_state.m_signedDistance = d;
+        a_state.m_metaData       = groupMeta;
+      }
+    }
+  };
+
+  const auto pruneDist2 = [](const ClosestTriangle& a_state) noexcept -> T {
+    return a_state.m_signedDistance * a_state.m_signedDistance;
+  };
+
+  m_bvh->pruneTraverse(a_point, closest, evalLeaf, pruneDist2);
+
+  return closest;
+}
+
+template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
+std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleAoSoA<T, Meta, W>, K, StoragePolicy>>&
 TriMeshSDF<T, Meta, K, W, StoragePolicy>::getRoot() noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
@@ -518,7 +558,7 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::getRoot() noexcept
 }
 
 template <class T, class Meta, size_t K, size_t W, class StoragePolicy>
-const std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleSoAT<T, W>, K, StoragePolicy>>&
+const std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::TriangleAoSoA<T, Meta, W>, K, StoragePolicy>>&
 TriMeshSDF<T, Meta, K, W, StoragePolicy>::getRoot() const noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -532,15 +532,15 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::getClosestTriangle(const Vec3T<T>& a_p
 
       EBGEOMETRY_EXPECT(!std::isnan(d));
 
-      if (std::abs(d) < std::abs(a_state.m_signedDistance)) {
-        a_state.m_signedDistance = d;
-        a_state.m_metaData       = groupMeta;
+      if (std::abs(d) < std::abs(a_state.signedDistance)) {
+        a_state.signedDistance = d;
+        a_state.metaData       = groupMeta;
       }
     }
   };
 
   const auto pruneDist2 = [](const ClosestTriangle& a_state) noexcept -> T {
-    return a_state.m_signedDistance * a_state.m_signedDistance;
+    return a_state.signedDistance * a_state.signedDistance;
   };
 
   m_bvh->pruneTraverse(a_point, closest, evalLeaf, pruneDist2);

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -26,6 +26,7 @@
 #include "EBGeometry_PLY.hpp"
 #include "EBGeometry_STL.hpp"
 #include "EBGeometry_Triangle.hpp"
+#include "EBGeometry_TriangleAoSoA.hpp"
 #include "EBGeometry_TriangleSoA.hpp"
 #include "EBGeometry_VTK.hpp"
 
@@ -244,7 +245,7 @@ readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Build a_bu
  * (8/float or 4/double on AVX; 4 otherwise).
  * @tparam StoragePolicy PackedBVH primitive storage policy forwarded to TriMeshSDF (see
  * BVH::SharedPtrStorage / BVH::ValueStorage). Defaults to
- * BVH::ValueStorage<TriangleSoAT<T, W>>, matching TriMeshSDF's own default.
+ * BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>, matching TriMeshSDF's own default.
  * @param[in] a_filename      File name (STL, PLY, or VTK).
  * @param[in] a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf; the
  * actual raw-triangle leaf-size bound used is a_maxLeafGroups * W (see TriMeshSDF's mesh-based
@@ -256,7 +257,7 @@ template <typename T,
           typename Meta       = DCEL::DefaultMetaData,
           size_t K            = BVH::DefaultBranchingRatio<T>(),
           size_t W            = TriangleSoA::DefaultWidth<T>(),
-          class StoragePolicy = BVH::ValueStorage<TriangleSoAT<T, W>>>
+          class StoragePolicy = BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>>
 [[nodiscard]] inline static std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>
 readIntoTriangleBVH(const std::string a_filename,
                     const size_t      a_maxLeafGroups = 4,
@@ -280,7 +281,7 @@ template <typename T,
           typename Meta       = DCEL::DefaultMetaData,
           size_t K            = BVH::DefaultBranchingRatio<T>(),
           size_t W            = TriangleSoA::DefaultWidth<T>(),
-          class StoragePolicy = BVH::ValueStorage<TriangleSoAT<T, W>>>
+          class StoragePolicy = BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>>
 [[nodiscard]] inline static std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>>
 readIntoTriangleBVH(const std::vector<std::string>& a_files,
                     const size_t                    a_maxLeafGroups = 4,

--- a/Source/EBGeometry_TriangleAoSoA.hpp
+++ b/Source/EBGeometry_TriangleAoSoA.hpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_TriangleAoSoA.hpp
+ * @brief  Declaration of a metadata-carrying wrapper around TriangleSoAT.
+ * @author Robert Marskar
+ */
+
+#ifndef EBGEOMETRY_TRIANGLEAOSOA_HPP
+#define EBGEOMETRY_TRIANGLEAOSOA_HPP
+
+// Std includes
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+// Our includes
+#include "EBGeometry_Triangle.hpp"
+#include "EBGeometry_TriangleSoA.hpp"
+#include "EBGeometry_Vec.hpp"
+
+namespace EBGeometry {
+
+/**
+ * @brief Metadata-carrying wrapper around a single TriangleSoAT<T, W>.
+ * @details Structurally this is an AoSoA (Array of Structures of Arrays): TriangleSoAT<T, W> itself
+ * is true SoA (one flat array per coordinate, no per-triangle structure at all), and TriangleAoSoA
+ * adds exactly one more member -- a std::array<Meta, W> -- alongside it. The two are never merged or
+ * interleaved: the hot signedDistance(const Vec3T<T>&) query is delegated straight through to the
+ * embedded TriangleSoAT and never reads m_metaData at all, so a pure signed-distance traversal over
+ * TriangleAoSoA-packed leaves touches exactly the same bytes it would touch over bare
+ * TriangleSoAT-packed leaves -- metadata is only ever read afterward, once a query already knows
+ * which lane (and therefore which triangle) it cares about, via getMetaData() or the
+ * metadata-reporting signedDistance(point, Meta&) overload. This is the exact same relationship
+ * PointAoSoA<T, Meta, W> has with PointSoAT<T, W>, and it is what lets TriMeshSDF answer "which
+ * triangle (and its metadata) is closest" -- the SIMD analogue of MeshSDF::getClosestFaces() -- with
+ * no cost to its throughput signedDistance() path.
+ * @warning Inherits the embedded TriangleSoAT's over-alignment (up to 64 bytes, for AVX-512F). The
+ * library's own usage (PackedBVH storing groups inside a std::vector<TriangleAoSoA>) is safe: C++17
+ * mandates that std::allocator respect over-alignment. If you allocate a TriangleAoSoA yourself
+ * outside of that path -- a raw `new`, a container with a custom/pre-C++17-style allocator,
+ * placement-new into externally-owned storage, or a `malloc`'d buffer -- you are responsible for
+ * ensuring the memory is aligned to `alignof(TriangleAoSoA<T, Meta, W>)`.
+ * @tparam T    Floating-point precision.
+ * @tparam Meta Per-triangle user metadata type stored with each triangle.
+ * @tparam W    SIMD width; see TriangleSoAT. Defaults to TriangleSoA::DefaultWidth<T>(), matching
+ * TriangleSoAT's own default.
+ */
+template <class T, class Meta, size_t W = TriangleSoA::DefaultWidth<T>()>
+struct TriangleAoSoA
+{
+  static_assert(W > 0, "W must be positive");
+  static_assert(std::is_floating_point_v<T>, "TriangleAoSoA requires a floating-point type T");
+
+public:
+  /**
+   * @brief Pack a_count triangles from a_triangles[0..a_count-1] into this group.
+   * @details Pads lanes a_count..W-1 by repeating the last real triangle (its coordinates *and* its
+   * metadata), matching TriangleSoAT::pack()'s own padding convention, so all W lanes hold valid
+   * data. The coordinates go into the embedded TriangleSoAT; each triangle's metadata (via
+   * Triangle::getMetaData()) goes into the parallel m_metaData array.
+   * @param[in] a_triangles Source triangle array with at least a_count elements. Must not be null.
+   * @param[in] a_count     Number of valid triangles to pack. Must satisfy 1 <= a_count <= W.
+   */
+  void
+  pack(const Triangle<T, Meta>* a_triangles, uint32_t a_count) noexcept;
+
+  /**
+   * @brief Evaluate signed distance from a_point to the closest triangle in this group.
+   * @details Delegates entirely to the embedded TriangleSoAT<T, W>; never touches m_metaData, so the
+   * metadata array adds no cost to this hot (SIMD) path. See TriangleSoAT::signedDistance().
+   * @param[in] a_point Query point. Must be finite.
+   * @return Signed distance from a_point to the closest valid triangle.
+   */
+  [[nodiscard]] T
+  signedDistance(const Vec3T<T>& a_point) const noexcept;
+
+  /**
+   * @brief Evaluate signed distance from a_point to the closest triangle *and* report that
+   * triangle's metadata.
+   * @details The metadata-retrieving analogue of signedDistance(const Vec3T<T>&): it returns the
+   * same minimum-absolute-value signed distance, but also writes the winning triangle's metadata to
+   * @p a_closestMeta. Unlike the plain overload it takes the scalar per-lane path
+   * (TriangleSoAT::signedDistances()) to recover *which* lane won, then reads that lane's metadata --
+   * the extra work the throughput path deliberately avoids (see issue #105).
+   * @param[in]  a_point       Query point. Must be finite.
+   * @param[out] a_closestMeta Set to the metadata of the winning (minimum-|distance|) triangle.
+   * @return Signed distance from a_point to the closest valid triangle.
+   */
+  [[nodiscard]] T
+  signedDistance(const Vec3T<T>& a_point, Meta& a_closestMeta) const noexcept;
+
+  /**
+   * @brief Get the metadata for one lane of this group.
+   * @details Requires the group to have already been packed via pack() (1 <= m_validCount <= W).
+   * Mirrors PointAoSoA::getMetaData().
+   * @param[in] a_lane Lane index. Must satisfy 0 <= a_lane < W (padded lanes return the last real
+   * triangle's metadata -- see pack()).
+   * @return Metadata for the triangle at a_lane.
+   */
+  [[nodiscard]] const Meta&
+  getMetaData(size_t a_lane) const noexcept;
+
+  /**
+   * @brief Compute the bounding volume enclosing all valid triangles in this group.
+   * @details Delegates entirely to the embedded TriangleSoAT<T, W>.
+   * @tparam BV Bounding volume type (e.g. AABBT<T>); must be constructible from a
+   * std::vector<Vec3T<T>> of vertex positions.
+   * @return Bounding volume enclosing all vertices of the valid triangles.
+   */
+  template <class BV>
+  [[nodiscard]] BV
+  computeBoundingVolume() const noexcept;
+
+protected:
+  /**
+   * @brief The wrapped, coordinate-only SoA block. SIMD-hot: this is all signedDistance() touches.
+   */
+  TriangleSoAT<T, W> m_triangles;
+
+  /**
+   * @brief Per-lane metadata, physically separate from m_triangles. m_metaData[j] = metadata of
+   * triangle j. Never read by signedDistance(const Vec3T<T>&).
+   */
+  std::array<Meta, W> m_metaData;
+
+  /**
+   * @brief Number of valid (non-padded) triangles in this group (1..W).
+   * @details Zero-initialized so that a default-constructed (not-yet-packed) group reliably fails
+   * the EBGEOMETRY_EXPECT(m_validCount >= 1) precondition in getMetaData()/signedDistance(point,
+   * Meta&), rather than reading whatever indeterminate value happened to be there. (The plain
+   * signedDistance() gets the same protection for free from the embedded TriangleSoAT's own
+   * m_validCount.)
+   */
+  uint32_t m_validCount = 0;
+};
+
+} // namespace EBGeometry
+
+#include "EBGeometry_TriangleAoSoAImplem.hpp"
+
+#endif

--- a/Source/EBGeometry_TriangleAoSoA.hpp
+++ b/Source/EBGeometry_TriangleAoSoA.hpp
@@ -32,12 +32,10 @@ namespace EBGeometry {
  * interleaved: the hot signedDistance(const Vec3T<T>&) query is delegated straight through to the
  * embedded TriangleSoAT and never reads m_metaData at all, so a pure signed-distance traversal over
  * TriangleAoSoA-packed leaves touches exactly the same bytes it would touch over bare
- * TriangleSoAT-packed leaves -- metadata is only ever read afterward, once a query already knows
- * which lane (and therefore which triangle) it cares about, via getMetaData() or the
- * metadata-reporting signedDistance(point, Meta&) overload. This is the exact same relationship
- * PointAoSoA<T, Meta, W> has with PointSoAT<T, W>, and it is what lets TriMeshSDF answer "which
- * triangle (and its metadata) is closest" -- the SIMD analogue of MeshSDF::getClosestFaces() -- with
- * no cost to its throughput signedDistance() path.
+ * TriangleSoAT-packed leaves. The metadata is read only afterward, once a query already knows which
+ * lane (and therefore which triangle) it cares about, via getMetaData() or the metadata-reporting
+ * signedDistance(point, Meta&) overload -- so a caller can recover which triangle (and its metadata)
+ * is closest at no cost to the throughput signedDistance() path.
  * @warning Inherits the embedded TriangleSoAT's over-alignment (up to 64 bytes, for AVX-512F). The
  * library's own usage (PackedBVH storing groups inside a std::vector<TriangleAoSoA>) is safe: C++17
  * mandates that std::allocator respect over-alignment. If you allocate a TriangleAoSoA yourself
@@ -96,7 +94,6 @@ public:
   /**
    * @brief Get the metadata for one lane of this group.
    * @details Requires the group to have already been packed via pack() (1 <= m_validCount <= W).
-   * Mirrors PointAoSoA::getMetaData().
    * @param[in] a_lane Lane index. Must satisfy 0 <= a_lane < W (padded lanes return the last real
    * triangle's metadata -- see pack()).
    * @return Metadata for the triangle at a_lane.

--- a/Source/EBGeometry_TriangleAoSoAImplem.hpp
+++ b/Source/EBGeometry_TriangleAoSoAImplem.hpp
@@ -37,10 +37,19 @@ TriangleAoSoA<T, Meta, W>::pack(const Triangle<T, Meta>* a_triangles, uint32_t a
   m_triangles.pack(a_triangles, a_count);
 
   // Same padding convention as TriangleSoAT::pack(): lanes a_count..W-1 repeat the last real entry.
-  for (uint32_t j = 0; j < W; j++) {
-    const uint32_t src = (j < a_count) ? j : (a_count - 1U);
+  // The last real metadata is carried forward in a local rather than re-read via a_triangles[a_count
+  // - 1]: the outer loop is bounded by the compile-time W and every a_triangles read is guarded by
+  // j < a_count, so no index can run past the source array -- which also keeps GCC's -Warray-bounds
+  // value analysis from mistaking the (assertion-guarded, hence Release-invisible) a_count >= 1
+  // precondition for a possible a_count - 1 unsigned underflow.
+  Meta lastMeta{};
 
-    m_metaData[j] = a_triangles[src].getMetaData();
+  for (uint32_t j = 0; j < W; j++) {
+    if (j < a_count) {
+      lastMeta = a_triangles[j].getMetaData();
+    }
+
+    m_metaData[j] = lastMeta;
   }
 }
 

--- a/Source/EBGeometry_TriangleAoSoAImplem.hpp
+++ b/Source/EBGeometry_TriangleAoSoAImplem.hpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_TriangleAoSoAImplem.hpp
+ * @brief  Implementation of EBGeometry_TriangleAoSoA.hpp
+ * @author Robert Marskar
+ */
+
+#ifndef EBGEOMETRY_TRIANGLEAOSOAIMPLEM_HPP
+#define EBGEOMETRY_TRIANGLEAOSOAIMPLEM_HPP
+
+// Std includes
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+// Our includes
+#include "EBGeometry_Macros.hpp"
+#include "EBGeometry_TriangleAoSoA.hpp"
+
+namespace EBGeometry {
+
+template <class T, class Meta, size_t W>
+void
+TriangleAoSoA<T, Meta, W>::pack(const Triangle<T, Meta>* a_triangles, uint32_t a_count) noexcept
+{
+  EBGEOMETRY_EXPECT(a_triangles != nullptr);
+  EBGEOMETRY_EXPECT(a_count >= 1U);
+  EBGEOMETRY_EXPECT(a_count <= W);
+
+  m_validCount = a_count;
+
+  m_triangles.pack(a_triangles, a_count);
+
+  // Same padding convention as TriangleSoAT::pack(): lanes a_count..W-1 repeat the last real entry.
+  for (uint32_t j = 0; j < W; j++) {
+    const uint32_t src = (j < a_count) ? j : (a_count - 1U);
+
+    m_metaData[j] = a_triangles[src].getMetaData();
+  }
+}
+
+template <class T, class Meta, size_t W>
+T
+TriangleAoSoA<T, Meta, W>::signedDistance(const Vec3T<T>& a_point) const noexcept
+{
+  return m_triangles.signedDistance(a_point);
+}
+
+template <class T, class Meta, size_t W>
+T
+TriangleAoSoA<T, Meta, W>::signedDistance(const Vec3T<T>& a_point, Meta& a_closestMeta) const noexcept
+{
+  EBGEOMETRY_EXPECT(m_validCount >= 1U);
+  EBGEOMETRY_EXPECT(m_validCount <= W);
+
+  const std::array<T, W> distances = m_triangles.signedDistances(a_point);
+
+  T        best     = distances[0];
+  T        bestAbs  = std::abs(distances[0]);
+  uint32_t bestLane = 0;
+
+  for (uint32_t i = 1; i < m_validCount; i++) {
+    const T ad = std::abs(distances[i]);
+
+    if (ad < bestAbs) {
+      best     = distances[i];
+      bestAbs  = ad;
+      bestLane = i;
+    }
+  }
+
+  a_closestMeta = m_metaData[bestLane];
+
+  return best;
+}
+
+template <class T, class Meta, size_t W>
+const Meta&
+TriangleAoSoA<T, Meta, W>::getMetaData(size_t a_lane) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_lane < W);
+  EBGEOMETRY_EXPECT(m_validCount >= 1U);
+
+  return m_metaData[a_lane];
+}
+
+template <class T, class Meta, size_t W>
+template <class BV>
+BV
+TriangleAoSoA<T, Meta, W>::computeBoundingVolume() const noexcept
+{
+  return m_triangles.template computeBoundingVolume<BV>();
+}
+
+} // namespace EBGeometry
+
+#endif

--- a/Source/EBGeometry_TriangleSoA.hpp
+++ b/Source/EBGeometry_TriangleSoA.hpp
@@ -12,6 +12,7 @@
 #define EBGEOMETRY_TRIANGLESOA_HPP
 
 // Std includes
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -129,6 +130,23 @@ public:
   signedDistance(const Vec3T<T>& a_point) const noexcept;
 
   /**
+   * @brief Signed distances from a_point to every one of the W lane triangles.
+   * @details The per-lane analogue of signedDistance(), mirroring PointSoAT::getDistances2():
+   * signedDistance() horizontally reduces this to the single minimum-|value| entry, whereas this
+   * returns all W of them so a caller can recover *which* lane won -- the piece the SIMD reduction
+   * discards, and the only way to index a parallel per-lane array such as TriangleAoSoA's metadata.
+   * Computed with a scalar per-lane loop rather than the SIMD kernel, since it is used only by the
+   * metadata-retrieving (non-throughput) path. All W lanes are filled: padded lanes
+   * (m_validCount..W-1) repeat the last real triangle's distance, matching pack()'s padding, so a
+   * caller iterating lanes should stop at m_validCount (or de-duplicate). Requires the group to have
+   * already been packed via pack() (1 <= m_validCount <= W).
+   * @param[in] a_point Query point. Must be finite.
+   * @return Per-lane signed distances, one per W lanes.
+   */
+  [[nodiscard]] std::array<T, W>
+  signedDistances(const Vec3T<T>& a_point) const noexcept;
+
+  /**
    * @brief Compute the bounding volume enclosing all valid triangles in this group.
    * @details Requires the group to have already been packed via pack() (1 <= m_validCount <= W).
    * @tparam BV Bounding volume type (e.g. AABBT<T>); must be constructible from a
@@ -140,6 +158,17 @@ public:
   computeBoundingVolume() const noexcept;
 
 protected:
+  /**
+   * @brief Signed distance from a_point to the single triangle stored in lane a_lane.
+   * @details The scalar per-lane kernel shared by the scalar fallback of signedDistance() and by
+   * signedDistances(). Reads only lane a_lane's coordinates/normals; performs no reduction.
+   * @param[in] a_lane  Lane index. Must satisfy 0 <= a_lane < W.
+   * @param[in] a_point Query point.
+   * @return Signed distance from a_point to lane a_lane's triangle, sign from its nearest feature.
+   */
+  [[nodiscard]] T
+  signedDistanceLane(uint32_t a_lane, const Vec3T<T>& a_point) const noexcept;
+
   /**
    * @brief x-coordinates of vertex positions. m_vx[i][j] = x-coord of vertex i for triangle j.
    */

--- a/Source/EBGeometry_TriangleSoA.hpp
+++ b/Source/EBGeometry_TriangleSoA.hpp
@@ -131,15 +131,14 @@ public:
 
   /**
    * @brief Signed distances from a_point to every one of the W lane triangles.
-   * @details The per-lane analogue of signedDistance(), mirroring PointSoAT::getDistances2():
-   * signedDistance() horizontally reduces this to the single minimum-|value| entry, whereas this
-   * returns all W of them so a caller can recover *which* lane won -- the piece the SIMD reduction
-   * discards, and the only way to index a parallel per-lane array such as TriangleAoSoA's metadata.
-   * Computed with a scalar per-lane loop rather than the SIMD kernel, since it is used only by the
-   * metadata-retrieving (non-throughput) path. All W lanes are filled: padded lanes
-   * (m_validCount..W-1) repeat the last real triangle's distance, matching pack()'s padding, so a
-   * caller iterating lanes should stop at m_validCount (or de-duplicate). Requires the group to have
-   * already been packed via pack() (1 <= m_validCount <= W).
+   * @details The per-lane analogue of signedDistance(): signedDistance() horizontally reduces the W
+   * per-triangle distances to the single minimum-|value| entry, whereas this returns all W of them so
+   * a caller can recover *which* lane won -- the piece the SIMD reduction discards. Computed with a
+   * scalar per-lane loop rather than the SIMD kernel, since it is used only by the metadata-retrieving
+   * (non-throughput) path. All W lanes are filled: padded lanes (m_validCount..W-1) repeat the last
+   * real triangle's distance, matching pack()'s padding, so a caller iterating lanes should stop at
+   * m_validCount (or de-duplicate). Requires the group to have already been packed via pack()
+   * (1 <= m_validCount <= W).
    * @param[in] a_point Query point. Must be finite.
    * @return Per-lane signed distances, one per W lanes.
    */

--- a/Source/EBGeometry_TriangleSoAImplem.hpp
+++ b/Source/EBGeometry_TriangleSoAImplem.hpp
@@ -12,6 +12,7 @@
 #define EBGEOMETRY_TRIANGLESOAIMPLEM_HPP
 
 // Std includes
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -1183,92 +1184,9 @@ TriangleSoAT<T, W>::signedDistance(const Vec3T<T>& a_p) const noexcept
   T best_abs = std::numeric_limits<T>::max();
 
   for (uint32_t i = 0; i < m_validCount; i++) {
-    const Vec3T<T> v0{m_vx[0][i], m_vy[0][i], m_vz[0][i]};
-    const Vec3T<T> v1{m_vx[1][i], m_vy[1][i], m_vz[1][i]};
-    const Vec3T<T> v2{m_vx[2][i], m_vy[2][i], m_vz[2][i]};
-    const Vec3T<T> n{m_nx[i], m_ny[i], m_nz[i]};
-    const Vec3T<T> vn0{m_vnx[0][i], m_vny[0][i], m_vnz[0][i]};
-    const Vec3T<T> vn1{m_vnx[1][i], m_vny[1][i], m_vnz[1][i]};
-    const Vec3T<T> vn2{m_vnx[2][i], m_vny[2][i], m_vnz[2][i]};
-    const Vec3T<T> en0{m_enx[0][i], m_eny[0][i], m_enz[0][i]};
-    const Vec3T<T> en1{m_enx[1][i], m_eny[1][i], m_enz[1][i]};
-    const Vec3T<T> en2{m_enx[2][i], m_eny[2][i], m_enz[2][i]};
-
-    auto sgn = [](const T x) -> int { return (x > T(0)) ? 1 : -1; };
-
-    const Vec3T<T> v21 = v1 - v0;
-    const Vec3T<T> v32 = v2 - v1;
-    const Vec3T<T> v13 = v0 - v2;
-
-    EBGEOMETRY_EXPECT(dot(v21, v21) > T(0));
-    EBGEOMETRY_EXPECT(dot(v32, v32) > T(0));
-    EBGEOMETRY_EXPECT(dot(v13, v13) > T(0));
-
-    const Vec3T<T> p1 = a_p - v0;
-    const Vec3T<T> p2 = a_p - v1;
-    const Vec3T<T> p3 = a_p - v2;
-
-    const T ss0 = sgn(dot(v21.cross(n), p1));
-    const T ss1 = sgn(dot(v32.cross(n), p2));
-    const T ss2 = sgn(dot(v13.cross(n), p3));
-
-    T d;
-    if (std::abs(ss0 + ss1 + ss2) >= T(2)) {
-      d = n.dot(p1);
-    }
-    else {
-      T        r2 = p1.dot(p1);
-      Vec3T<T> rv = p1;
-      Vec3T<T> rn = vn0;
-
-      const T p2d = p2.dot(p2);
-      if (p2d < r2) {
-        r2 = p2d;
-        rv = p2;
-        rn = vn1;
-      }
-      const T p3d = p3.dot(p3);
-      if (p3d < r2) {
-        r2 = p3d;
-        rv = p3;
-        rn = vn2;
-      }
-
-      const T t1 = dot(p1, v21) / dot(v21, v21);
-      if (t1 > T(0) && t1 < T(1)) {
-        const Vec3T<T> y1 = p1 - t1 * v21;
-        const T        yd = y1.dot(y1);
-        if (yd < r2) {
-          r2 = yd;
-          rv = y1;
-          rn = en0;
-        }
-      }
-      const T t2 = dot(p2, v32) / dot(v32, v32);
-      if (t2 > T(0) && t2 < T(1)) {
-        const Vec3T<T> y2 = p2 - t2 * v32;
-        const T        yd = y2.dot(y2);
-        if (yd < r2) {
-          r2 = yd;
-          rv = y2;
-          rn = en1;
-        }
-      }
-      const T t3 = dot(p3, v13) / dot(v13, v13);
-      if (t3 > T(0) && t3 < T(1)) {
-        const Vec3T<T> y3 = p3 - t3 * v13;
-        const T        yd = y3.dot(y3);
-        if (yd < r2) {
-          r2 = yd;
-          rv = y3;
-          rn = en2;
-        }
-      }
-
-      d = std::sqrt(r2) * sgn(rn.dot(rv));
-    }
-
+    const T d  = this->signedDistanceLane(i, a_p);
     const T ad = std::abs(d);
+
     if (ad < best_abs) {
       best     = d;
       best_abs = ad;
@@ -1276,6 +1194,125 @@ TriangleSoAT<T, W>::signedDistance(const Vec3T<T>& a_p) const noexcept
   }
 
   return best;
+}
+
+template <class T, size_t W>
+T
+TriangleSoAT<T, W>::signedDistanceLane(uint32_t a_lane, const Vec3T<T>& a_point) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_lane < W);
+
+  const uint32_t i = a_lane;
+
+  const Vec3T<T> v0{m_vx[0][i], m_vy[0][i], m_vz[0][i]};
+  const Vec3T<T> v1{m_vx[1][i], m_vy[1][i], m_vz[1][i]};
+  const Vec3T<T> v2{m_vx[2][i], m_vy[2][i], m_vz[2][i]};
+  const Vec3T<T> n{m_nx[i], m_ny[i], m_nz[i]};
+  const Vec3T<T> vn0{m_vnx[0][i], m_vny[0][i], m_vnz[0][i]};
+  const Vec3T<T> vn1{m_vnx[1][i], m_vny[1][i], m_vnz[1][i]};
+  const Vec3T<T> vn2{m_vnx[2][i], m_vny[2][i], m_vnz[2][i]};
+  const Vec3T<T> en0{m_enx[0][i], m_eny[0][i], m_enz[0][i]};
+  const Vec3T<T> en1{m_enx[1][i], m_eny[1][i], m_enz[1][i]};
+  const Vec3T<T> en2{m_enx[2][i], m_eny[2][i], m_enz[2][i]};
+
+  auto sgn = [](const T x) -> int { return (x > T(0)) ? 1 : -1; };
+
+  const Vec3T<T> v21 = v1 - v0;
+  const Vec3T<T> v32 = v2 - v1;
+  const Vec3T<T> v13 = v0 - v2;
+
+  EBGEOMETRY_EXPECT(dot(v21, v21) > T(0));
+  EBGEOMETRY_EXPECT(dot(v32, v32) > T(0));
+  EBGEOMETRY_EXPECT(dot(v13, v13) > T(0));
+
+  const Vec3T<T> p1 = a_point - v0;
+  const Vec3T<T> p2 = a_point - v1;
+  const Vec3T<T> p3 = a_point - v2;
+
+  const T ss0 = sgn(dot(v21.cross(n), p1));
+  const T ss1 = sgn(dot(v32.cross(n), p2));
+  const T ss2 = sgn(dot(v13.cross(n), p3));
+
+  T d;
+  if (std::abs(ss0 + ss1 + ss2) >= T(2)) {
+    d = n.dot(p1);
+  }
+  else {
+    T        r2 = p1.dot(p1);
+    Vec3T<T> rv = p1;
+    Vec3T<T> rn = vn0;
+
+    const T p2d = p2.dot(p2);
+    if (p2d < r2) {
+      r2 = p2d;
+      rv = p2;
+      rn = vn1;
+    }
+    const T p3d = p3.dot(p3);
+    if (p3d < r2) {
+      r2 = p3d;
+      rv = p3;
+      rn = vn2;
+    }
+
+    const T t1 = dot(p1, v21) / dot(v21, v21);
+    if (t1 > T(0) && t1 < T(1)) {
+      const Vec3T<T> y1 = p1 - t1 * v21;
+      const T        yd = y1.dot(y1);
+      if (yd < r2) {
+        r2 = yd;
+        rv = y1;
+        rn = en0;
+      }
+    }
+    const T t2 = dot(p2, v32) / dot(v32, v32);
+    if (t2 > T(0) && t2 < T(1)) {
+      const Vec3T<T> y2 = p2 - t2 * v32;
+      const T        yd = y2.dot(y2);
+      if (yd < r2) {
+        r2 = yd;
+        rv = y2;
+        rn = en1;
+      }
+    }
+    const T t3 = dot(p3, v13) / dot(v13, v13);
+    if (t3 > T(0) && t3 < T(1)) {
+      const Vec3T<T> y3 = p3 - t3 * v13;
+      const T        yd = y3.dot(y3);
+      if (yd < r2) {
+        r2 = yd;
+        rv = y3;
+        rn = en2;
+      }
+    }
+
+    d = std::sqrt(r2) * sgn(rn.dot(rv));
+  }
+
+  return d;
+}
+
+template <class T, size_t W>
+std::array<T, W>
+TriangleSoAT<T, W>::signedDistances(const Vec3T<T>& a_point) const noexcept
+{
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
+  EBGEOMETRY_EXPECT(m_validCount >= 1U);
+  EBGEOMETRY_EXPECT(m_validCount <= W);
+
+  std::array<T, W> distances;
+
+  // Real lanes computed directly; padded lanes (m_validCount..W-1) repeat the last real lane's
+  // distance, matching pack()'s padding convention so a lane-iterating caller sees no fresh values.
+  for (uint32_t i = 0; i < W; i++) {
+    const uint32_t lane = (i < m_validCount) ? i : (m_validCount - 1U);
+
+    distances[i] = this->signedDistanceLane(lane, a_point);
+  }
+
+  return distances;
 }
 
 template <class T, size_t W>

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -73,6 +73,8 @@ using Meta = short;
                                                                                \
   /* -- Triangles -----------------------------------------------------------*/\
   template class Triangle<PREC, Meta>;                                      \
+  template struct TriangleSoAT<PREC, 4>;                                     \
+  template struct TriangleAoSoA<PREC, Meta, 4>;                              \
                                                                                \
   /* -- Mesh distance functions --------------------------------------------*/\
   template class FlatMeshSDF<PREC, Meta>;                                    \

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -305,8 +305,8 @@ TEMPLATE_TEST_CASE("TriMeshSDF::getClosestTriangle reports the closest triangle'
 
       const auto closest = tri.getClosestTriangle(q);
 
-      REQUIRE(closest.m_metaData == static_cast<Meta>(100 + i));
-      REQUIRE_THAT(closest.m_signedDistance, withinAbsT(tri.signedDistance(q), traversalMargin<T>()));
+      REQUIRE(closest.metaData == static_cast<Meta>(100 + i));
+      REQUIRE_THAT(closest.signedDistance, withinAbsT(tri.signedDistance(q), traversalMargin<T>()));
     }
   }
 }

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -267,6 +267,50 @@ TEMPLATE_TEST_CASE("MeshSDF::getClosestFaces returns the correct number of candi
   REQUIRE_THAT(closestUnsignedDist, withinAbsT(std::abs(packed.signedDistance(p)), traversalMargin<T>()));
 }
 
+TEMPLATE_TEST_CASE("TriMeshSDF::getClosestTriangle reports the closest triangle's metadata and a "
+                   "distance matching signedDistance()",
+                   "[BVH][TriMesh][Meta]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+
+  constexpr size_t K = 4;
+  constexpr size_t W = 4;
+
+  // A soup of well-separated triangles (3 apart along x), each tagged with a distinct metadata value
+  // so the closest-triangle query's returned metadata is unambiguous. Enough triangles to force
+  // several BVH leaves/levels.
+  constexpr int N = 12;
+
+  std::vector<std::shared_ptr<Triangle<T, Meta>>> tris;
+  for (int i = 0; i < N; i++) {
+    const Vec3 base(T(3 * i), T(0), T(0));
+
+    auto tri = std::make_shared<Triangle<T, Meta>>();
+    tri->setVertexPositions({base + Vec3(0, 0, 0), base + Vec3(1, 0, 0), base + Vec3(0, 1, 0)});
+    tri->setNormal(Vec3(0, 0, 1));
+    tri->setVertexNormals({Vec3(0, 0, 1), Vec3(0, 0, 1), Vec3(0, 0, 1)});
+    tri->setEdgeNormals({Vec3(0, 0, 1), Vec3(0, 0, 1), Vec3(0, 0, 1)});
+    tri->setMetaData(static_cast<Meta>(100 + i));
+
+    tris.emplace_back(tri);
+  }
+
+  for (const auto build : {BVH::Build::TopDown, BVH::Build::SAH}) {
+    const TriMeshSDF<T, Meta, K, W> tri(tris, build, 2);
+
+    for (int i = 0; i < N; i++) {
+      const Vec3 q(T(3 * i) + T(0.25), T(0.25), T(0.2)); // unambiguously nearest to triangle i
+
+      const auto closest = tri.getClosestTriangle(q);
+
+      REQUIRE(closest.m_metaData == static_cast<Meta>(100 + i));
+      REQUIRE_THAT(closest.m_signedDistance, withinAbsT(tri.signedDistance(q), traversalMargin<T>()));
+    }
+  }
+}
+
 namespace {
 
 // Bare point primitive with no signedDistance() (or any other) member at all -- used below to
@@ -564,8 +608,7 @@ TEMPLATE_TEST_CASE("BVH refit: TreeBVH::refit and PackedBVH::refit update boundi
     const AABB tight = tightRoot();
 
     for (int d = 0; d < 3; d++) {
-      REQUIRE_THAT(tree->getBoundingVolume().getLowCorner()[d],
-                   withinAbsT(tight.getLowCorner()[d], tightMargin<T>()));
+      REQUIRE_THAT(tree->getBoundingVolume().getLowCorner()[d], withinAbsT(tight.getLowCorner()[d], tightMargin<T>()));
       REQUIRE_THAT(tree->getBoundingVolume().getHighCorner()[d],
                    withinAbsT(tight.getHighCorner()[d], tightMargin<T>()));
       REQUIRE_THAT(packed->getBoundingVolume().getLowCorner()[d],
@@ -908,8 +951,8 @@ TEMPLATE_TEST_CASE("TriMeshSDF: default StoragePolicy is BVH::ValueStorage<TriSo
   constexpr size_t K = 4;
   constexpr size_t W = 4;
 
-  using Face   = DCEL::FaceT<T, Meta>;
-  using TriSoA = TriangleSoAT<T, W>;
+  using Face     = DCEL::FaceT<T, Meta>;
+  using TriAoSoA = TriangleAoSoA<T, Meta, W>;
 
   // MeshSDF always shares each packed face with the DCEL mesh's own face list (no copy, and no
   // StoragePolicy template parameter to override it): DCEL::FaceT's copy constructor deliberately
@@ -919,11 +962,11 @@ TEMPLATE_TEST_CASE("TriMeshSDF: default StoragePolicy is BVH::ValueStorage<TriSo
   // shared with nothing else), so it defaults to storing them inline with no indirection. See
   // ImplemBVH.rst's "Storage policy" section for the full rationale.
   static_assert(std::is_same_v<typename MeshSDF<T, Meta, K>::Root::StorageType, std::shared_ptr<const Face>>);
-  static_assert(std::is_same_v<typename TriMeshSDF<T, Meta, K, W>::Root::StorageType, TriSoA>);
+  static_assert(std::is_same_v<typename TriMeshSDF<T, Meta, K, W>::Root::StorageType, TriAoSoA>);
 }
 
-TEMPLATE_TEST_CASE("TriMeshSDF: explicit BVH::SharedPtrStorage<TriSoA> agrees with the default "
-                   "BVH::ValueStorage<TriSoA>",
+TEMPLATE_TEST_CASE("TriMeshSDF: explicit BVH::SharedPtrStorage<TriAoSoA> agrees with the default "
+                   "BVH::ValueStorage<TriAoSoA>",
                    "[BVH][Dodecahedron][StoragePolicy]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
@@ -932,13 +975,13 @@ TEMPLATE_TEST_CASE("TriMeshSDF: explicit BVH::SharedPtrStorage<TriSoA> agrees wi
   constexpr size_t K = 4;
   constexpr size_t W = 4;
 
-  using TriSoA = TriangleSoAT<T, W>;
+  using TriAoSoA = TriangleAoSoA<T, Meta, W>;
 
   const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
   REQUIRE(mesh != nullptr);
 
-  const TriMeshSDF<T, Meta, K, W>                                defaultStorage(mesh, BVH::Build::SAH, 2);
-  const TriMeshSDF<T, Meta, K, W, BVH::SharedPtrStorage<TriSoA>> sharedStorage(mesh, BVH::Build::SAH, 2);
+  const TriMeshSDF<T, Meta, K, W>                                  defaultStorage(mesh, BVH::Build::SAH, 2);
+  const TriMeshSDF<T, Meta, K, W, BVH::SharedPtrStorage<TriAoSoA>> sharedStorage(mesh, BVH::Build::SAH, 2);
 
   for (const auto& p : queryPoints<T>()) {
     REQUIRE_THAT(sharedStorage.signedDistance(p), withinAbsT(defaultStorage.signedDistance(p), traversalMargin<T>()));
@@ -954,11 +997,11 @@ TEMPLATE_TEST_CASE("Parser::readIntoTriangleBVH accepts an explicit StoragePolic
   constexpr size_t K = 4;
   constexpr size_t W = 4;
 
-  using TriSoA = TriangleSoAT<T, W>;
+  using TriAoSoA = TriangleAoSoA<T, Meta, W>;
 
   const auto defaultTri = Parser::readIntoTriangleBVH<T, Meta, K, W>(dataPath("dodecahedron.stl"));
   const auto sharedTri =
-    Parser::readIntoTriangleBVH<T, Meta, K, W, BVH::SharedPtrStorage<TriSoA>>(dataPath("dodecahedron.stl"));
+    Parser::readIntoTriangleBVH<T, Meta, K, W, BVH::SharedPtrStorage<TriAoSoA>>(dataPath("dodecahedron.stl"));
 
   REQUIRE(defaultTri != nullptr);
   REQUIRE(sharedTri != nullptr);

--- a/Tests/TestTriangleSoA.cpp
+++ b/Tests/TestTriangleSoA.cpp
@@ -23,6 +23,9 @@ constexpr size_t W = 4;
 template <class T>
 using SoA = TriangleSoAT<T, W>;
 
+template <class T>
+using AoSoA = TriangleAoSoA<T, short, W>;
+
 // Four disjoint, well-separated triangles, spread out along x so each one is unambiguously the
 // closest for a query point placed near it.
 template <class T>
@@ -36,6 +39,20 @@ fourTriangles()
     const Vec3 base(T(3.0 * i), T(0), T(0));
     tris.emplace_back(std::array<Vec3, 3>{base + Vec3(0, 0, 0), base + Vec3(1, 0, 0), base + Vec3(0, 1, 0)});
   }
+  return tris;
+}
+
+// The same four triangles, each tagged with a distinct metadata value (10, 11, 12, 13) so a
+// closest-triangle query's returned metadata can be checked against the known closest triangle.
+template <class T>
+std::vector<Tri<T>>
+fourTrianglesWithMeta()
+{
+  auto tris = fourTriangles<T>();
+  for (size_t i = 0; i < tris.size(); i++) {
+    tris[i].setMetaData(static_cast<short>(10 + i));
+  }
+
   return tris;
 }
 
@@ -150,4 +167,90 @@ TEMPLATE_TEST_CASE("TriangleSoAT::computeBoundingVolume matches an AABB built di
     REQUIRE_THAT(bv.getLowCorner()[i], withinAbsT(expected.getLowCorner()[i], looseMargin<T>()));
     REQUIRE_THAT(bv.getHighCorner()[i], withinAbsT(expected.getHighCorner()[i], looseMargin<T>()));
   }
+}
+
+TEMPLATE_TEST_CASE("TriangleSoAT::signedDistances returns per-lane distances whose min-|value| "
+                   "equals signedDistance()",
+                   "[TriangleSoA]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  const auto tris = fourTriangles<T>();
+
+  SoA<T> group;
+  group.template pack<short>(tris.data(), static_cast<uint32_t>(tris.size()));
+
+  for (const auto& p : queryPoints<T>()) {
+    const std::array<T, W> perLane = group.signedDistances(p);
+
+    // Each lane must match the corresponding individual triangle, and the min-|lane| must equal the
+    // reduced signedDistance().
+    T best = std::numeric_limits<T>::max();
+    for (size_t i = 0; i < tris.size(); i++) {
+      REQUIRE_THAT(perLane[i], withinAbsT(tris[i].signedDistance(p), looseMargin<T>()));
+
+      if (std::abs(perLane[i]) < std::abs(best)) {
+        best = perLane[i];
+      }
+    }
+
+    REQUIRE_THAT(group.signedDistance(p), withinAbsT(best, looseMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("TriangleAoSoA::signedDistance(point, meta) reports the closest triangle's "
+                   "metadata and matches the plain overload",
+                   "[TriangleSoA][TriangleAoSoA]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  const auto tris = fourTrianglesWithMeta<T>();
+  REQUIRE(tris.size() == W);
+
+  AoSoA<T> group;
+  group.pack(tris.data(), static_cast<uint32_t>(tris.size()));
+
+  for (const auto& p : queryPoints<T>()) {
+    // Brute-force the closest triangle (by |signed distance|) and its metadata.
+    T     best         = std::numeric_limits<T>::max();
+    short expectedMeta = -1;
+    for (const auto& tri : tris) {
+      const T d = tri.signedDistance(p);
+
+      if (std::abs(d) < std::abs(best)) {
+        best         = d;
+        expectedMeta = tri.getMetaData();
+      }
+    }
+
+    short   meta = -1;
+    const T d    = group.signedDistance(p, meta);
+
+    REQUIRE_THAT(d, withinAbsT(best, looseMargin<T>()));
+    REQUIRE(meta == expectedMeta);
+
+    // The plain overload (hot path) must agree with the metadata-reporting one.
+    REQUIRE_THAT(group.signedDistance(p), withinAbsT(best, looseMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("TriangleAoSoA::getMetaData returns each lane's metadata and pads with the last "
+                   "real triangle",
+                   "[TriangleSoA][TriangleAoSoA]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  auto tris = fourTrianglesWithMeta<T>();
+  tris.resize(2); // Pack only the first 2; lanes 2 and 3 are padded with the last real triangle.
+
+  AoSoA<T> group;
+  group.pack(tris.data(), 2);
+
+  REQUIRE(group.getMetaData(0) == short(10));
+  REQUIRE(group.getMetaData(1) == short(11));
+  REQUIRE(group.getMetaData(2) == short(11)); // padded -> last real triangle's metadata
+  REQUIRE(group.getMetaData(3) == short(11)); // padded -> last real triangle's metadata
 }


### PR DESCRIPTION
# Summary

Add an AoSoA capable triangle group, similar to PointAoSoA. This is used by TriMeshSDF to simultaneously enable SIMD and metadata -- the past version was based on TriangleSoA, which did not support metadata.

Closes #105 

### Background

`MeshSDF` (via `DCEL::FaceT`) lets a caller locate the closest primitive to a query point *and*
retrieve its associated `Meta`, through `MeshSDF::getClosestFaces()`. `TriMeshSDF` is meant to be the
SIMD-accelerated, high-throughput analogue of that same use case, packing triangles into SoA groups —
but it was throughput-only: `TriangleSoAT<T, W>` stored no metadata, `signedDistance()` returned a
bare `T` without reporting which lane won, and `TriMeshSDF` had no `getClosestFaces()`-equivalent. A
caller needing both maximum SIMD throughput *and* per-triangle metadata retrieval had no supported
path — they had to fall back to `MeshSDF`/`Triangle` and give up SoA SIMD throughput entirely
(issue #105).

### Solution

Mirror the existing `PointSoAT` / `PointAoSoA` split rather than parameterising the SoA class itself:

- **`TriangleSoAT<T, W>` stays a pure, geometry-only SoA.** It gains a per-lane
  `signedDistances(point)` (scalar, mirroring `PointSoAT::getDistances2()`) and a shared scalar
  `signedDistanceLane()` helper — also used by the existing scalar fallback of `signedDistance()`, so
  that hot SIMD path is unchanged. `signedDistances()` is what lets a caller recover *which* lane won,
  the piece the SIMD horizontal reduction discards.
- **New `TriangleAoSoA<T, Meta, W>`** wraps a `TriangleSoAT<T, W>` plus a physically-separate
  `std::array<Meta, W>`, exactly as `PointAoSoA` wraps `PointSoAT`. `signedDistance(point)` delegates
  to the embedded SoA (hot path, never touches metadata); `signedDistance(point, Meta&)` reports the
  winning lane's metadata; `getMetaData(lane)` mirrors `PointAoSoA`.
- **`TriMeshSDF` now packs `TriangleAoSoA` leaves** (its default `StoragePolicy`,
  `Parser::readIntoTriangleBVH`'s default, and the `groupTrianglesIntoSoA`/`getRoot` wiring updated to
  match) and exposes **`getClosestTriangle(point) → {signed distance, Meta}`**, driving the same
  SIMD-pruned `pruneTraverse()` as `signedDistance()` but tracking the closest triangle's metadata.

Tests cover `TriangleAoSoA` metadata storage/padding and winning-lane retrieval, per-lane
`signedDistances()` consistency, and an end-to-end `TriMeshSDF::getClosestTriangle()` metadata test
over a tagged triangle soup. `TriangleSoAT`/`TriangleAoSoA` were added to `InstantiateAll`, and the
Sphinx docs (SIMDClasses, ImplemBVH, Parsers, TestingLocally) updated.

### Side-effects

- Per-group memory grows by `sizeof(Meta) * W` (the metadata array), as anticipated in the issue.
  `Meta` defaults to `DCEL::DefaultMetaData` (`short`), so the default cost is tiny.
- `TriMeshSDF`'s leaf primitive type and `Root::StorageType` change from `TriangleSoAT<T, W>` to
  `TriangleAoSoA<T, Meta, W>`; the default `StoragePolicy` becomes
  `BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>` (and likewise for `Parser::readIntoTriangleBVH`).
  Source-compatible for callers that don't name the primitive type explicitly.
- `getClosestTriangle()` recovers the winning lane via the scalar `signedDistances()` path, so its
  returned distance can differ from `signedDistance()`'s SIMD result at the floating-point-rounding
  level on near-tied lanes — documented as approximate equality. The hot `signedDistance()` path is
  byte-for-byte unchanged.
- Verified green across the `debug`, `debug-san` (ASan/UBSan), both-precisions, and `release-test`
  (AVX) presets; clang-format (pinned v21) and the Sphinx `-W` build are clean.

### Alternative solutions

- Add a `Meta` template parameter directly to `TriangleSoAT` (metadata array inline). Rejected in
  favour of the `PointAoSoA`-style wrapper, which keeps the SoA class metadata-free and reuses the
  established, already-documented AoSoA pattern.
- Thread an arg-min lane index through all six SIMD reduction paths so `getClosestTriangle()` stays
  fully vectorised. Rejected as high-complexity/high-risk for a query that is not the throughput hot
  path; a scalar per-lane recompute for the metadata query is simpler and, per the issue, the
  intended place to pay that small extra cost.
- Leave `TriMeshSDF` throughput-only and document that metadata callers use `MeshSDF`. Rejected — it
  does not close the capability gap the issue describes.

Closes #105

### Reviewer checklist (to be completed by a human)

- [x] The test suite compiles and runs to completion without warnings or errors.
- [x] All relevant new features are documented in the user documentation (Sphinx).
- [x] This contribution does not break existing sections in the user documentation. 
- [x] All relevant APIs are documented in the doxygen documentation.
- [x] Appropriate labels have been assigned to this PR.
- [x] New or revised proper licensing and copyright information is in place.
- [x] A PR review has been run using `@claude review`.
- [x] The continuous integration and testing hooks at GitHub run to completion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhdRJydutVJqQjg2Fuee9Z)_