### PR TITLE
GPU port (Tier 1): index-based DCEL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,16 +287,20 @@ does not follow this template, edit the PR body to conform to it.
   `debug-san`, OFF in `release`/`release-test`) and are the primary way internal invariant
   violations (e.g. a dangling half-edge, a malformed mesh) surface during development; they compile
   to nothing in Release.
-- **DCEL topology uses `weak_ptr` for back-references** (edge→pair edge, edge→face, vertex→
-  outgoing edge, etc.) with the `DCEL::MeshT`'s own vertex/edge/face vectors as the sole
-  `shared_ptr` owners. Introducing a *new* back-reference field as a `shared_ptr` will very likely
-  create a reference cycle that leaks (invisible without a leak-checking sanitizer, since nothing
-  crashes) — always use `weak_ptr` + `.lock()` for anything that points "backward" in the mesh
-  graph.
-- **`MeshSDF` retains its source `DCEL::MeshT`, not just the packed BVH.** If you write a similar
-  wrapper around a DCEL mesh, remember that a `PackedBVH` of faces holds `shared_ptr<const
-  DCEL::FaceT>`s that transitively `weak_ptr`-reference the mesh's edges/vertices — nothing keeps
-  the mesh itself alive unless something holds an explicit `shared_ptr<DCEL::MeshT>`.
+- **DCEL topology is index-based, not pointer-based.** `DCEL::MeshT` owns its vertices, half-edges,
+  and faces in flat `std::vector`s by value; every topological link (edge→pair edge, edge→next edge,
+  edge→face, edge→origin vertex, vertex→outgoing edge, vertex→incident faces, face→half-edge) is a
+  `DCEL::DCELIndex` (`int`) into those arrays, with `DCEL::InvalidIndex` (`-1`) denoting "no link"
+  (e.g. a boundary half-edge's absent pair). There are no `shared_ptr`/`weak_ptr` links, so there is
+  no reference-cycle hazard. Traversal and geometric queries (`signedDistanceToFace/Edge/Vertex`,
+  the `EdgeIteratorT` cursor, `reconcile`, normals) live on `MeshT` because an element can no longer
+  chase pointers on its own — add new topology as an index field and resolve it against the mesh
+  arrays.
+- **`MeshSDF` retains its source `DCEL::MeshT`, not just the packed BVH.** The `PackedBVH` stores
+  face *indices* (`DCELIndex`, via `BVH::ValueStorage`) into the mesh's face array, and every
+  distance query resolves an index against the retained mesh (`MeshSDF::getMesh()`); the mesh must
+  therefore outlive the BVH. `getClosestFaces()` accordingly returns `(face index, distance)` pairs,
+  not face pointers.
 - **Every CMake preset gets its own `build/<preset-name>/` directory** (see `CMakePresets.json`'s
   `binaryDir`) specifically so switching presets can't silently reuse a stale `CMakeCache.txt` from
   a different configuration.

--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -565,7 +565,8 @@ step. See `its doxygen page <doxygen/html/classEBGeometry_1_1TriMeshSDF.html>`__
 page for TriangleSoAT <doxygen/html/structEBGeometry_1_1TriangleSoAT.html>`__ for the SoA storage
 itself.
 
-Just as ``MeshSDF::getClosestFaces()`` recovers the nearest face (and its ``Meta``) for a DCEL mesh,
+Just as ``MeshSDF::getClosestFaces()`` recovers the nearest face index for a DCEL mesh (from which
+its ``Meta`` is read by indexing the retained mesh, exposed via ``MeshSDF::getMesh()``),
 ``TriMeshSDF::getClosestTriangle()`` recovers the nearest triangle's signed distance *and* its
 metadata through the SIMD SoA path -- the supported route when you need both maximum SIMD throughput
 and per-triangle metadata retrieval. Each leaf group is a ``TriangleAoSoA<T, Meta, W>``: a

--- a/Docs/Sphinx/source/ImplemDCEL.rst
+++ b/Docs/Sphinx/source/ImplemDCEL.rst
@@ -20,19 +20,22 @@ Main types
 
 The main DCEL functionality (vertices, edges, faces) is provided by classes templated on both a
 floating-point precision ``T`` and a user-defined meta-data type ``Meta`` attached to each
-instance:
+instance. The mesh owns its vertices, half-edges, and faces in flat arrays; each element is a
+trivially copyable value type, and every topological link between them is an integer index
+(``DCELIndex``) into those arrays -- with ``InvalidIndex`` denoting "no link" (e.g. the pair edge
+of a boundary half-edge) -- rather than a pointer:
 
-*  ``VertexT<T, Meta>`` stores the vertex position, its (outward) normal vector, and the outgoing
-   half-edge from the vertex, plus pointers to every polygon face sharing that vertex. It also has
-   member functions for computing the vertex pseudonormal, see :ref:`Chap:NormalDCEL`. For the
-   full API, see the Doxygen reference for
+*  ``VertexT<T, Meta>`` stores the vertex position, its (outward) normal vector, and the index of
+   an outgoing half-edge from the vertex, plus the indices of every polygon face sharing that
+   vertex. It also has member functions for computing the vertex pseudonormal, see
+   :ref:`Chap:NormalDCEL`. For the full API, see the Doxygen reference for
    `VertexT <doxygen/html/classEBGeometry_1_1DCEL_1_1VertexT.html>`__.
 
-*  ``EdgeT<T, Meta>`` represents a half-edge: it stores a reference to its owning face, and
-   pointers to the next edge, its pair edge, and its starting vertex. For the full API, see the
-   Doxygen reference for `EdgeT <doxygen/html/classEBGeometry_1_1DCEL_1_1EdgeT.html>`__.
+*  ``EdgeT<T, Meta>`` represents a half-edge: it stores the indices of its owning face, its next
+   edge, its pair edge (``InvalidIndex`` on a boundary), and its origin vertex. For the full API,
+   see the Doxygen reference for `EdgeT <doxygen/html/classEBGeometry_1_1DCEL_1_1EdgeT.html>`__.
 
-*  ``FaceT<T, Meta>`` represents a polygon face. Besides its half-edge, it also stores the face
+*  ``FaceT<T, Meta>`` represents a polygon face. Besides the index of one of its half-edges, it also stores the face
    normal vector, a 2D embedding of the polygon, and its centroid position: the normal and 2D
    embedding exist because the signed distance computation needs them, and the centroid exists
    because BVH partitioners use it when partitioning the surface mesh. For the full API, see the
@@ -43,8 +46,9 @@ instance:
    ``unsignedDistance2()``, that scan every face directly. It is not itself a
    ``SignedDistanceFunction<T>``: for anything beyond small meshes, one instead wraps a
    ``MeshT<T, Meta>`` in one of the BVH-accelerated classes described in
-   :ref:`Chap:MeshSDFClasses`, which hold a ``shared_ptr<MeshT<T, Meta>>`` internally and only fall
-   back to it for topology (not for the accelerated distance queries themselves). A mesh is
+   :ref:`Chap:MeshSDFClasses`, which hold a ``shared_ptr<MeshT<T, Meta>>`` internally; the
+   accelerated hierarchy stores face indices into that mesh and resolves each pruned candidate
+   face's distance against it. A mesh is
    typically never constructed by hand -- it is built by a file parser reading vertices and faces
    from disk, see :ref:`Chap:Parsers`. For the full API, see the Doxygen reference for
    `MeshT <doxygen/html/classEBGeometry_1_1DCEL_1_1MeshT.html>`__.

--- a/Docs/Sphinx/source/Implementation.rst
+++ b/Docs/Sphinx/source/Implementation.rst
@@ -26,14 +26,14 @@ components). A handful of design choices recur throughout the implementation:
   same bounding volume hierarchy machinery, reducing an :math:`\mathcal{O}(N)` linear scan to an
   :math:`\mathcal{O}(\log N)` tree traversal in either case. See :ref:`Chap:ImplemBVH`.
 
-* **Value types where topology permits it.** A DCEL mesh needs pointer-based topology (a
-  half-edge, its pair, and its owning face are genuinely different objects referencing each
-  other), so it uses ``weak_ptr`` back-references to avoid reference cycles. Where no topology is
-  needed, however, EBGeometry prefers small, self-contained value types instead -- a triangle
-  with no half-edge structure, or a bounding-volume-hierarchy node stored by index offset rather
-  than by pointer -- since these can be packed tightly in memory and, where the data layout
-  allows it, evaluated with SIMD instructions. See :ref:`Chap:ImplemDCEL` and
-  :ref:`Chap:ImplemBVH`.
+* **Flat, index-based data structures -- no pointers.** Even a DCEL mesh -- whose half-edges,
+  pairs, and owning faces genuinely reference each other -- is stored as flat arrays of value-type
+  vertices, edges, and faces, with every topological link expressed as an integer index into those
+  arrays rather than a pointer (a boundary half-edge's missing pair is a sentinel index). This is
+  the same by-index-offset style the bounding-volume-hierarchy nodes use to reference their children
+  and primitives, and the self-contained value types the triangle SoA paths use. Keeping everything
+  flat and trivially copyable lets the data pack tightly in memory and, where the layout allows it,
+  be evaluated with SIMD instructions. See :ref:`Chap:ImplemDCEL` and :ref:`Chap:ImplemBVH`.
 
 * **SIMD as an opt-in, compile-time-detected layer.** SIMD acceleration is implemented with
   hand-written compiler intrinsics in exactly two places, selected at compile time from the

--- a/Integrations/AMReX/PaintEB/main.cpp
+++ b/Integrations/AMReX/PaintEB/main.cpp
@@ -40,7 +40,7 @@ public:
     // Set the meta-data for all facets to their "index", i.e. position in the list of facets
     auto& faces = mesh->getFaces();
     for (size_t i = 0; i < faces.size(); i++) {
-      faces[i]->getMetaData() = 1.0 * i;
+      faces[i].getMetaData() = 1.0 * i;
     }
 
     m_sdf = std::make_shared<EBGeometry::MeshSDF<T, Meta, K>>(mesh, EBGeometry::BVH::Build::SAH);
@@ -75,11 +75,23 @@ public:
 
   /*!
     @brief Get the face(s) that are closest to the input point.
+    @details The DCEL is index-based, so this returns (face index, unsigned distance) pairs. Resolve
+    a face index against the mesh with getFaceMetaData() (or m_sdf->getMesh()).
   */
-  inline std::vector<std::pair<std::shared_ptr<const Face>, T>>
+  inline std::vector<std::pair<EBGeometry::DCEL::DCELIndex, T>>
   getClosestFaces(AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
   {
     return m_sdf->getClosestFaces(EBGeometry::Vec3T<T>(x, y, z), true);
+  }
+
+  /*!
+    @brief Resolve a face index (from getClosestFaces) to its metadata.
+    @param[in] a_faceIdx Index into the DCEL mesh's face array.
+  */
+  inline Meta
+  getFaceMetaData(EBGeometry::DCEL::DCELIndex a_faceIdx) const noexcept
+  {
+    return m_sdf->getMesh()->getFaces()[a_faceIdx].getMetaData();
   }
 
 protected:
@@ -170,7 +182,7 @@ main(int argc, char* argv[])
 
         const auto& candidateFaces = sdf.getClosestFaces(x, y, z);
 
-        mf_array(i, j, k) = 1.0 * (candidateFaces.front().first)->getMetaData();
+        mf_array(i, j, k) = 1.0 * sdf.getFaceMetaData(candidateFaces.front().first);
       });
     }
   }

--- a/Source/EBGeometry_DCEL.hpp
+++ b/Source/EBGeometry_DCEL.hpp
@@ -28,6 +28,21 @@ namespace DCEL {
 using DefaultMetaData = short;
 
 /**
+ * @brief Integer type used for topology cross-references in the index-based DCEL.
+ * @details The mesh owns its vertices, half-edges, and faces in flat arrays; every topological
+ * link (an edge's origin vertex, pair edge, next edge, and face; a vertex's outgoing edge and
+ * incident faces; a face's half-edge) is stored as an index into the corresponding @c MeshT array
+ * rather than as a pointer. This keeps the representation flat and trivially copyable -- the same
+ * structure is used on the host and (after annotation) on the device.
+ */
+using DCELIndex = int;
+
+/**
+ * @brief Sentinel index denoting "no link" (e.g. the pair edge of a boundary half-edge).
+ */
+static constexpr DCELIndex InvalidIndex = -1;
+
+/**
  * @brief Vertex class for navigating a DCEL mesh.
  * @tparam T    Floating-point precision type.
  * @tparam Meta User-defined metadata type.

--- a/Source/EBGeometry_DCEL_Edge.hpp
+++ b/Source/EBGeometry_DCEL_Edge.hpp
@@ -14,12 +14,10 @@
 
 // Std includes
 #include <cstddef>
-#include <memory>
 #include <type_traits>
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
-#include "EBGeometry_DCEL_Face.hpp"
 #include "EBGeometry_Vec.hpp"
 
 namespace EBGeometry {
@@ -30,17 +28,13 @@ namespace DCEL {
  * @brief Class which represents a half-edge in a double-edge connected list
  * (DCEL).
  * @details This class is used in DCEL functionality which stores polygonal
- * surfaces in a mesh. The information contain in an EdgeT object contains the
- * necessary object for logically circulating the inside of a polygon face. This
- * means that a polygon face has a double-connected list of half-edges which
- * circulate the interior of the face. The EdgeT object is such a half-edge; it
- * represents the outgoing half-edge from a vertex, located such that it can be
- * logically represented as a half edge on the "inside" of a polygon face. It
- * contains pointers to the polygon face, vertex, and next half edge It also contains
- * a pointer to the "pair" half edge, i.e. the
- * corresponding half-edge on the other face that shares this edge. Since this
- * class is used with DCEL functionality and signed distance fields, this class
- * also has a signed distance function and thus a "normal vector".
+ * surfaces in a mesh. In the flat, index-based DCEL representation the half-edge is a pure data
+ * holder: it stores a normal vector plus four topological links, each a @c DCELIndex index into
+ * the owning MeshT's flat arrays -- the origin vertex, the pair (twin) half-edge, the next
+ * half-edge around the face, and the owning face. @c InvalidIndex means "no link" (e.g. the pair
+ * of a boundary half-edge). There is no stored previous-edge link. Walking a face's edge loop, and
+ * all geometric queries (signed distance, projection, the end vertex), are performed by MeshT,
+ * which owns the arrays these indices refer to.
  * @note The normal vector is outgoing, i.e. a point x is "outside" if the dot
  * product between n and (x - x0) is positive.
  * @tparam T    Floating-point precision.
@@ -58,73 +52,35 @@ public:
   using Vec3 = Vec3T<T>;
 
   /**
-   * @brief Alias for vertex type
-   */
-  using Vertex = VertexT<T, Meta>;
-
-  /**
    * @brief Alias for edge type
    */
   using Edge = EdgeT<T, Meta>;
 
   /**
-   * @brief Alias for face type
-   */
-  using Face = FaceT<T, Meta>;
-
-  /**
-   * @brief Alias for vertex pointer type
-   */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
-
-  /**
-   * @brief Default constructor. Sets all pointers to zero and vectors to zero
-   * vectors
+   * @brief Default constructor. Sets all indices to InvalidIndex and the normal to the zero vector.
    */
   EdgeT() noexcept = default;
 
   /**
-   * @brief Copy constructor.
-   * @details Copies the normal vector and all four topology pointers (vertex, pair edge, next
-   * edge, face) from the other half-edge. Meta-data (m_metaData) is deliberately NOT copied --
-   * it default-constructs instead; use setMetaData() afterwards if it needs to be populated.
-   * Rationale: same as VertexT's copy constructor -- these pointers are back-references into a
-   * specific mesh's topology (the objects they point to still reference the original edge, not
-   * this copy), so copying them wholesale is not topologically meaningful in general, but is
-   * occasionally useful (e.g. duplicating an edge's geometric/adjacency snapshot).
-   * operator=(const Edge&) has identical semantics.
+   * @brief Copy constructor (defaulted memberwise copy).
+   * @details The half-edge is a flat data holder whose topological links are plain array indices,
+   * so an ordinary memberwise copy is well-defined -- the indices remain valid in a copied MeshT
+   * array. Copies the normal vector, all four topology indices, and the meta-data.
    * @param[in] a_otherEdge Other edge.
    */
-  EdgeT(const Edge& a_otherEdge) noexcept;
+  EdgeT(const Edge& a_otherEdge) noexcept = default;
 
   /**
-   * @brief Move constructor.
-   * @details Unlike the copy constructor, this transfers the entire state (including m_metaData)
-   * from a_otherEdge, since moving relocates a single object's identity. Defaulted (memberwise
-   * move) rather than hand-written: explicitly defaulting is required here since the presence of a
-   * user-declared copy constructor would otherwise suppress the implicitly-generated move
-   * constructor. Not marked noexcept since Meta is an unconstrained template parameter whose move
-   * constructor is not guaranteed to be noexcept.
+   * @brief Move constructor (defaulted memberwise move).
    * @param[in, out] a_otherEdge Other edge.
    */
-  EdgeT(Edge&& a_otherEdge) = default;
+  EdgeT(Edge&& a_otherEdge) noexcept = default;
 
   /**
-   * @brief Partial constructor. Calls the default constructor but sets the
-   * starting vertex.
-   * @param[in] a_vertex Starting vertex.
+   * @brief Partial constructor. Sets the starting-vertex index.
+   * @param[in] a_vertex Index of the starting (origin) vertex.
    */
-  EdgeT(const VertexPtr& a_vertex) noexcept;
+  EdgeT(const DCELIndex a_vertex) noexcept;
 
   /**
    * @brief Destructor (does nothing)
@@ -132,25 +88,20 @@ public:
   ~EdgeT() = default;
 
   /**
-   * @brief Copy assignment operator.
-   * @details Has the same semantics as the copy constructor (including that m_metaData is not
-   * copied; use setMetaData() afterwards if it needs to be populated). See the copy constructor's
-   * documentation for details.
+   * @brief Copy assignment operator (defaulted memberwise copy).
    * @param[in] a_otherEdge Other edge.
    * @return Reference to (*this).
    */
   Edge&
-  operator=(const Edge& a_otherEdge) noexcept;
+  operator=(const Edge& a_otherEdge) noexcept = default;
 
   /**
-   * @brief Move assignment operator.
-   * @details Has the same full-state-transfer semantics as the move constructor (defaulted
-   * memberwise move; see its documentation for why this must be defaulted explicitly).
+   * @brief Move assignment operator (defaulted memberwise move).
    * @param[in, out] a_otherEdge Other edge.
    * @return Reference to (*this).
    */
   Edge&
-  operator=(Edge&& a_otherEdge) = default;
+  operator=(Edge&& a_otherEdge) noexcept = default;
 
   /**
    * @brief Get size (in bytes) of this object.
@@ -160,20 +111,13 @@ public:
   size() const noexcept;
 
   /**
-   * @brief Define function. Sets the starting vertex, edges, and normal vectors
-   * @param[in] a_vertex       Starting vertex
-   * @param[in] a_pairEdge     Pair half-edge
-   * @param[in] a_nextEdge     Next half-edge
+   * @brief Define function. Sets the origin vertex, pair edge, and next edge indices.
+   * @param[in] a_vertex   Index of the origin vertex
+   * @param[in] a_pairEdge Index of the pair (twin) half-edge
+   * @param[in] a_nextEdge Index of the next half-edge around the face
    */
   inline void
-  define(const VertexPtr& a_vertex, const EdgePtr& a_pairEdge, const EdgePtr& a_nextEdge) noexcept;
-
-  /**
-   * @brief Reconcile internal logic
-   * @details Computes normal.
-   */
-  inline void
-  reconcile() noexcept;
+  define(const DCELIndex a_vertex, const DCELIndex a_pairEdge, const DCELIndex a_nextEdge) noexcept;
 
   /**
    * @brief Flip surface normal
@@ -182,32 +126,32 @@ public:
   flipNormal() noexcept;
 
   /**
-   * @brief Set the starting vertex
-   * @param[in] a_vertex Starting vertex
+   * @brief Set the origin-vertex index
+   * @param[in] a_vertex Index of the origin vertex
    */
   inline void
-  setVertex(const VertexPtr& a_vertex) noexcept;
+  setVertex(const DCELIndex a_vertex) noexcept;
 
   /**
-   * @brief Set the pair edge
-   * @param[in] a_pairEdge Pair edge
+   * @brief Set the pair-edge index
+   * @param[in] a_pairEdge Index of the pair edge
    */
   inline void
-  setPairEdge(const EdgePtr& a_pairEdge) noexcept;
+  setPairEdge(const DCELIndex a_pairEdge) noexcept;
 
   /**
-   * @brief Set the next edge
-   * @param[in] a_nextEdge Next edge
+   * @brief Set the next-edge index
+   * @param[in] a_nextEdge Index of the next edge
    */
   inline void
-  setNextEdge(const EdgePtr& a_nextEdge) noexcept;
+  setNextEdge(const DCELIndex a_nextEdge) noexcept;
 
   /**
-   * @brief Set the pointer to this half-edge's face.
-   * @param[in] a_face Face to associate with this half-edge.
+   * @brief Set the index of this half-edge's face.
+   * @param[in] a_face Index of the face to associate with this half-edge.
    */
   inline void
-  setFace(const FacePtr& a_face) noexcept;
+  setFace(const DCELIndex a_face) noexcept;
 
   /**
    * @brief Set the meta-data.
@@ -217,71 +161,32 @@ public:
   setMetaData(const Meta& a_metaData) noexcept;
 
   /**
-   * @brief Get the starting vertex.
-   * @details Returns a shared_ptr obtained by locking the internal weak_ptr (see the class-level
-   * @details note on ownership). Returns nullptr if the vertex has been destroyed, which should
-   * not happen while the owning mesh is alive.
-   * @return Starting vertex, or nullptr.
+   * @brief Get the index of the origin vertex.
+   * @return Origin-vertex index, or InvalidIndex.
    */
-  [[nodiscard]] inline VertexPtr
-  getVertex() noexcept;
-
-  /**
-   * @brief Get the starting vertex (const overload).
-   * @return Starting vertex, or nullptr.
-   */
-  [[nodiscard]] inline VertexPtr
+  [[nodiscard]] inline DCELIndex
   getVertex() const noexcept;
 
   /**
-   * @brief Get the end vertex.
-   * @return The next half-edge's starting vertex, or nullptr.
+   * @brief Get the index of the pair (twin) edge.
+   * @return Pair-edge index, or InvalidIndex.
    */
-  [[nodiscard]] inline VertexPtr
-  getOtherVertex() noexcept;
-
-  /**
-   * @brief Get the end vertex (const overload).
-   * @return The next half-edge's starting vertex, or nullptr.
-   */
-  [[nodiscard]] inline VertexPtr
-  getOtherVertex() const noexcept;
-
-  /**
-   * @brief Get the pair edge.
-   * @return Pair edge, or nullptr.
-   */
-  [[nodiscard]] inline EdgePtr
-  getPairEdge() noexcept;
-
-  /**
-   * @brief Get the pair edge (const overload).
-   * @return Pair edge, or nullptr.
-   */
-  [[nodiscard]] inline EdgePtr
+  [[nodiscard]] inline DCELIndex
   getPairEdge() const noexcept;
 
   /**
-   * @brief Get the next edge.
-   * @return Next edge, or nullptr.
+   * @brief Get the index of the next edge around the face.
+   * @return Next-edge index, or InvalidIndex.
    */
-  [[nodiscard]] inline EdgePtr
-  getNextEdge() noexcept;
-
-  /**
-   * @brief Get the next edge (const overload).
-   * @return Next edge, or nullptr.
-   */
-  [[nodiscard]] inline EdgePtr
+  [[nodiscard]] inline DCELIndex
   getNextEdge() const noexcept;
 
   /**
-   * @brief Compute the normal vector as the average of the face normals on
-   * both sides of this edge.
-   * @return Unit normal vector for this edge.
+   * @brief Get the index of this half-edge's face.
+   * @return Owning-face index, or InvalidIndex.
    */
-  [[nodiscard]] inline Vec3T<T>
-  computeNormal() const noexcept;
+  [[nodiscard]] inline DCELIndex
+  getFace() const noexcept;
 
   /**
    * @brief Get modifiable normal vector.
@@ -298,20 +203,6 @@ public:
   getNormal() const noexcept;
 
   /**
-   * @brief Get this half-edge's face.
-   * @return Owning face, or nullptr.
-   */
-  [[nodiscard]] inline FacePtr
-  getFace() noexcept;
-
-  /**
-   * @brief Get this half-edge's face (const overload).
-   * @return Owning face, or nullptr.
-   */
-  [[nodiscard]] inline FacePtr
-  getFace() const noexcept;
-
-  /**
    * @brief Get meta-data
    * @return m_metaData
    */
@@ -325,28 +216,6 @@ public:
   [[nodiscard]] inline const Meta&
   getMetaData() const noexcept;
 
-  /**
-   * @brief Get the signed distance from a_x0 to this half-edge.
-   * @details Checks whether a_x0 projects onto the edge segment or past one of
-   * the end vertices. If it projects to a vertex, the signed distance to that
-   * vertex is returned. Otherwise the sign is determined from the edge normal.
-   * @param[in] a_x0 Query point.
-   * @return Signed distance; positive on the normal side of the edge.
-   */
-  [[nodiscard]] inline T
-  signedDistance(const Vec3& a_x0) const noexcept;
-
-  /**
-   * @brief Get the squared unsigned distance from a_x0 to this half-edge.
-   * @details Clamps the projection parameter to [0,1] so the closest point is
-   * always on the segment, then returns the squared distance. Faster than
-   * signedDistance().
-   * @param[in] a_x0 Query point.
-   * @return Squared Euclidean distance to the closest point on the edge.
-   */
-  [[nodiscard]] inline T
-  unsignedDistance2(const Vec3& a_x0) const noexcept;
-
 protected:
   /**
    * @brief Normal vector
@@ -354,55 +223,30 @@ protected:
   Vec3 m_normal = Vec3::zeros();
 
   /**
-   * @brief Starting vertex.
-   * @details Stored as a weak_ptr: the vertex is owned by the mesh's own vertex list, and a
-   * plain shared_ptr here (mirrored by the sibling m_pairEdge/m_nextEdge/m_face links, and by
-   * FaceT::m_halfEdge and VertexT::m_outgoingEdge) would form a reference cycle across the
-   * half-edge/face/vertex graph that shared_ptr's reference counting can never collect.
+   * @brief Index of the origin (starting) vertex (InvalidIndex if unset).
    */
-  std::weak_ptr<Vertex> m_vertex;
+  DCELIndex m_vertex = InvalidIndex;
 
   /**
-   * @brief Pair edge. See m_vertex for why this is a weak_ptr.
+   * @brief Index of the pair (twin) half-edge (InvalidIndex for a boundary edge).
    */
-  std::weak_ptr<Edge> m_pairEdge;
+  DCELIndex m_pairEdge = InvalidIndex;
 
   /**
-   * @brief Next edge. See m_vertex for why this is a weak_ptr.
+   * @brief Index of the next half-edge around the face (InvalidIndex if unset).
    */
-  std::weak_ptr<Edge> m_nextEdge;
+  DCELIndex m_nextEdge = InvalidIndex;
 
   /**
-   * @brief Enclosing polygon face. See m_vertex for why this is a weak_ptr.
+   * @brief Index of the enclosing polygon face (InvalidIndex if unset).
    */
-  std::weak_ptr<Face> m_face;
+  DCELIndex m_face = InvalidIndex;
 
   /**
    * @brief Meta-data attached to this edge
-   * @details Value-initialized so that every constructor leaves it in a defined state: for a
-   * fundamental Meta type (e.g. short, int), a member with no initializer and no explicit mention
-   * in a constructor's member-initializer list is left indeterminate, not zero.
+   * @details Value-initialized so that every constructor leaves it in a defined state.
    */
   Meta m_metaData{};
-
-  /**
-   * @brief Returns the parametric projection of a_x0 onto this edge.
-   * @details Parametrizes the edge as x(t) = x1 + (x2-x1)*t and computes t
-   * such that x(t) is the closest point to a_x0. Returns t in (-inf, +inf);
-   * the point is on the segment when t in [0,1].
-   * @param[in] a_x0 Query point.
-   * @return Projection parameter t.
-   */
-  [[nodiscard]] inline T
-  projectPointToEdge(const Vec3& a_x0) const noexcept;
-
-  /**
-   * @brief Get the vector pointing along this edge (from start to end vertex).
-   * @return x2 - x1, where x1 = getVertex()->getPosition() and x2 =
-   * getOtherVertex()->getPosition().
-   */
-  [[nodiscard]] inline Vec3T<T>
-  getX2X1() const noexcept;
 };
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_EdgeImplem.hpp
+++ b/Source/EBGeometry_DCEL_EdgeImplem.hpp
@@ -6,23 +6,16 @@
  * @file   EBGeometry_DCEL_EdgeImplem.hpp
  * @brief  Implementation of EBGeometry_DCEL_Edge.hpp
  * @author Robert Marskar
- * @todo   Include m_face in constructors
  */
 
 #ifndef EBGEOMETRY_DCEL_EDGEIMPLEM_HPP
 #define EBGEOMETRY_DCEL_EDGEIMPLEM_HPP
 
 // Std includes
-#include <algorithm>
-#include <cmath>
 #include <cstddef>
-#include <limits>
-#include <memory>
 
 // Our includes
 #include "EBGeometry_DCEL_Edge.hpp"
-#include "EBGeometry_DCEL_Face.hpp"
-#include "EBGeometry_DCEL_Vertex.hpp"
 #include "EBGeometry_Macros.hpp"
 
 namespace EBGeometry {
@@ -30,34 +23,9 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline EdgeT<T, Meta>::EdgeT(const VertexPtr& a_vertex) noexcept
+inline EdgeT<T, Meta>::EdgeT(const DCELIndex a_vertex) noexcept
 {
   m_vertex = a_vertex;
-}
-
-template <class T, class Meta>
-inline EdgeT<T, Meta>::EdgeT(const Edge& a_otherEdge) noexcept
-{
-  m_normal   = a_otherEdge.m_normal;
-  m_face     = a_otherEdge.m_face;
-  m_vertex   = a_otherEdge.m_vertex;
-  m_pairEdge = a_otherEdge.m_pairEdge;
-  m_nextEdge = a_otherEdge.m_nextEdge;
-}
-
-template <class T, class Meta>
-inline EdgeT<T, Meta>&
-EdgeT<T, Meta>::operator=(const Edge& a_otherEdge) noexcept
-{
-  if (this != &a_otherEdge) {
-    m_normal   = a_otherEdge.m_normal;
-    m_face     = a_otherEdge.m_face;
-    m_vertex   = a_otherEdge.m_vertex;
-    m_pairEdge = a_otherEdge.m_pairEdge;
-    m_nextEdge = a_otherEdge.m_nextEdge;
-  }
-
-  return *this;
 }
 
 template <class T, class Meta>
@@ -69,7 +37,7 @@ EdgeT<T, Meta>::size() const noexcept
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::define(const VertexPtr& a_vertex, const EdgePtr& a_pairEdge, const EdgePtr& a_nextEdge) noexcept
+EdgeT<T, Meta>::define(const DCELIndex a_vertex, const DCELIndex a_pairEdge, const DCELIndex a_nextEdge) noexcept
 {
   m_vertex   = a_vertex;
   m_pairEdge = a_pairEdge;
@@ -85,35 +53,28 @@ EdgeT<T, Meta>::flipNormal() noexcept
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::reconcile() noexcept
-{
-  m_normal = this->computeNormal();
-}
-
-template <class T, class Meta>
-inline void
-EdgeT<T, Meta>::setVertex(const VertexPtr& a_vertex) noexcept
+EdgeT<T, Meta>::setVertex(const DCELIndex a_vertex) noexcept
 {
   m_vertex = a_vertex;
 }
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::setPairEdge(const EdgePtr& a_pairEdge) noexcept
+EdgeT<T, Meta>::setPairEdge(const DCELIndex a_pairEdge) noexcept
 {
   m_pairEdge = a_pairEdge;
 }
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::setNextEdge(const EdgePtr& a_nextEdge) noexcept
+EdgeT<T, Meta>::setNextEdge(const DCELIndex a_nextEdge) noexcept
 {
   m_nextEdge = a_nextEdge;
 }
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::setFace(const FacePtr& a_face) noexcept
+EdgeT<T, Meta>::setFace(const DCELIndex a_face) noexcept
 {
   m_face = a_face;
 }
@@ -123,45 +84,6 @@ inline void
 EdgeT<T, Meta>::setMetaData(const Meta& a_metaData) noexcept
 {
   m_metaData = a_metaData;
-}
-
-template <class T, class Meta>
-inline Vec3T<T>
-EdgeT<T, Meta>::computeNormal() const noexcept
-{
-  // Every half-edge belongs to exactly one face by DCEL invariant, so m_face must be set. The pair
-  // edge (and its face) may legitimately be null for a boundary edge on an open mesh -- that case
-  // is handled gracefully below rather than asserted against.
-  EBGEOMETRY_EXPECT(!m_face.expired());
-
-  Vec3T<T> normal = Vec3T<T>::zeros();
-
-  if (const auto face = m_face.lock()) {
-    const Vec3T<T>& faceNormal = face->getNormal();
-
-    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[0]));
-    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[1]));
-    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[2]));
-
-    normal += faceNormal;
-  }
-  if (const auto pairEdge = m_pairEdge.lock()) {
-    if (const auto pairFace = pairEdge->getFace()) {
-      const Vec3T<T>& pairFaceNormal = pairFace->getNormal();
-
-      EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[0]));
-      EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[1]));
-      EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[2]));
-
-      normal += pairFaceNormal;
-    }
-  }
-
-  const T len = normal.length();
-
-  EBGEOMETRY_EXPECT(len > T(0));
-
-  return (len > std::numeric_limits<T>::epsilon()) ? normal / len : Vec3T<T>::zeros();
 }
 
 template <class T, class Meta>
@@ -179,89 +101,31 @@ EdgeT<T, Meta>::getNormal() const noexcept
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
-EdgeT<T, Meta>::getVertex() noexcept
-{
-  return m_vertex.lock();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
+inline DCELIndex
 EdgeT<T, Meta>::getVertex() const noexcept
 {
-  return m_vertex.lock();
+  return m_vertex;
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
-EdgeT<T, Meta>::getOtherVertex() noexcept
-{
-  EBGEOMETRY_EXPECT(!m_nextEdge.expired());
-
-  return m_nextEdge.lock()->getVertex();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
-EdgeT<T, Meta>::getOtherVertex() const noexcept
-{
-  EBGEOMETRY_EXPECT(!m_nextEdge.expired());
-
-  return m_nextEdge.lock()->getVertex();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-EdgeT<T, Meta>::getPairEdge() noexcept
-{
-  return m_pairEdge.lock();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
+inline DCELIndex
 EdgeT<T, Meta>::getPairEdge() const noexcept
 {
-  return m_pairEdge.lock();
+  return m_pairEdge;
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-EdgeT<T, Meta>::getNextEdge() noexcept
-{
-  return m_nextEdge.lock();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
+inline DCELIndex
 EdgeT<T, Meta>::getNextEdge() const noexcept
 {
-  return m_nextEdge.lock();
+  return m_nextEdge;
 }
 
 template <class T, class Meta>
-inline Vec3T<T>
-EdgeT<T, Meta>::getX2X1() const noexcept
-{
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
-
-  const auto& x1 = this->getVertex()->getPosition();
-  const auto& x2 = this->getOtherVertex()->getPosition();
-
-  return x2 - x1;
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<FaceT<T, Meta>>
-EdgeT<T, Meta>::getFace() noexcept
-{
-  return m_face.lock();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<FaceT<T, Meta>>
+inline DCELIndex
 EdgeT<T, Meta>::getFace() const noexcept
 {
-  return m_face.lock();
+  return m_face;
 }
 
 template <class T, class Meta>
@@ -276,83 +140,6 @@ inline const Meta&
 EdgeT<T, Meta>::getMetaData() const noexcept
 {
   return m_metaData;
-}
-
-template <class T, class Meta>
-inline T
-EdgeT<T, Meta>::projectPointToEdge(const Vec3& a_x0) const noexcept
-{
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
-
-  const auto p    = a_x0 - m_vertex.lock()->getPosition();
-  const auto x2x1 = this->getX2X1();
-
-  EBGEOMETRY_EXPECT(x2x1.dot(x2x1) > T(0));
-
-  return p.dot(x2x1) / (x2x1.dot(x2x1));
-}
-
-template <class T, class Meta>
-inline T
-EdgeT<T, Meta>::signedDistance(const Vec3& a_x0) const noexcept
-{
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
-
-  T retval = std::numeric_limits<T>::max();
-
-  // Project point to edge.
-  const T t = this->projectPointToEdge(a_x0);
-
-  if (t <= T(0.0)) {
-    // Closest point is the starting vertex
-    retval = this->getVertex()->signedDistance(a_x0);
-  }
-  else if (t >= T(1.0)) {
-    // Closest point is the end vertex
-    retval = this->getOtherVertex()->signedDistance(a_x0);
-  }
-  else {
-    // Closest point is the edge itself.
-    const Vec3 x2x1      = this->getX2X1();
-    const Vec3 linePoint = m_vertex.lock()->getPosition() + t * x2x1;
-    const Vec3 delta     = a_x0 - linePoint;
-    const T    dot       = m_normal.dot(delta);
-
-    const int sgn = (dot > T(0.0)) ? 1 : -1;
-
-    retval = sgn * delta.length();
-  }
-
-  return retval;
-}
-
-template <class T, class Meta>
-inline T
-EdgeT<T, Meta>::unsignedDistance2(const Vec3& a_x0) const noexcept
-{
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
-
-  constexpr T zero = 0.0;
-  constexpr T one  = 1.0;
-
-  // Project point to edge and restrict to edge length.
-  const auto t = std::clamp(this->projectPointToEdge(a_x0), zero, one);
-
-  // Compute distance to this edge.
-  const Vec3T<T> x2x1      = this->getX2X1();
-  const Vec3T<T> linePoint = m_vertex.lock()->getPosition() + t * x2x1;
-  const Vec3T<T> delta     = a_x0 - linePoint;
-
-  return delta.dot(delta);
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_Face.hpp
+++ b/Source/EBGeometry_DCEL_Face.hpp
@@ -14,14 +14,10 @@
 
 // Std includes
 #include <cstddef>
-#include <memory>
 #include <type_traits>
-#include <vector>
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
-#include "EBGeometry_DCEL_Edge.hpp"
-#include "EBGeometry_DCEL_Vertex.hpp"
 #include "EBGeometry_Polygon2D.hpp"
 #include "EBGeometry_Vec.hpp"
 
@@ -32,16 +28,13 @@ namespace DCEL {
 /**
  * @brief Class which represents a polygon face in a double-edge connected list
  * (DCEL).
- * @details This class is a polygon face in a DCEL mesh. It contains pointer
- * storage to one of the half-edges that circulate the inside of the polygon
- * face, as well as having a normal vector, a centroid, and an area. This class
- * supports signed distance computations. These computations require algorithms
- * that compute e.g. the winding number of the polygon, or the number of times a
- * ray cast passes through it. Thus, one of its central features is that it can
- * be embedded in 2D by projecting it along the cardinal direction of its normal
- * vector. To be fully consistent with a DCEL structure the class stores a
- * reference to one of its half edges, but for performance reasons it also stores
- * references to the other half edges.
+ * @details This class is a polygon face in a DCEL mesh. In the flat, index-based DCEL
+ * representation it is a data holder: it stores a normal vector, a centroid, an area, the index of
+ * one of the half-edges circulating the inside of the polygon (@c DCELIndex into the owning
+ * MeshT's edge array; @c InvalidIndex if unset), and -- for signed-distance evaluation -- the 2D
+ * embedding of the polygon (stored by value) together with the inside/outside test algorithm. All
+ * traversal of the face's half-edge loop and all geometric queries are performed by MeshT, which
+ * owns the arrays the half-edge index refers to.
  * @note To compute the distance from a point to the face one must determine if
  * the point projects "inside" or "outside" the polygon. There are several
  * algorithms for this, and by default this class uses a crossing number
@@ -61,75 +54,41 @@ public:
   using Vec3 = Vec3T<T>;
 
   /**
-   * @brief Alias for vertex type
-   */
-  using Vertex = VertexT<T, Meta>;
-
-  /**
-   * @brief Alias for edge type
-   */
-  using Edge = EdgeT<T, Meta>;
-
-  /**
    * @brief Alias for face type
    */
   using Face = FaceT<T, Meta>;
 
   /**
-   * @brief Alias for vertex pointer type
+   * @brief Alias for the inside/outside test algorithm type.
    */
-  using VertexPtr = std::shared_ptr<Vertex>;
+  using InsideOutsideAlgorithm = typename Polygon2D<T>::InsideOutsideAlgorithm;
 
   /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
-
-  /**
-   * @brief Alias for edge iterator
-   */
-  using EdgeIterator = EdgeIteratorT<T, Meta>;
-
-  /**
-   * @brief Default constructor. Sets the half-edge to zero and the
-   * inside/outside algorithm to crossing number algorithm
+   * @brief Default constructor. Leaves the half-edge index unset and the inside/outside algorithm
+   * at the crossing-number algorithm.
    */
   FaceT() = default;
 
   /**
    * @brief Partial constructor. Calls default constructor but associates a
-   * half-edge
-   * @param[in] a_edge Half-edge
+   * half-edge index.
+   * @param[in] a_edge Index of the half-edge.
    */
-  FaceT(const EdgePtr& a_edge);
+  FaceT(const DCELIndex a_edge);
 
   /**
-   * @brief Copy constructor.
-   * @details Copies the normal vector, half-edge pointer, centroid, and area from the other face.
-   * Meta-data (m_metaData), the 2D embedding (m_poly2), and the inside/outside algorithm
-   * (m_poly2Algorithm) are deliberately NOT copied -- they default-construct instead; use
-   * setMetaData() and reconcile() afterwards if they need to be (re)populated. Rationale: m_halfEdge
-   * is a back-reference into a specific mesh's topology (same as VertexT/EdgeT's copy constructors),
-   * so copying it wholesale is not topologically meaningful in general, but is occasionally useful.
-   * m_normal, m_centroid, and m_area are plain geometric/cached values with no such concern, so they
-   * are copied like any other value. operator=(const Face&) has identical semantics.
+   * @brief Copy constructor (defaulted memberwise copy).
+   * @details The face is a flat data holder: its half-edge link is a plain array index, and the 2D
+   * embedding (m_poly2) is stored by value, so an ordinary memberwise copy carries everything --
+   * normal, centroid, area, half-edge index, meta-data, the 2D embedding, and the inside/outside
+   * algorithm. This removes the old "copy silently drops m_poly2" hazard that the previous
+   * shared_ptr-based storage had.
    * @param[in] a_otherFace Other face to copy from.
    */
-  FaceT(const Face& a_otherFace);
+  FaceT(const Face& a_otherFace) = default;
 
   /**
-   * @brief Move constructor.
-   * @details Unlike the copy constructor, this transfers the entire state (including m_metaData,
-   * m_poly2, and m_poly2Algorithm) from a_otherFace, since moving relocates a single object's
-   * identity. Defaulted (memberwise move) rather than hand-written: explicitly defaulting is
-   * required here since the presence of a user-declared copy constructor would otherwise suppress
-   * the implicitly-generated move constructor. Not marked noexcept since Meta is an unconstrained
-   * template parameter whose move constructor is not guaranteed to be noexcept.
+   * @brief Move constructor (defaulted memberwise move).
    * @param[in, out] a_otherFace Other face.
    */
   FaceT(Face&& a_otherFace) = default;
@@ -140,18 +99,15 @@ public:
   ~FaceT() = default;
 
   /**
-   * @brief Copy assignment operator.
-   * @details Has the same semantics as the copy constructor; see its documentation.
+   * @brief Copy assignment operator (defaulted memberwise copy).
    * @param[in] a_otherFace Other face.
    * @return Reference to (*this).
    */
   Face&
-  operator=(const Face& a_otherFace) noexcept;
+  operator=(const Face& a_otherFace) = default;
 
   /**
-   * @brief Move assignment operator.
-   * @details Has the same full-state-transfer semantics as the move constructor (defaulted
-   * memberwise move; see its documentation for why this must be defaulted explicitly).
+   * @brief Move assignment operator (defaulted memberwise move).
    * @param[in, out] a_otherFace Other face.
    * @return Reference to (*this).
    */
@@ -159,33 +115,12 @@ public:
   operator=(Face&& a_otherFace) = default;
 
   /**
-   * @brief Define function which sets the normal vector and half-edge
+   * @brief Define function which sets the normal vector and half-edge index
    * @param[in] a_normal Normal vector
-   * @param[in] a_edge   Half edge
+   * @param[in] a_edge   Index of the half-edge
    */
   inline void
-  define(const Vec3& a_normal, const EdgePtr& a_edge) noexcept;
-
-  /**
-   * @brief Reconcile face. This will compute the normal vector, area, centroid,
-   * and the 2D embedding of the polygon
-   * @note "Everything" must be set before doing this, i.e. the face must be
-   * complete with half edges and there can be no dangling edges.
-   */
-  inline void
-  reconcile();
-
-  /**
-   * @brief Compute the 2D embedding of this polygon from the current normal vector and topology,
-   * without touching the normal vector, centroid, or area.
-   * @details Unlike reconcile(), this does not recompute the normal vector, so it is safe to call
-   * after manually restoring a normal vector (e.g. when deep-copying a face and preserving whatever
-   * normal it had, including one set via flipNormal()) without having that normal silently
-   * overwritten by a geometrically-derived one.
-   * @note The face must be complete with half edges and there can be no dangling edges.
-   */
-  inline void
-  computePolygon2D();
+  define(const Vec3& a_normal, const DCELIndex a_edge) noexcept;
 
   /**
    * @brief Flip the normal vector
@@ -194,11 +129,17 @@ public:
   flipNormal() noexcept;
 
   /**
-   * @brief Set the half edge
-   * @param[in] a_halfEdge Half edge
+   * @brief Normalize the normal vector, ensuring it has a length of 1
    */
   inline void
-  setHalfEdge(const EdgePtr& a_halfEdge) noexcept;
+  normalizeNormalVector() noexcept;
+
+  /**
+   * @brief Set the half-edge index
+   * @param[in] a_halfEdge Index of the half-edge
+   */
+  inline void
+  setHalfEdge(const DCELIndex a_halfEdge) noexcept;
 
   /**
    * @brief Set the meta-data.
@@ -208,30 +149,25 @@ public:
   setMetaData(const Meta& a_metaData) noexcept;
 
   /**
+   * @brief Set the 2D embedding of this polygon.
+   * @param[in] a_poly2 2D embedding.
+   */
+  inline void
+  setPolygon2D(const Polygon2D<T>& a_poly2) noexcept;
+
+  /**
    * @brief Set the inside/outside algorithm when determining if a point projects
    * to the inside or outside of the polygon.
    * @param[in] a_algorithm Desired algorithm
-   * @note See CD_DCELAlgorithms.H for options (and CD_DCELPolyImplem.H for how
-   * the algorithms operate).
    */
   inline void
-  setInsideOutsideAlgorithm(typename Polygon2D<T>::InsideOutsideAlgorithm& a_algorithm) noexcept;
+  setInsideOutsideAlgorithm(const InsideOutsideAlgorithm a_algorithm) noexcept;
 
   /**
-   * @brief Get the starting half-edge.
-   * @details Returns a shared_ptr obtained by locking the internal weak_ptr (see the class-level
-   * note on ownership near m_halfEdge). Returns nullptr if the edge has been destroyed, which
-   * should not happen while the owning mesh is alive.
-   * @return Starting half-edge, or nullptr.
+   * @brief Get the index of the starting half-edge.
+   * @return Half-edge index, or InvalidIndex.
    */
-  [[nodiscard]] inline EdgePtr
-  getHalfEdge() noexcept;
-
-  /**
-   * @brief Get the starting half-edge (const overload).
-   * @return Starting half-edge, or nullptr.
-   */
-  [[nodiscard]] inline EdgePtr
+  [[nodiscard]] inline DCELIndex
   getHalfEdge() const noexcept;
 
   /**
@@ -279,14 +215,14 @@ public:
   getNormal() const noexcept;
 
   /**
-   * @brief Get modifiable polygon area (computed during reconcile()).
+   * @brief Get modifiable polygon area (computed during MeshT::reconcile()).
    * @return Reference to m_area.
    */
   [[nodiscard]] inline T&
   getArea() noexcept;
 
   /**
-   * @brief Get immutable polygon area (computed during reconcile()).
+   * @brief Get immutable polygon area (computed during MeshT::reconcile()).
    * @return Const reference to m_area.
    */
   [[nodiscard]] inline const T&
@@ -307,77 +243,20 @@ public:
   getMetaData() const noexcept;
 
   /**
-   * @brief Compute the signed distance to a point.
-   * @param[in] a_x0 Point in space
-   * @details This algorithm operates by checking if the input point projects to
-   * the inside of the polygon. If it does then the distance is just the
-   * projected distance onto the polygon plane and the sign is well-defined.
-   * Otherwise, we check the distance to the edges of the polygon.
-   * @return Signed distance to the face; sign determined by normal direction.
+   * @brief Get the 2D embedding of this polygon.
+   * @return Const reference to the 2D embedding.
    */
-  [[nodiscard]] inline T
-  signedDistance(const Vec3& a_x0) const noexcept;
+  [[nodiscard]] inline const Polygon2D<T>&
+  getPolygon2D() const noexcept;
 
   /**
-   * @brief Compute the unsigned squared distance to a point.
-   * @param[in] a_x0 Point in space
-   * @details This algorithm operates by checking if the input point projects to
-   * the inside of the polygon. If it does then the distance is just the
-   * projected distance onto the polygon plane. Otherwise, we check the distance
-   * to the edges of the polygon.
-   * @return Squared unsigned distance to the face.
+   * @brief Get the inside/outside test algorithm for this face.
+   * @return Inside/outside algorithm.
    */
-  [[nodiscard]] inline T
-  unsignedDistance2(const Vec3& a_x0) const noexcept;
-
-  /**
-   * @brief Return the coordinates of all the vertices on this polygon.
-   * @details This builds a list of all the vertex coordinates and returns it.
-   * @return Vector of 3D coordinates of all vertices on this polygon.
-   */
-  [[nodiscard]] inline std::vector<Vec3T<T>>
-  getAllVertexCoordinates() const;
-
-  /**
-   * @brief Return all the vertices on this polygon
-   * @details This builds a list of all the vertices and returns it.
-   * @return Vector of shared pointers to all vertices on this polygon.
-   */
-  [[nodiscard]] inline std::vector<VertexPtr>
-  gatherVertices() const;
-
-  /**
-   * @brief Return all the half-edges on this polygon
-   * @details This builds a list of all the edges and returns it.
-   * @return Vector of shared pointers to all half-edges on this polygon.
-   */
-  [[nodiscard]] inline std::vector<EdgePtr>
-  gatherEdges() const;
-
-  /**
-   * @brief Get the lower-left-most coordinate of this polygon face
-   * @return Lower-left-most coordinate of this polygon face.
-   */
-  [[nodiscard]] inline Vec3T<T>
-  getSmallestCoordinate() const;
-
-  /**
-   * @brief Get the upper-right-most coordinate of this polygon face
-   * @return Upper-right-most coordinate of this polygon face.
-   */
-  [[nodiscard]] inline Vec3T<T>
-  getHighestCoordinate() const;
+  [[nodiscard]] inline InsideOutsideAlgorithm
+  getInsideOutsideAlgorithm() const noexcept;
 
 protected:
-  /**
-   * @brief This polygon's half-edge. A valid face will always have this set.
-   * @details Stored as a weak_ptr: the edge is owned by the mesh's own edge list, and a plain
-   * shared_ptr here would form a reference cycle with EdgeT::m_face (and, transitively, with
-   * EdgeT::m_nextEdge/m_pairEdge and VertexT::m_outgoingEdge) that shared_ptr's reference
-   * counting can never collect.
-   */
-  std::weak_ptr<Edge> m_halfEdge;
-
   /**
    * @brief Polygon face normal vector
    */
@@ -389,69 +268,31 @@ protected:
   Vec3 m_centroid = Vec3::zeros();
 
   /**
-   * @brief Meta-data attached to this face
-   * @details Value-initialized so that every constructor leaves it in a defined state: for a
-   * fundamental Meta type (e.g. short, int), a member with no initializer and no explicit mention
-   * in a constructor's member-initializer list is left indeterminate, not zero.
-   */
-  Meta m_metaData{};
-
-  /**
-   * @brief Cached polygon face area (stored by reconcile()).
+   * @brief Cached polygon face area (stored by MeshT::reconcile()).
    */
   T m_area{T(0)};
 
   /**
-   * @brief 2D embedding of this polygon. This is the 2D view of the current
-   * object projected along its normal vector cardinal.
+   * @brief Index of one of this polygon's half-edges. A valid face always has this set.
    */
-  std::shared_ptr<Polygon2D<T>> m_poly2 = nullptr;
+  DCELIndex m_halfEdge = InvalidIndex;
+
+  /**
+   * @brief Meta-data attached to this face
+   * @details Value-initialized so that every constructor leaves it in a defined state.
+   */
+  Meta m_metaData{};
+
+  /**
+   * @brief 2D embedding of this polygon, stored by value. This is the 2D view of the current
+   * object projected along its normal vector cardinal. Populated by MeshT during reconcile().
+   */
+  Polygon2D<T> m_poly2;
 
   /**
    * @brief Algorithm for inside/outside tests
    */
-  typename Polygon2D<T>::InsideOutsideAlgorithm m_poly2Algorithm = Polygon2D<T>::InsideOutsideAlgorithm::CrossingNumber;
-
-  /**
-   * @brief Compute the centroid position of this polygon
-   */
-  inline void
-  computeCentroid();
-
-  /**
-   * @brief Compute the normal position of this polygon
-   */
-  inline void
-  computeNormal();
-
-  /**
-   * @brief Compute the area of this polygon and cache it in m_area.
-   */
-  inline void
-  computeArea();
-
-  /**
-   * @brief Normalize the normal vector, ensuring it has a length of 1
-   */
-  inline void
-  normalizeNormalVector() noexcept;
-
-  /**
-   * @brief Compute the projection of a point onto the polygon face plane
-   * @param[in] a_p Point in space
-   * @return Projected point in the face plane.
-   */
-  [[nodiscard]] inline Vec3T<T>
-  projectPointIntoFacePlane(const Vec3& a_p) const noexcept;
-
-  /**
-   * @brief Check if a point projects to inside or outside the polygon face
-   * @param[in] a_p Point in space
-   * @return Returns true if a_p projects to inside the polygon and false
-   * otherwise.
-   */
-  [[nodiscard]] inline bool
-  isPointInsideFace(const Vec3& a_p) const noexcept;
+  InsideOutsideAlgorithm m_poly2Algorithm = Polygon2D<T>::InsideOutsideAlgorithm::CrossingNumber;
 };
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_FaceImplem.hpp
+++ b/Source/EBGeometry_DCEL_FaceImplem.hpp
@@ -12,71 +12,34 @@
 #define EBGEOMETRY_DCEL_FACEIMPLEM_HPP
 
 // Std includes
-#include <cmath>
 #include <cstddef>
 #include <limits>
-#include <memory>
-#include <vector>
 
 // Our includes
 #include "EBGeometry_DCEL_Face.hpp"
-#include "EBGeometry_DCEL_Iterator.hpp"
+#include "EBGeometry_Macros.hpp"
 
 namespace EBGeometry {
 
 namespace DCEL {
 
 template <class T, class Meta>
-inline FaceT<T, Meta>::FaceT(const EdgePtr& a_edge)
+inline FaceT<T, Meta>::FaceT(const DCELIndex a_edge)
 {
   m_halfEdge = a_edge;
 }
 
 template <class T, class Meta>
-inline FaceT<T, Meta>::FaceT(const Face& a_otherFace)
-{
-  m_normal   = a_otherFace.m_normal;
-  m_halfEdge = a_otherFace.m_halfEdge;
-  m_centroid = a_otherFace.m_centroid;
-  m_area     = a_otherFace.m_area;
-}
-
-template <class T, class Meta>
-inline FaceT<T, Meta>&
-FaceT<T, Meta>::operator=(const Face& a_otherFace) noexcept
-{
-  if (this != &a_otherFace) {
-    m_normal   = a_otherFace.m_normal;
-    m_halfEdge = a_otherFace.m_halfEdge;
-    m_centroid = a_otherFace.m_centroid;
-    m_area     = a_otherFace.m_area;
-  }
-
-  return *this;
-}
-
-template <class T, class Meta>
 inline void
-FaceT<T, Meta>::define(const Vec3& a_normal, const EdgePtr& a_edge) noexcept
+FaceT<T, Meta>::define(const Vec3& a_normal, const DCELIndex a_edge) noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[2]));
 
-  // a_edge == nullptr is valid here (e.g. a freshly-created face not yet wired into the mesh).
+  // a_edge == InvalidIndex is valid here (e.g. a freshly-created face not yet wired into the mesh).
   m_normal   = a_normal;
   m_halfEdge = a_edge;
-}
-
-template <class T, class Meta>
-inline void
-FaceT<T, Meta>::reconcile()
-{
-  this->computeNormal();
-  this->normalizeNormalVector();
-  this->computeCentroid();
-  this->computeArea();
-  this->computePolygon2D();
 }
 
 template <class T, class Meta>
@@ -84,20 +47,6 @@ inline void
 FaceT<T, Meta>::flipNormal() noexcept
 {
   m_normal = -m_normal;
-}
-
-template <class T, class Meta>
-inline void
-FaceT<T, Meta>::setHalfEdge(const EdgePtr& a_halfEdge) noexcept
-{
-  m_halfEdge = a_halfEdge;
-}
-
-template <class T, class Meta>
-inline void
-FaceT<T, Meta>::setMetaData(const Meta& a_metaData) noexcept
-{
-  m_metaData = a_metaData;
 }
 
 template <class T, class Meta>
@@ -111,91 +60,30 @@ FaceT<T, Meta>::normalizeNormalVector() noexcept
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::setInsideOutsideAlgorithm(typename Polygon2D<T>::InsideOutsideAlgorithm& a_algorithm) noexcept
+FaceT<T, Meta>::setHalfEdge(const DCELIndex a_halfEdge) noexcept
+{
+  m_halfEdge = a_halfEdge;
+}
+
+template <class T, class Meta>
+inline void
+FaceT<T, Meta>::setMetaData(const Meta& a_metaData) noexcept
+{
+  m_metaData = a_metaData;
+}
+
+template <class T, class Meta>
+inline void
+FaceT<T, Meta>::setPolygon2D(const Polygon2D<T>& a_poly2) noexcept
+{
+  m_poly2 = a_poly2;
+}
+
+template <class T, class Meta>
+inline void
+FaceT<T, Meta>::setInsideOutsideAlgorithm(const InsideOutsideAlgorithm a_algorithm) noexcept
 {
   m_poly2Algorithm = a_algorithm;
-}
-
-template <class T, class Meta>
-inline void
-FaceT<T, Meta>::computeCentroid()
-{
-  m_centroid = Vec3::zeros();
-
-  const auto vertices = this->gatherVertices();
-
-  EBGEOMETRY_EXPECT(!vertices.empty());
-
-  for (const auto& v : vertices) {
-    m_centroid += v->getPosition();
-  }
-
-  m_centroid = m_centroid / vertices.size();
-}
-
-template <class T, class Meta>
-inline void
-FaceT<T, Meta>::computeNormal()
-{
-  const auto vertices = this->gatherVertices();
-
-  const size_t N = vertices.size();
-
-  // A polygon face needs at least 3 vertices to span a plane.
-  EBGEOMETRY_EXPECT(N >= 3);
-
-  // To compute the normal vector we find three vertices in this polygon face.
-  // They span a plane, and we just compute the normal vector of that plane.
-  for (size_t i = 0; i < N; i++) {
-    const auto& x0 = vertices[i]->getPosition();
-    const auto& x1 = vertices[(i + 1) % N]->getPosition();
-    const auto& x2 = vertices[(i + 2) % N]->getPosition();
-
-    m_normal = (x2 - x0).cross(x2 - x1);
-
-    if (m_normal.length() > T(0.0)) {
-      break; // Found one.
-    }
-  }
-
-  // If every vertex triple was degenerate (collinear/coincident points), m_normal is still zero
-  // here and normalizeNormalVector() below would divide by zero.
-  EBGEOMETRY_EXPECT(m_normal.length() > std::numeric_limits<T>::epsilon());
-
-  this->normalizeNormalVector();
-}
-
-template <class T, class Meta>
-inline void
-FaceT<T, Meta>::computePolygon2D()
-{
-  m_poly2 = std::make_shared<Polygon2D<T>>(m_normal, this->getAllVertexCoordinates());
-}
-
-template <class T, class Meta>
-inline void
-FaceT<T, Meta>::computeArea()
-{
-  T area = 0.0;
-
-  // This computes the area of any N-side polygon.
-  const auto   vertices = this->gatherVertices();
-  const size_t N        = vertices.size();
-
-  EBGEOMETRY_EXPECT(N >= 3);
-
-  // Sum over ALL N edges, including the wraparound edge from vertices[N-1] back to vertices[0] --
-  // this is the standard cross-product/shoelace formula for a planar polygon's area relative to
-  // the origin, and omitting the wraparound edge silently produces a wrong (generally too large or
-  // too small) area for any polygon that doesn't happen to pass through the origin.
-  for (size_t i = 0; i < N; i++) {
-    const auto& v1 = vertices[i]->getPosition();
-    const auto& v2 = vertices[(i + 1) % N]->getPosition();
-
-    area += m_normal.dot(v2.cross(v1));
-  }
-
-  m_area = T(0.5) * std::abs(area);
 }
 
 template <class T, class Meta>
@@ -255,17 +143,10 @@ FaceT<T, Meta>::getNormal() const noexcept
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-FaceT<T, Meta>::getHalfEdge() noexcept
-{
-  return m_halfEdge.lock();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
+inline DCELIndex
 FaceT<T, Meta>::getHalfEdge() const noexcept
 {
-  return m_halfEdge.lock();
+  return m_halfEdge;
 }
 
 template <class T, class Meta>
@@ -283,180 +164,17 @@ FaceT<T, Meta>::getMetaData() const noexcept
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<VertexT<T, Meta>>>
-FaceT<T, Meta>::gatherVertices() const
+inline const Polygon2D<T>&
+FaceT<T, Meta>::getPolygon2D() const noexcept
 {
-  std::vector<VertexPtr> vertices;
-  vertices.reserve(3);
-
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-    vertices.emplace_back(edge->getVertex());
-  }
-
-  return vertices;
+  return m_poly2;
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<EdgeT<T, Meta>>>
-FaceT<T, Meta>::gatherEdges() const
+inline typename FaceT<T, Meta>::InsideOutsideAlgorithm
+FaceT<T, Meta>::getInsideOutsideAlgorithm() const noexcept
 {
-  std::vector<EdgePtr> edges;
-  edges.reserve(3);
-
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-
-    edges.emplace_back(edge);
-  }
-
-  return edges;
-}
-
-template <class T, class Meta>
-inline std::vector<Vec3T<T>>
-FaceT<T, Meta>::getAllVertexCoordinates() const
-{
-  std::vector<Vec3> ret;
-  ret.reserve(3);
-
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-
-    ret.emplace_back(edge->getVertex()->getPosition());
-  }
-
-  return ret;
-}
-
-template <class T, class Meta>
-inline Vec3T<T>
-FaceT<T, Meta>::getSmallestCoordinate() const
-{
-  const auto coords = this->getAllVertexCoordinates();
-
-  EBGEOMETRY_EXPECT(!coords.empty());
-
-  auto minCoord = coords.front();
-
-  for (const auto& c : coords) {
-    minCoord = min(minCoord, c);
-  }
-
-  return minCoord;
-}
-
-template <class T, class Meta>
-inline Vec3T<T>
-FaceT<T, Meta>::getHighestCoordinate() const
-{
-  const auto coords = this->getAllVertexCoordinates();
-
-  EBGEOMETRY_EXPECT(!coords.empty());
-
-  auto maxCoord = coords.front();
-
-  for (const auto& c : coords) {
-    maxCoord = max(maxCoord, c);
-  }
-
-  return maxCoord;
-}
-
-template <class T, class Meta>
-inline Vec3T<T>
-FaceT<T, Meta>::projectPointIntoFacePlane(const Vec3& a_p) const noexcept
-{
-  EBGEOMETRY_EXPECT(std::isfinite(a_p[0]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_p[1]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_p[2]));
-
-  return a_p - m_normal * (m_normal.dot(a_p - m_centroid));
-}
-
-template <class T, class Meta>
-inline bool
-FaceT<T, Meta>::isPointInsideFace(const Vec3& a_p) const noexcept
-{
-  EBGEOMETRY_EXPECT(m_poly2 != nullptr);
-
-  const Vec3 p = this->projectPointIntoFacePlane(a_p);
-
-  return m_poly2->isPointInside(p, m_poly2Algorithm);
-}
-
-template <class T, class Meta>
-inline T
-FaceT<T, Meta>::signedDistance(const Vec3& a_x0) const noexcept
-{
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_halfEdge.expired());
-
-  T retval = std::numeric_limits<T>::infinity();
-
-  const bool inside = this->isPointInsideFace(a_x0);
-
-  if (inside) {
-    retval = m_normal.dot(a_x0 - m_centroid);
-  }
-  else {
-    const EdgePtr startEdge = m_halfEdge.lock();
-    EdgePtr       cur       = startEdge;
-
-    while (true) {
-      const T curDist = cur->signedDistance(a_x0);
-
-      retval = (std::abs(curDist) < std::abs(retval)) ? curDist : retval;
-
-      cur = cur->getNextEdge();
-
-      if (cur == nullptr || cur == startEdge) {
-        break;
-      }
-    }
-  }
-
-  return retval;
-}
-
-template <class T, class Meta>
-inline T
-FaceT<T, Meta>::unsignedDistance2(const Vec3& a_x0) const noexcept
-{
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_halfEdge.expired());
-
-  T retval = std::numeric_limits<T>::infinity();
-
-  const bool inside = this->isPointInsideFace(a_x0);
-
-  if (inside) {
-    const T normDist = m_normal.dot(a_x0 - m_centroid);
-
-    retval = normDist * normDist;
-  }
-  else {
-    const EdgePtr startEdge = m_halfEdge.lock();
-    EdgePtr       cur       = startEdge;
-
-    while (true) {
-      const T curDist2 = cur->unsignedDistance2(a_x0);
-
-      retval = (curDist2 < retval) ? curDist2 : retval;
-
-      cur = cur->getNextEdge();
-
-      if (cur == nullptr || cur == startEdge) {
-        break;
-      }
-    }
-  }
-
-  return retval;
+  return m_poly2Algorithm;
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_Iterator.hpp
+++ b/Source/EBGeometry_DCEL_Iterator.hpp
@@ -12,11 +12,12 @@
 #define EBGEOMETRY_DCEL_ITERATOR_HPP
 
 // Std includes
-#include <memory>
 #include <type_traits>
+#include <vector>
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
+#include "EBGeometry_DCEL_Edge.hpp"
 
 namespace EBGeometry {
 
@@ -25,12 +26,14 @@ namespace DCEL {
 /**
  * @brief Class which makes it easier to iterate through DCEL edges
  * @details Iterates the half-edge loop bounding a polygon face (or starting from an arbitrary
- * half-edge), following EdgeT::getNextEdge() until either the loop returns to its starting edge
- * (a well-formed, closed face) or a null next-edge is reached (an incomplete/open half-edge chain).
- * Typical usage:
+ * half-edge index), following EdgeT::getNextEdge() until either the loop returns to its starting
+ * edge (a well-formed, closed face) or an InvalidIndex next-edge is reached (an incomplete/open
+ * half-edge chain). This is an index cursor over a MeshT's flat edge array: it holds a pointer to
+ * that array plus the starting and current half-edge indices, and dereferences to the current
+ * @c DCELIndex.
  * @code{.cpp}
- * for (EdgeIterator it(someFace); it.ok(); ++it) {
- *   const EdgePtr& edge = it();
+ * for (EdgeIterator it(mesh.getEdges(), startEdgeIndex); it.ok(); ++it) {
+ *   const DCELIndex edge = it();
  *   // ... use edge ...
  * }
  * @endcode
@@ -44,66 +47,22 @@ class EdgeIteratorT
 
 public:
   /**
-   * @brief Alias for DCEL vertex type
-   */
-  using Vertex = VertexT<T, Meta>;
-
-  /**
    * @brief Alias for DCEL edge type
    */
   using Edge = EdgeT<T, Meta>;
 
   /**
-   * @brief Alias for DCEL face type
-   */
-  using Face = FaceT<T, Meta>;
-
-  /**
-   * @brief Alias for vertex pointer
-   */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer
-   */
-  using FacePtr = std::shared_ptr<Face>;
-
-  /**
-   * @brief Default construction is not allowed. Use one of the full constructors
+   * @brief Default construction is not allowed. Use the full constructor.
    */
   EdgeIteratorT() = delete;
 
   /**
-   * @brief Constructor, taking a face as argument. The iterator begins at the
-   * half-edge pointer contained in the face
-   * @param[in] a_face DCEL polygon face
-   * @note This constructor will will iterate through the half-edges in the
-   * polygon face.
+   * @brief Constructor, taking the mesh's edge array and a starting half-edge index.
+   * @param[in] a_edges     Reference to the mesh's flat edge array. Must outlive the iterator.
+   * @param[in] a_startEdge Starting half-edge index. May be InvalidIndex (ok() will then
+   * immediately return false).
    */
-  EdgeIteratorT(Face& a_face) noexcept;
-
-  /**
-   * @brief Constructor, taking a face as argument. The iterator begins at the
-   * half-edge pointer contained in the face
-   * @param[in] a_face DCEL polygon face
-   * @note This constructor will will iterate through the half-edges in the
-   * polygon face.
-   */
-  EdgeIteratorT(const Face& a_face) noexcept;
-
-  /**
-   * @brief Constructor, taking an arbitrary starting half-edge directly (rather than a face's own
-   * half-edge). Useful for iterating a half-edge loop when only an edge -- not its face -- is
-   * available.
-   * @param[in] a_startEdge Starting half-edge. May be nullptr (ok() will then immediately return
-   * false).
-   */
-  EdgeIteratorT(const EdgePtr& a_startEdge) noexcept;
+  EdgeIteratorT(const std::vector<Edge>& a_edges, const DCELIndex a_startEdge) noexcept;
 
   /**
    * @brief Copy constructor.
@@ -139,22 +98,15 @@ public:
   operator=(EdgeIteratorT&& a_other) noexcept = default;
 
   /**
-   * @brief Operator returning a pointer to the current half-edge
-   * @return Reference to the shared pointer to the current half-edge.
+   * @brief Operator returning the current half-edge index.
+   * @return Index of the current half-edge.
    */
-  [[nodiscard]] inline EdgePtr&
-  operator()() noexcept;
-
-  /**
-   * @brief Operator returning a pointer to the current half-edge (const overload)
-   * @return Const reference to the shared pointer to the current half-edge.
-   */
-  [[nodiscard]] inline const EdgePtr&
+  [[nodiscard]] inline DCELIndex
   operator()() const noexcept;
 
   /**
    * @brief Reset function for the iterator. This resets the iterator so that it
-   * begins from the starting half-edge
+   * begins from the starting half-edge index.
    */
   inline void
   reset() noexcept;
@@ -167,7 +119,7 @@ public:
 
   /**
    * @brief Function which checks if the iteration can be continued.
-   * @return True if the iterator has not completed a full loop and the current edge is not null.
+   * @return True if the iterator has not completed a full loop and the current edge index is valid.
    */
   [[nodiscard]] inline bool
   ok() const noexcept;
@@ -179,14 +131,19 @@ protected:
   bool m_fullLoop = false;
 
   /**
-   * @brief Starting half-edge
+   * @brief Starting half-edge index
    */
-  std::shared_ptr<Edge> m_startEdge = nullptr;
+  DCELIndex m_startEdge = InvalidIndex;
 
   /**
-   * @brief Current half-edge
+   * @brief Current half-edge index
    */
-  std::shared_ptr<Edge> m_curEdge = nullptr;
+  DCELIndex m_curEdge = InvalidIndex;
+
+  /**
+   * @brief Pointer to the mesh's flat edge array (not owned).
+   */
+  const std::vector<Edge>* m_edges = nullptr;
 };
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_IteratorImplem.hpp
+++ b/Source/EBGeometry_DCEL_IteratorImplem.hpp
@@ -12,13 +12,11 @@
 #define EBGEOMETRY_DCEL_ITERATORIMPLEM_HPP
 
 // Std includes
-#include <memory>
+#include <vector>
 
 // Our includes
 #include "EBGeometry_DCEL_Edge.hpp"
-#include "EBGeometry_DCEL_Face.hpp"
 #include "EBGeometry_DCEL_Iterator.hpp"
-#include "EBGeometry_DCEL_Vertex.hpp"
 #include "EBGeometry_Macros.hpp"
 
 namespace EBGeometry {
@@ -26,35 +24,15 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline EdgeIteratorT<T, Meta>::EdgeIteratorT(Face& a_face) noexcept
+inline EdgeIteratorT<T, Meta>::EdgeIteratorT(const std::vector<Edge>& a_edges, const DCELIndex a_startEdge) noexcept
 {
-  m_startEdge = a_face.getHalfEdge();
-  m_curEdge   = m_startEdge;
-}
-
-template <class T, class Meta>
-inline EdgeIteratorT<T, Meta>::EdgeIteratorT(const Face& a_face) noexcept
-{
-  m_startEdge = a_face.getHalfEdge();
-  m_curEdge   = m_startEdge;
-}
-
-template <class T, class Meta>
-inline EdgeIteratorT<T, Meta>::EdgeIteratorT(const EdgePtr& a_startEdge) noexcept
-{
+  m_edges     = &a_edges;
   m_startEdge = a_startEdge;
-  m_curEdge   = m_startEdge;
+  m_curEdge   = a_startEdge;
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>&
-EdgeIteratorT<T, Meta>::operator()() noexcept
-{
-  return m_curEdge;
-}
-
-template <class T, class Meta>
-inline const std::shared_ptr<EdgeT<T, Meta>>&
+inline DCELIndex
 EdgeIteratorT<T, Meta>::operator()() const noexcept
 {
   return m_curEdge;
@@ -72,9 +50,10 @@ template <class T, class Meta>
 inline void
 EdgeIteratorT<T, Meta>::operator++() noexcept
 {
-  EBGEOMETRY_EXPECT(m_curEdge != nullptr);
+  EBGEOMETRY_EXPECT(m_edges != nullptr);
+  EBGEOMETRY_EXPECT(m_curEdge != InvalidIndex);
 
-  m_curEdge  = m_curEdge->getNextEdge();
+  m_curEdge  = (*m_edges)[m_curEdge].getNextEdge();
   m_fullLoop = (m_curEdge == m_startEdge);
 }
 
@@ -82,7 +61,7 @@ template <class T, class Meta>
 inline bool
 EdgeIteratorT<T, Meta>::ok() const noexcept
 {
-  return !m_fullLoop && m_curEdge;
+  return !m_fullLoop && m_curEdge != InvalidIndex;
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_Mesh.hpp
+++ b/Source/EBGeometry_DCEL_Mesh.hpp
@@ -22,6 +22,9 @@
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
+#include "EBGeometry_DCEL_Edge.hpp"
+#include "EBGeometry_DCEL_Face.hpp"
+#include "EBGeometry_DCEL_Vertex.hpp"
 #include "EBGeometry_Polygon2D.hpp"
 
 namespace EBGeometry {
@@ -32,12 +35,12 @@ namespace DCEL {
  * @brief Mesh class which stores a full DCEL mesh (with signed distance
  * functions)
  * @details This encapsulates a full DCEL mesh, and also includes DIRECT signed
- * distance functions. The mesh consists of a set of vertices, half-edges, and
- * polygon faces who each have references to other vertices, half-edges, and
- * polygon faces. The signed distance functions DIRECT, which means that they go
- * through ALL of the polygon faces and compute the signed distance to them. This
- * is extremely inefficient, which is why this class is almost always embedded
- * into a bounding volume hierarchy.
+ * distance functions. The mesh owns its vertices, half-edges, and polygon faces in three flat
+ * arrays (by value); every topological link between them is a @c DCELIndex index into these
+ * arrays. Because the elements can no longer chase pointers, all traversal and geometric-query
+ * logic lives on this class. The signed distance functions are DIRECT, which means that they go
+ * through ALL of the polygon faces and compute the signed distance to them. This is extremely
+ * inefficient, which is why this class is almost always embedded into a bounding volume hierarchy.
  * @note This class is not for the light of heart -- it will almost always be
  * instantiated through a file parser which reads vertices and edges from file
  * and builds the mesh from that. Do not try to build a MeshT object yourself,
@@ -89,34 +92,17 @@ public:
   using Mesh = MeshT<T, Meta>;
 
   /**
-   * @brief Alias for vertex pointer type
-   */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
-
-  /**
    * @brief Default constructor.
    * @details Leaves the mesh empty (no vertices, edges, or faces) with the default search
-   * algorithm; use define() or the mutable getVertices()/getEdges()/getFaces() to populate it.
+   * algorithm; use the full constructor or the mutable getVertices()/getEdges()/getFaces() to
+   * populate it.
    */
   MeshT() noexcept = default;
 
   /**
    * @brief Disallowed copy construction.
-   * @details Copying is deliberately disallowed: a shallow copy of m_vertices/m_edges/m_faces would
-   * share the same underlying vertex/edge/face objects as the original (they reference each other
-   * internally), so it would not behave like an independent mesh -- mutating the "copy" would also
-   * mutate the original. Use a file parser to build an independent mesh instead. Moving is allowed
-   * (see the move constructor), since that transfers ownership rather than aliasing it.
+   * @details Copying is deliberately disallowed; use deepCopy() to obtain an independent mesh.
+   * Moving is allowed (see the move constructor), since that transfers ownership.
    * @param[in] a_otherMesh Other mesh.
    */
   MeshT(const Mesh& a_otherMesh) = delete;
@@ -130,9 +116,8 @@ public:
   /**
    * @brief Full constructor. This provides the faces, edges, and vertices to the
    * mesh.
-   * @details Copies the three vectors directly into m_faces/m_edges/m_vertices. This only
-   * associates pointer structures through the mesh; internal parameters like face area and normal
-   * are computed by reconcile().
+   * @details Copies the three vectors directly into m_faces/m_edges/m_vertices. This only stores
+   * the topology; internal parameters like face area and normal are computed by reconcile().
    * @param[in] a_faces    Polygon faces
    * @param[in] a_edges    Half-edges
    * @param[in] a_vertices Vertices
@@ -140,7 +125,7 @@ public:
    * description. This is usually done through a file parser which reads a mesh
    * file format and creates the DCEL mesh structure
    */
-  MeshT(std::vector<FacePtr>& a_faces, std::vector<EdgePtr>& a_edges, std::vector<VertexPtr>& a_vertices) noexcept;
+  MeshT(std::vector<Face>& a_faces, std::vector<Edge>& a_edges, std::vector<Vertex>& a_vertices) noexcept;
 
   /**
    * @brief Destructor (does nothing)
@@ -149,7 +134,7 @@ public:
 
   /**
    * @brief Disallowed copy assignment.
-   * @details Has the same rationale as the disallowed copy constructor; see its documentation.
+   * @details Has the same rationale as the disallowed copy constructor; use deepCopy().
    * @param[in] a_otherMesh Other mesh.
    * @return Reference to (*this).
    */
@@ -166,14 +151,13 @@ public:
 
   /**
    * @brief Create an independent, fully-decoupled copy of this mesh.
-   * @details Since copy construction/assignment are disallowed (see their documentation), this is
-   * the supported way to duplicate a mesh. Unlike a shallow copy, this creates brand new
-   * VertexT/EdgeT/FaceT objects and relinks all of their internal pointers (outgoing edge, pair
-   * edge, next edge, half edge, adjacent faces) so that the copy shares no vertex, edge, or face
-   * with the original -- mutating one mesh does not affect the other. Every field is preserved
-   * exactly (position, normal vector, centroid, area, meta-data, search algorithm) rather than
-   * recomputed, so a mesh that has had flipNormal()/flip() called on it and not yet been
-   * re-reconciled will be copied faithfully rather than silently "un-flipped".
+   * @details Since copy construction/assignment are disallowed, this is the supported way to
+   * duplicate a mesh. Because the flat representation stores topology as plain array indices and
+   * every element (including a face's cached 2D embedding) by value, an independent copy is simply
+   * a by-value copy of the three arrays -- the indices remain valid and every geometric field
+   * (including a face's 2D embedding) is preserved exactly. In particular a mesh that has had
+   * flip()/flipNormal() called on it and not yet been re-reconciled is copied faithfully rather
+   * than silently "un-flipped".
    * @return A new mesh, independent of this one.
    */
   [[nodiscard]] inline std::shared_ptr<Mesh>
@@ -182,7 +166,7 @@ public:
   /**
    * @brief Perform a sanity check.
    * @details This will provide error messages if vertices are badly linked,
-   * faces are nullptr, and so on. These messages are logged by calling
+   * faces have no half-edge, and so on. These messages are logged by calling
    * incrementWarning() which identifies types of errors that can occur, and how
    * many of those errors have occurred.
    * @param[in] a_id Identifier when printing error messages (can be empty string).
@@ -201,7 +185,7 @@ public:
    * @brief Set the inside/outside algorithm to use when computing the signed
    * distance to polygon faces.
    * @details Computing the signed distance to faces requires testing if a point
-   * projected to a polygo face plane falls inside or outside the polygon face.
+   * projected to a polygon face plane falls inside or outside the polygon face.
    * There are multiple algorithms to use here.
    * @param[in] a_algorithm Algorithm to use
    */
@@ -231,14 +215,14 @@ public:
    * @brief Get modifiable vertices in this mesh
    * @return Reference to the vector of vertices.
    */
-  [[nodiscard]] inline std::vector<VertexPtr>&
+  [[nodiscard]] inline std::vector<Vertex>&
   getVertices() noexcept;
 
   /**
    * @brief Get immutable vertices in this mesh
    * @return Const reference to the vector of vertices.
    */
-  [[nodiscard]] inline const std::vector<VertexPtr>&
+  [[nodiscard]] inline const std::vector<Vertex>&
   getVertices() const noexcept;
 
   /**
@@ -252,29 +236,100 @@ public:
    * @brief Get modifiable half-edges in this mesh
    * @return Reference to the vector of half-edges.
    */
-  [[nodiscard]] inline std::vector<EdgePtr>&
+  [[nodiscard]] inline std::vector<Edge>&
   getEdges() noexcept;
 
   /**
    * @brief Get immutable half-edges in this mesh
    * @return Const reference to the vector of half-edges.
    */
-  [[nodiscard]] inline const std::vector<EdgePtr>&
+  [[nodiscard]] inline const std::vector<Edge>&
   getEdges() const noexcept;
 
   /**
    * @brief Get modifiable faces in this mesh
    * @return Reference to the vector of polygon faces.
    */
-  [[nodiscard]] inline std::vector<FacePtr>&
+  [[nodiscard]] inline std::vector<Face>&
   getFaces() noexcept;
 
   /**
    * @brief Get immutable faces in this mesh
    * @return Const reference to the vector of polygon faces.
    */
-  [[nodiscard]] inline const std::vector<FacePtr>&
+  [[nodiscard]] inline const std::vector<Face>&
   getFaces() const noexcept;
+
+  /**
+   * @brief Return the coordinates of all the vertices on the given polygon face.
+   * @param[in] a_faceIdx Face index.
+   * @return Vector of 3D vertex coordinates, in half-edge order around the face.
+   */
+  [[nodiscard]] inline std::vector<Vec3T<T>>
+  getFaceVertexCoordinates(const DCELIndex a_faceIdx) const noexcept;
+
+  /**
+   * @brief Get the index of the end (destination) vertex of a half-edge.
+   * @details This is the origin vertex of the half-edge's next edge around the face.
+   * @param[in] a_edgeIdx Half-edge index.
+   * @return Index of the end vertex.
+   */
+  [[nodiscard]] inline DCELIndex
+  getOtherVertex(const DCELIndex a_edgeIdx) const noexcept;
+
+  /**
+   * @brief Compute the signed distance from a point to a polygon face.
+   * @param[in] a_faceIdx Face index.
+   * @param[in] a_x0      Query point.
+   * @return Signed distance to the face; sign determined by the face normal direction.
+   */
+  [[nodiscard]] inline T
+  signedDistanceToFace(const DCELIndex a_faceIdx, const Vec3& a_x0) const noexcept;
+
+  /**
+   * @brief Compute the unsigned squared distance from a point to a polygon face.
+   * @param[in] a_faceIdx Face index.
+   * @param[in] a_x0      Query point.
+   * @return Squared unsigned distance to the face.
+   */
+  [[nodiscard]] inline T
+  unsignedDistance2ToFace(const DCELIndex a_faceIdx, const Vec3& a_x0) const noexcept;
+
+  /**
+   * @brief Compute the signed distance from a point to a half-edge.
+   * @param[in] a_edgeIdx Half-edge index.
+   * @param[in] a_x0      Query point.
+   * @return Signed distance; positive on the normal side of the edge.
+   */
+  [[nodiscard]] inline T
+  signedDistanceToEdge(const DCELIndex a_edgeIdx, const Vec3& a_x0) const noexcept;
+
+  /**
+   * @brief Compute the unsigned squared distance from a point to a half-edge.
+   * @param[in] a_edgeIdx Half-edge index.
+   * @param[in] a_x0      Query point.
+   * @return Squared distance to the closest point on the edge segment.
+   */
+  [[nodiscard]] inline T
+  unsignedDistance2ToEdge(const DCELIndex a_edgeIdx, const Vec3& a_x0) const noexcept;
+
+  /**
+   * @brief Compute the signed distance from a point to a vertex.
+   * @param[in] a_vertexIdx Vertex index.
+   * @param[in] a_x0        Query point.
+   * @return Signed distance to the vertex.
+   */
+  [[nodiscard]] inline T
+  signedDistanceToVertex(const DCELIndex a_vertexIdx, const Vec3& a_x0) const noexcept;
+
+  /**
+   * @brief Compute the unsigned squared distance from a point to a vertex.
+   * @param[in] a_vertexIdx Vertex index.
+   * @param[in] a_x0        Query point.
+   * @return Squared distance to the vertex.
+   */
+  [[nodiscard]] inline T
+  unsignedDistance2ToVertex(const DCELIndex a_vertexIdx, const Vec3& a_x0) const noexcept;
 
   /**
    * @brief Compute the signed distance from a point to this mesh
@@ -325,28 +380,75 @@ protected:
   /**
    * @brief Mesh vertices
    */
-  std::vector<VertexPtr> m_vertices;
+  std::vector<Vertex> m_vertices;
 
   /**
    * @brief Mesh half-edges
    */
-  std::vector<EdgePtr> m_edges;
+  std::vector<Edge> m_edges;
 
   /**
    * @brief Mesh faces
    */
-  std::vector<FacePtr> m_faces;
+  std::vector<Face> m_faces;
+
+  /**
+   * @brief Project a point onto the plane of a polygon face.
+   * @param[in] a_faceIdx Face index.
+   * @param[in] a_p       Point in space.
+   * @return Projected point in the face plane.
+   */
+  [[nodiscard]] inline Vec3
+  projectPointIntoFacePlane(const DCELIndex a_faceIdx, const Vec3& a_p) const noexcept;
+
+  /**
+   * @brief Check if a point projects to inside or outside a polygon face.
+   * @param[in] a_faceIdx Face index.
+   * @param[in] a_p       Point in space.
+   * @return True if a_p projects to inside the polygon and false otherwise.
+   */
+  [[nodiscard]] inline bool
+  isPointInsideFace(const DCELIndex a_faceIdx, const Vec3& a_p) const noexcept;
+
+  /**
+   * @brief Reconcile a single face: compute its normal vector, centroid, area, and 2D embedding.
+   * @param[in] a_faceIdx Face index.
+   */
+  inline void
+  reconcileFace(const DCELIndex a_faceIdx) noexcept;
+
+  /**
+   * @brief Compute the pseudonormal of a half-edge (average of its face normal and its pair
+   * edge's face normal; a boundary edge uses just its own face normal).
+   * @param[in] a_edgeIdx Half-edge index.
+   * @return Unit pseudonormal vector for this edge.
+   */
+  [[nodiscard]] inline Vec3
+  computeEdgeNormal(const DCELIndex a_edgeIdx) const noexcept;
+
+  /**
+   * @brief Compute the vertex normal as the unweighted average of its incident faces' normals.
+   * @param[in] a_vertexIdx Vertex index.
+   */
+  inline void
+  computeVertexNormalAverage(const DCELIndex a_vertexIdx) noexcept;
+
+  /**
+   * @brief Compute the angle-weighted pseudonormal of a vertex (Baerentzen and Aanes,
+   * DOI: 10.1109/TVCG.2005.49).
+   * @param[in] a_vertexIdx Vertex index.
+   */
+  inline void
+  computeVertexNormalAngleWeighted(const DCELIndex a_vertexIdx);
 
   /**
    * @brief Function which computes internal things for the polygon faces.
-   * @note This calls DCEL::FaceT<T, Meta>::reconcile()
    */
   inline void
   reconcileFaces() noexcept;
 
   /**
    * @brief Function which computes internal things for the half-edges
-   * @note This calls DCEL::EdgeT<T, Meta>::reconcile()
    */
   inline void
   reconcileEdges() noexcept;
@@ -354,8 +456,6 @@ protected:
   /**
    * @brief Function which computes internal things for the vertices
    * @param[in] a_weight Vertex angle weighting
-   * @note This calls DCEL::VertexT<T, Meta>::computeVertexNormalAverage() or
-   * DCEL::VertexT<T, Meta>::computeVertexNormalAngleWeighted()
    */
   inline void
   reconcileVertices(const DCEL::VertexNormalWeight a_weight) noexcept;
@@ -390,8 +490,8 @@ protected:
   /**
    * @brief Implementation of squared signed distance function which iterates
    * through all faces.
-   * @details This first find the face with the smallest unsigned square
-   * distance, and the returns the signed distance to that face (more efficient
+   * @details This first finds the face with the smallest unsigned square
+   * distance, and then returns the signed distance to that face (more efficient
    * than the other version).
    * @param[in] a_point 3D point
    * @return Signed distance to the nearest face.

--- a/Source/EBGeometry_DCEL_MeshImplem.hpp
+++ b/Source/EBGeometry_DCEL_MeshImplem.hpp
@@ -20,7 +20,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 // Our includes
@@ -36,9 +35,9 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline MeshT<T, Meta>::MeshT(std::vector<FacePtr>&   a_faces,
-                             std::vector<EdgePtr>&   a_edges,
-                             std::vector<VertexPtr>& a_vertices) noexcept
+inline MeshT<T, Meta>::MeshT(std::vector<Face>&   a_faces,
+                             std::vector<Edge>&   a_edges,
+                             std::vector<Vertex>& a_vertices) noexcept
   : MeshT()
 {
   m_faces    = a_faces;
@@ -50,121 +49,17 @@ template <class T, class Meta>
 inline std::shared_ptr<MeshT<T, Meta>>
 MeshT<T, Meta>::deepCopy() const
 {
-  EBGEOMETRY_EXPECT(m_vertices.size() > 0 || m_edges.size() > 0 || m_faces.size() > 0);
-
-  // Pass 0: allocate a fresh, default-constructed object for every existing vertex/edge/face, and
-  // record the old->new correspondence. This must happen before any relinking below, since a
-  // vertex/edge/face's pointers can reference any other vertex/edge/face in the mesh.
-  std::vector<VertexPtr> newVertices(m_vertices.size());
-  std::vector<EdgePtr>   newEdges(m_edges.size());
-  std::vector<FacePtr>   newFaces(m_faces.size());
-
-  std::unordered_map<VertexPtr, VertexPtr> vertexMap;
-  std::unordered_map<EdgePtr, EdgePtr>     edgeMap;
-  std::unordered_map<FacePtr, FacePtr>     faceMap;
-
-  for (size_t i = 0; i < m_vertices.size(); i++) {
-    EBGEOMETRY_EXPECT(m_vertices[i] != nullptr);
-
-    newVertices[i]           = std::make_shared<Vertex>();
-    vertexMap[m_vertices[i]] = newVertices[i];
-  }
-  for (size_t i = 0; i < m_edges.size(); i++) {
-    EBGEOMETRY_EXPECT(m_edges[i] != nullptr);
-
-    newEdges[i]         = std::make_shared<Edge>();
-    edgeMap[m_edges[i]] = newEdges[i];
-  }
-  for (size_t i = 0; i < m_faces.size(); i++) {
-    EBGEOMETRY_EXPECT(m_faces[i] != nullptr);
-
-    newFaces[i]         = std::make_shared<Face>();
-    faceMap[m_faces[i]] = newFaces[i];
-  }
-
-  // Remap a possibly-null old pointer to its corresponding new one. A non-null pointer that is not
-  // in the map means it refers to a vertex/edge/face outside of this mesh's own vectors, which is a
-  // corrupted/inconsistent mesh (the same condition sanityCheck() is meant to catch beforehand).
-  auto remapVertex = [&](const VertexPtr& a_v) -> VertexPtr {
-    if (a_v == nullptr) {
-      return nullptr;
-    }
-    const auto it = vertexMap.find(a_v);
-    EBGEOMETRY_EXPECT(it != vertexMap.end());
-
-    return it->second;
-  };
-  auto remapEdge = [&](const EdgePtr& a_e) -> EdgePtr {
-    if (a_e == nullptr) {
-      return nullptr;
-    }
-    const auto it = edgeMap.find(a_e);
-    EBGEOMETRY_EXPECT(it != edgeMap.end());
-
-    return it->second;
-  };
-  auto remapFace = [&](const FacePtr& a_f) -> FacePtr {
-    if (a_f == nullptr) {
-      return nullptr;
-    }
-    const auto it = faceMap.find(a_f);
-    EBGEOMETRY_EXPECT(it != faceMap.end());
-
-    return it->second;
-  };
-
-  // Pass 1: vertices. Copy value data (position, normal, meta-data) exactly, and relink the
-  // outgoing edge and face list to the new objects.
-  for (size_t i = 0; i < m_vertices.size(); i++) {
-    const VertexPtr& oldV = m_vertices[i];
-    const VertexPtr& newV = newVertices[i];
-
-    newV->setPosition(oldV->getPosition());
-    newV->setNormal(oldV->getNormal());
-    newV->setMetaData(oldV->getMetaData());
-    newV->setEdge(remapEdge(oldV->getOutgoingEdge()));
-
-    for (const auto& f : oldV->getFaces()) {
-      newV->addFace(remapFace(f));
-    }
-  }
-
-  // Pass 2: edges. Copy the normal vector and meta-data exactly, and relink the vertex, pair edge,
-  // next edge, and face to the new objects.
-  for (size_t i = 0; i < m_edges.size(); i++) {
-    const EdgePtr& oldE = m_edges[i];
-    const EdgePtr& newE = newEdges[i];
-
-    newE->setVertex(remapVertex(oldE->getVertex()));
-    newE->setPairEdge(remapEdge(oldE->getPairEdge()));
-    newE->setNextEdge(remapEdge(oldE->getNextEdge()));
-    newE->setFace(remapFace(oldE->getFace()));
-    newE->getNormal() = oldE->getNormal();
-    newE->setMetaData(oldE->getMetaData());
-  }
-
-  // Pass 3: faces. Copy the normal vector, centroid, area, and meta-data exactly, relink the half
-  // edge to the new object, and rebuild the 2D embedding from the (already-relinked) topology and
-  // the (already-restored) normal vector. This deliberately does NOT call reconcile(), which would
-  // recompute the normal vector from vertex winding and silently discard a prior flipNormal().
-  for (size_t i = 0; i < m_faces.size(); i++) {
-    const FacePtr& oldF = m_faces[i];
-    const FacePtr& newF = newFaces[i];
-
-    newF->setHalfEdge(remapEdge(oldF->getHalfEdge()));
-    newF->getNormal()   = oldF->getNormal();
-    newF->getCentroid() = oldF->getCentroid();
-    newF->getArea()     = oldF->getArea();
-    newF->setMetaData(oldF->getMetaData());
-    newF->computePolygon2D();
-  }
-
+  // The flat representation stores topology as plain array indices and every element (including a
+  // face's cached 2D embedding) by value, so an independent copy is simply a by-value copy of the
+  // three arrays plus the search algorithm. The indices remain valid, and every geometric field
+  // (including flipped normals) is preserved exactly. This deliberately does NOT call reconcile(),
+  // which would recompute normals from vertex winding and silently discard a prior flip().
   auto newMesh = std::make_shared<Mesh>();
 
-  newMesh->getVertices() = std::move(newVertices);
-  newMesh->getEdges()    = std::move(newEdges);
-  newMesh->getFaces()    = std::move(newFaces);
-  newMesh->setSearchAlgorithm(m_algorithm);
+  newMesh->m_vertices  = m_vertices;
+  newMesh->m_edges     = m_edges;
+  newMesh->m_faces     = m_faces;
+  newMesh->m_algorithm = m_algorithm;
 
   return newMesh;
 }
@@ -199,81 +94,70 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::sanityCheck(const std::string a_id) const
 {
-  const std::string f_null       = "nullptr face";
   const std::string f_noEdge     = "face with no edge";
   const std::string f_degenerate = "degenerate face";
 
-  const std::string e_null       = "nullptr edges";
   const std::string e_degenerate = "degenerate edge";
   const std::string e_noPairEdge = "no pair edge (not watertight)";
   const std::string e_noNextEdge = "no next edge (badly linked dcel)";
   const std::string e_noOrigVert = "no origin vertex found for half edge (badly linked dcel)";
   const std::string e_noFace     = "no face found for half edge (badly linked dcel)";
 
-  const std::string v_null   = "nullptr vertex";
   const std::string v_noEdge = "no referenced edge for vertex (unreferenced vertex)";
 
-  std::map<std::string, size_t> warnings = {{f_null, 0},
-                                            {f_noEdge, 0},
+  std::map<std::string, size_t> warnings = {{f_noEdge, 0},
                                             {f_degenerate, 0},
-                                            {e_null, 0},
                                             {e_degenerate, 0},
                                             {e_noPairEdge, 0},
                                             {e_noNextEdge, 0},
                                             {e_noOrigVert, 0},
                                             {e_noFace, 0},
-                                            {v_null, 0},
                                             {v_noEdge, 0}};
 
-  for (const auto& f : m_faces) {
-    if (f == nullptr) {
-      this->incrementWarning(warnings, f_null);
+  for (size_t iFace = 0; iFace < m_faces.size(); iFace++) {
+    const DCELIndex halfEdge = m_faces[iFace].getHalfEdge();
+    if (halfEdge == InvalidIndex) {
+      this->incrementWarning(warnings, f_noEdge);
+
       continue;
     }
 
-    const auto& halfEdge = f->getHalfEdge();
-    if (halfEdge == nullptr) {
-      this->incrementWarning(warnings, f_noEdge);
+    std::vector<DCELIndex> vertices;
+
+    for (EdgeIteratorT<T, Meta> edgeIt(m_edges, halfEdge); edgeIt.ok(); ++edgeIt) {
+      vertices.emplace_back(m_edges[edgeIt()].getVertex());
     }
 
-    auto vertices = f->gatherVertices();
     std::sort(vertices.begin(), vertices.end());
-    auto       it           = std::unique(vertices.begin(), vertices.end());
+    const auto it           = std::unique(vertices.begin(), vertices.end());
     const bool noDuplicates = (it == vertices.end());
     if (!noDuplicates) {
       this->incrementWarning(warnings, f_degenerate);
     }
   }
 
-  for (const auto& e : m_edges) {
-    if (e == nullptr) {
-      this->incrementWarning(warnings, e_null);
-      continue;
-    }
+  for (size_t iEdge = 0; iEdge < m_edges.size(); iEdge++) {
+    const Edge& e = m_edges[iEdge];
 
-    if (e->getVertex() == e->getOtherVertex()) {
+    if (e.getNextEdge() != InvalidIndex && e.getVertex() == this->getOtherVertex(static_cast<DCELIndex>(iEdge))) {
       this->incrementWarning(warnings, e_degenerate);
     }
-    if (e->getPairEdge() == nullptr) {
+    if (e.getPairEdge() == InvalidIndex) {
       this->incrementWarning(warnings, e_noPairEdge);
     }
-    if (e->getNextEdge() == nullptr) {
+    if (e.getNextEdge() == InvalidIndex) {
       this->incrementWarning(warnings, e_noNextEdge);
     }
-    if (e->getVertex() == nullptr) {
+    if (e.getVertex() == InvalidIndex) {
       this->incrementWarning(warnings, e_noOrigVert);
     }
-    if (e->getFace() == nullptr) {
+    if (e.getFace() == InvalidIndex) {
       this->incrementWarning(warnings, e_noFace);
     }
   }
 
-  // Vertex check
   for (const auto& v : m_vertices) {
-    if (v == nullptr) {
-      this->incrementWarning(warnings, v_null);
-    }
-    else if (v->getOutgoingEdge() == nullptr) {
+    if (v.getOutgoingEdge() == InvalidIndex) {
       this->incrementWarning(warnings, v_noEdge);
     }
   }
@@ -293,9 +177,7 @@ inline void
 MeshT<T, Meta>::setInsideOutsideAlgorithm(typename Polygon2D<T>::InsideOutsideAlgorithm a_algorithm) noexcept
 {
   for (auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    f->setInsideOutsideAlgorithm(a_algorithm);
+    f.setInsideOutsideAlgorithm(a_algorithm);
   }
 }
 
@@ -319,12 +201,233 @@ MeshT<T, Meta>::flip() noexcept
 
 template <class T, class Meta>
 inline void
+MeshT<T, Meta>::reconcileFace(const DCELIndex a_faceIdx) noexcept
+{
+  EBGEOMETRY_EXPECT(a_faceIdx >= 0 && a_faceIdx < static_cast<DCELIndex>(m_faces.size()));
+
+  Face& face = m_faces[a_faceIdx];
+
+  const std::vector<Vec3> vertices = this->getFaceVertexCoordinates(a_faceIdx);
+  const size_t            N        = vertices.size();
+
+  // A polygon face needs at least 3 vertices to span a plane.
+  EBGEOMETRY_EXPECT(N >= 3);
+
+  // Compute the normal vector from three non-degenerate vertices spanning the face plane.
+  Vec3 normal = Vec3::zeros();
+
+  for (size_t i = 0; i < N; i++) {
+    const Vec3& x0 = vertices[i];
+    const Vec3& x1 = vertices[(i + 1) % N];
+    const Vec3& x2 = vertices[(i + 2) % N];
+
+    normal = (x2 - x0).cross(x2 - x1);
+
+    if (normal.length() > T(0.0)) {
+      break; // Found one.
+    }
+  }
+
+  EBGEOMETRY_EXPECT(normal.length() > std::numeric_limits<T>::epsilon());
+
+  face.getNormal() = normal;
+  face.normalizeNormalVector();
+
+  // Compute the centroid.
+  Vec3 centroid = Vec3::zeros();
+
+  for (const auto& v : vertices) {
+    centroid += v;
+  }
+
+  centroid = centroid / static_cast<T>(N);
+
+  face.getCentroid() = centroid;
+
+  // Compute the area using the cross-product/shoelace formula over ALL N edges, including the
+  // wraparound edge from vertices[N-1] back to vertices[0].
+  T area = T(0.0);
+
+  for (size_t i = 0; i < N; i++) {
+    const Vec3& v1 = vertices[i];
+    const Vec3& v2 = vertices[(i + 1) % N];
+
+    area += face.getNormal().dot(v2.cross(v1));
+  }
+
+  face.getArea() = T(0.5) * std::abs(area);
+
+  // Compute the 2D embedding from the (now-normalized) normal vector and the vertex coordinates.
+  face.setPolygon2D(Polygon2D<T>(face.getNormal(), vertices));
+}
+
+template <class T, class Meta>
+inline Vec3T<T>
+MeshT<T, Meta>::computeEdgeNormal(const DCELIndex a_edgeIdx) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_edgeIdx >= 0 && a_edgeIdx < static_cast<DCELIndex>(m_edges.size()));
+
+  const Edge& edge = m_edges[a_edgeIdx];
+
+  // Every half-edge belongs to exactly one face by DCEL invariant. The pair edge (and its face)
+  // may legitimately be missing for a boundary edge on an open mesh -- handled gracefully below.
+  EBGEOMETRY_EXPECT(edge.getFace() != InvalidIndex);
+
+  Vec3 normal = Vec3::zeros();
+
+  if (edge.getFace() != InvalidIndex) {
+    const Vec3& faceNormal = m_faces[edge.getFace()].getNormal();
+
+    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[0]));
+    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[1]));
+    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[2]));
+
+    normal += faceNormal;
+  }
+  if (edge.getPairEdge() != InvalidIndex) {
+    const DCELIndex pairFaceIdx = m_edges[edge.getPairEdge()].getFace();
+
+    if (pairFaceIdx != InvalidIndex) {
+      const Vec3& pairFaceNormal = m_faces[pairFaceIdx].getNormal();
+
+      EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[0]));
+      EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[1]));
+      EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[2]));
+
+      normal += pairFaceNormal;
+    }
+  }
+
+  const T len = normal.length();
+
+  EBGEOMETRY_EXPECT(len > T(0));
+
+  return (len > std::numeric_limits<T>::epsilon()) ? normal / len : Vec3::zeros();
+}
+
+template <class T, class Meta>
+inline void
+MeshT<T, Meta>::computeVertexNormalAverage(const DCELIndex a_vertexIdx) noexcept
+{
+  EBGEOMETRY_EXPECT(a_vertexIdx >= 0 && a_vertexIdx < static_cast<DCELIndex>(m_vertices.size()));
+
+  Vertex& vertex = m_vertices[a_vertexIdx];
+
+  const std::vector<DCELIndex>& faces = vertex.getFaces();
+
+  EBGEOMETRY_EXPECT(!faces.empty());
+
+  Vec3 normal = Vec3::zeros();
+
+  // We simply compute the sum of the normal vectors for each face incident on this vertex and then
+  // normalize -- an "average" of the incident faces' normal vectors.
+  for (const auto& faceIdx : faces) {
+    EBGEOMETRY_EXPECT(faceIdx >= 0 && faceIdx < static_cast<DCELIndex>(m_faces.size()));
+
+    normal += m_faces[faceIdx].getNormal();
+  }
+
+  vertex.getNormal() = normal;
+  vertex.normalizeNormalVector();
+}
+
+template <class T, class Meta>
+inline void
+MeshT<T, Meta>::computeVertexNormalAngleWeighted(const DCELIndex a_vertexIdx)
+{
+  EBGEOMETRY_EXPECT(a_vertexIdx >= 0 && a_vertexIdx < static_cast<DCELIndex>(m_vertices.size()));
+
+  Vertex& vertex = m_vertices[a_vertexIdx];
+
+  const std::vector<DCELIndex>& faces = vertex.getFaces();
+
+  // This routine computes the pseudonormal from Baerentzen and Aanes in "Signed distance
+  // computation using the angle weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49). The normal is
+  // an average of the incident faces' normals weighted by the angle each face subtends at this
+  // vertex (the angle spanned by the incoming/outgoing edges of the face that pass through this
+  // vertex). We look through each incident face to find the two edge endpoints that neighbor this
+  // vertex on that face, so a flipped input face does not cause infinite iteration.
+  EBGEOMETRY_EXPECT(!faces.empty());
+  EBGEOMETRY_EXPECT(vertex.getOutgoingEdge() != InvalidIndex);
+
+  Vec3 normal = Vec3::zeros();
+
+  for (const auto& faceIdx : faces) {
+    EBGEOMETRY_EXPECT(faceIdx >= 0 && faceIdx < static_cast<DCELIndex>(m_faces.size()));
+
+    std::vector<DCELIndex> inoutVertices(0);
+
+    for (EdgeIteratorT<T, Meta> edgeIt(m_edges, m_faces[faceIdx].getHalfEdge()); edgeIt.ok(); ++edgeIt) {
+      const DCELIndex v1 = m_edges[edgeIt()].getVertex();
+      const DCELIndex v2 = this->getOtherVertex(edgeIt());
+
+      if (v1 == a_vertexIdx || v2 == a_vertexIdx) {
+        if (v1 == a_vertexIdx) {
+          inoutVertices.emplace_back(v2);
+        }
+        else if (v2 == a_vertexIdx) {
+          inoutVertices.emplace_back(v1);
+        }
+        else {
+          std::cerr << "MeshT<T, Meta>::computeVertexNormalAngleWeighted(): unreachable branch hit "
+                       "-- a half-edge of the face was found to have the origin vertex as one of "
+                       "its two endpoints, but neither v1 nor v2 compares equal to it. This points "
+                       "to a corrupted or inconsistent half-edge/vertex topology.\n";
+        }
+      }
+    }
+
+    if (inoutVertices.size() != 2) {
+      std::cerr << "MeshT<T, Meta>::computeVertexNormalAngleWeighted(): face should be incident on "
+                   "the origin vertex through exactly 2 half-edges (one incoming, one outgoing), "
+                   "but "
+                << inoutVertices.size()
+                << " were found. This means the face is not a well-formed triangle sharing this "
+                   "vertex -- check the mesh for degenerate or non-manifold faces.\n";
+    }
+
+    EBGEOMETRY_EXPECT(inoutVertices.size() == 2);
+
+    const Vec3& x0 = vertex.getPosition();
+    const Vec3& x1 = m_vertices[inoutVertices[0]].getPosition();
+    const Vec3& x2 = m_vertices[inoutVertices[1]].getPosition();
+
+    if (x0 == x1 || x0 == x2 || x1 == x2) {
+      std::cerr << "MeshT<T, Meta>::computeVertexNormalAngleWeighted(): degenerate face -- two of "
+                   "the origin vertex position ("
+                << x0 << ") and its two neighboring vertex positions (" << x1 << ", " << x2
+                << ") coincide. This produces a zero-length edge, which has no well-defined "
+                   "subtended angle -- check the mesh for duplicate/collapsed vertices.\n";
+    }
+
+    EBGEOMETRY_EXPECT(x0 != x1);
+    EBGEOMETRY_EXPECT(x0 != x2);
+    EBGEOMETRY_EXPECT(x1 != x2);
+
+    Vec3 v1 = x1 - x0;
+    Vec3 v2 = x2 - x0;
+
+    v1 = v1 / v1.length();
+    v2 = v2 / v2.length();
+
+    const Vec3& norm = m_faces[faceIdx].getNormal();
+
+    // Clamp to [-1,1] to guard against std::acos(NaN) from floating-point rounding.
+    const T alpha = std::acos(std::clamp(v1.dot(v2), T(-1), T(1)));
+
+    normal += alpha * norm;
+  }
+
+  vertex.getNormal() = normal;
+  vertex.normalizeNormalVector();
+}
+
+template <class T, class Meta>
+inline void
 MeshT<T, Meta>::reconcileFaces() noexcept
 {
-  for (auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    f->reconcile();
+  for (size_t i = 0; i < m_faces.size(); i++) {
+    this->reconcileFace(static_cast<DCELIndex>(i));
   }
 }
 
@@ -332,10 +435,8 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::reconcileEdges() noexcept
 {
-  for (auto& e : m_edges) {
-    EBGEOMETRY_EXPECT(e != nullptr);
-
-    e->reconcile();
+  for (size_t i = 0; i < m_edges.size(); i++) {
+    m_edges[i].getNormal() = this->computeEdgeNormal(static_cast<DCELIndex>(i));
   }
 }
 
@@ -343,17 +444,15 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::reconcileVertices(const DCEL::VertexNormalWeight a_weight) noexcept
 {
-  for (auto& v : m_vertices) {
-    EBGEOMETRY_EXPECT(v != nullptr);
-
+  for (size_t i = 0; i < m_vertices.size(); i++) {
     switch (a_weight) {
     case DCEL::VertexNormalWeight::None: {
-      v->computeVertexNormalAverage();
+      this->computeVertexNormalAverage(static_cast<DCELIndex>(i));
 
       break;
     }
     case DCEL::VertexNormalWeight::Angle: {
-      v->computeVertexNormalAngleWeighted();
+      this->computeVertexNormalAngleWeighted(static_cast<DCELIndex>(i));
 
       break;
     }
@@ -375,9 +474,7 @@ inline void
 MeshT<T, Meta>::flipFaceNormals() noexcept
 {
   for (auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    f->flipNormal();
+    f.flipNormal();
   }
 }
 
@@ -386,9 +483,7 @@ inline void
 MeshT<T, Meta>::flipEdgeNormals() noexcept
 {
   for (auto& e : m_edges) {
-    EBGEOMETRY_EXPECT(e != nullptr);
-
-    e->flipNormal();
+    e.flipNormal();
   }
 }
 
@@ -397,49 +492,47 @@ inline void
 MeshT<T, Meta>::flipVertexNormals() noexcept
 {
   for (auto& v : m_vertices) {
-    EBGEOMETRY_EXPECT(v != nullptr);
-
-    v->flipNormal();
+    v.flipNormal();
   }
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<VertexT<T, Meta>>>&
+inline std::vector<VertexT<T, Meta>>&
 MeshT<T, Meta>::getVertices() noexcept
 {
   return m_vertices;
 }
 
 template <class T, class Meta>
-inline const std::vector<std::shared_ptr<VertexT<T, Meta>>>&
+inline const std::vector<VertexT<T, Meta>>&
 MeshT<T, Meta>::getVertices() const noexcept
 {
   return m_vertices;
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<EdgeT<T, Meta>>>&
+inline std::vector<EdgeT<T, Meta>>&
 MeshT<T, Meta>::getEdges() noexcept
 {
   return m_edges;
 }
 
 template <class T, class Meta>
-inline const std::vector<std::shared_ptr<EdgeT<T, Meta>>>&
+inline const std::vector<EdgeT<T, Meta>>&
 MeshT<T, Meta>::getEdges() const noexcept
 {
   return m_edges;
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<FaceT<T, Meta>>>&
+inline std::vector<FaceT<T, Meta>>&
 MeshT<T, Meta>::getFaces() noexcept
 {
   return m_faces;
 }
 
 template <class T, class Meta>
-inline const std::vector<std::shared_ptr<FaceT<T, Meta>>>&
+inline const std::vector<FaceT<T, Meta>>&
 MeshT<T, Meta>::getFaces() const noexcept
 {
   return m_faces;
@@ -451,13 +544,231 @@ MeshT<T, Meta>::getAllVertexCoordinates() const noexcept
 {
   std::vector<Vec3> vertexCoordinates;
   vertexCoordinates.reserve(m_vertices.size());
-  for (const auto& v : m_vertices) {
-    EBGEOMETRY_EXPECT(v != nullptr);
 
-    vertexCoordinates.emplace_back(v->getPosition());
+  for (const auto& v : m_vertices) {
+    vertexCoordinates.emplace_back(v.getPosition());
   }
 
   return vertexCoordinates;
+}
+
+template <class T, class Meta>
+inline std::vector<Vec3T<T>>
+MeshT<T, Meta>::getFaceVertexCoordinates(const DCELIndex a_faceIdx) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_faceIdx >= 0 && a_faceIdx < static_cast<DCELIndex>(m_faces.size()));
+
+  std::vector<Vec3> coordinates;
+  coordinates.reserve(3);
+
+  for (EdgeIteratorT<T, Meta> edgeIt(m_edges, m_faces[a_faceIdx].getHalfEdge()); edgeIt.ok(); ++edgeIt) {
+    coordinates.emplace_back(m_vertices[m_edges[edgeIt()].getVertex()].getPosition());
+  }
+
+  return coordinates;
+}
+
+template <class T, class Meta>
+inline DCELIndex
+MeshT<T, Meta>::getOtherVertex(const DCELIndex a_edgeIdx) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_edgeIdx >= 0 && a_edgeIdx < static_cast<DCELIndex>(m_edges.size()));
+
+  const DCELIndex nextEdge = m_edges[a_edgeIdx].getNextEdge();
+
+  EBGEOMETRY_EXPECT(nextEdge != InvalidIndex);
+
+  return m_edges[nextEdge].getVertex();
+}
+
+template <class T, class Meta>
+inline Vec3T<T>
+MeshT<T, Meta>::projectPointIntoFacePlane(const DCELIndex a_faceIdx, const Vec3& a_p) const noexcept
+{
+  EBGEOMETRY_EXPECT(std::isfinite(a_p[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_p[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_p[2]));
+
+  const Face& face = m_faces[a_faceIdx];
+
+  return a_p - face.getNormal() * (face.getNormal().dot(a_p - face.getCentroid()));
+}
+
+template <class T, class Meta>
+inline bool
+MeshT<T, Meta>::isPointInsideFace(const DCELIndex a_faceIdx, const Vec3& a_p) const noexcept
+{
+  const Face& face = m_faces[a_faceIdx];
+
+  const Vec3 p = this->projectPointIntoFacePlane(a_faceIdx, a_p);
+
+  return face.getPolygon2D().isPointInside(p, face.getInsideOutsideAlgorithm());
+}
+
+template <class T, class Meta>
+inline T
+MeshT<T, Meta>::signedDistanceToVertex(const DCELIndex a_vertexIdx, const Vec3& a_x0) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_vertexIdx >= 0 && a_vertexIdx < static_cast<DCELIndex>(m_vertices.size()));
+
+  return m_vertices[a_vertexIdx].signedDistance(a_x0);
+}
+
+template <class T, class Meta>
+inline T
+MeshT<T, Meta>::unsignedDistance2ToVertex(const DCELIndex a_vertexIdx, const Vec3& a_x0) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_vertexIdx >= 0 && a_vertexIdx < static_cast<DCELIndex>(m_vertices.size()));
+
+  return m_vertices[a_vertexIdx].unsignedDistance2(a_x0);
+}
+
+template <class T, class Meta>
+inline T
+MeshT<T, Meta>::signedDistanceToEdge(const DCELIndex a_edgeIdx, const Vec3& a_x0) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_edgeIdx >= 0 && a_edgeIdx < static_cast<DCELIndex>(m_edges.size()));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
+
+  const DCELIndex v1Idx = m_edges[a_edgeIdx].getVertex();
+  const DCELIndex v2Idx = this->getOtherVertex(a_edgeIdx);
+
+  const Vec3& x1   = m_vertices[v1Idx].getPosition();
+  const Vec3& x2   = m_vertices[v2Idx].getPosition();
+  const Vec3  x2x1 = x2 - x1;
+
+  EBGEOMETRY_EXPECT(x2x1.dot(x2x1) > T(0));
+
+  const T t = (a_x0 - x1).dot(x2x1) / x2x1.dot(x2x1);
+
+  T retval = std::numeric_limits<T>::max();
+
+  if (t <= T(0.0)) {
+    // Closest point is the starting vertex.
+    retval = this->signedDistanceToVertex(v1Idx, a_x0);
+  }
+  else if (t >= T(1.0)) {
+    // Closest point is the end vertex.
+    retval = this->signedDistanceToVertex(v2Idx, a_x0);
+  }
+  else {
+    // Closest point is the edge itself.
+    const Vec3 linePoint = x1 + t * x2x1;
+    const Vec3 delta     = a_x0 - linePoint;
+    const T    dot       = m_edges[a_edgeIdx].getNormal().dot(delta);
+
+    const int sgn = (dot > T(0.0)) ? 1 : -1;
+
+    retval = sgn * delta.length();
+  }
+
+  return retval;
+}
+
+template <class T, class Meta>
+inline T
+MeshT<T, Meta>::unsignedDistance2ToEdge(const DCELIndex a_edgeIdx, const Vec3& a_x0) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_edgeIdx >= 0 && a_edgeIdx < static_cast<DCELIndex>(m_edges.size()));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
+
+  const DCELIndex v1Idx = m_edges[a_edgeIdx].getVertex();
+  const DCELIndex v2Idx = this->getOtherVertex(a_edgeIdx);
+
+  const Vec3& x1   = m_vertices[v1Idx].getPosition();
+  const Vec3& x2   = m_vertices[v2Idx].getPosition();
+  const Vec3  x2x1 = x2 - x1;
+
+  EBGEOMETRY_EXPECT(x2x1.dot(x2x1) > T(0));
+
+  const T t = std::clamp((a_x0 - x1).dot(x2x1) / x2x1.dot(x2x1), T(0.0), T(1.0));
+
+  const Vec3 linePoint = x1 + t * x2x1;
+  const Vec3 delta     = a_x0 - linePoint;
+
+  return delta.dot(delta);
+}
+
+template <class T, class Meta>
+inline T
+MeshT<T, Meta>::signedDistanceToFace(const DCELIndex a_faceIdx, const Vec3& a_x0) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_faceIdx >= 0 && a_faceIdx < static_cast<DCELIndex>(m_faces.size()));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
+
+  const Face& face = m_faces[a_faceIdx];
+
+  EBGEOMETRY_EXPECT(face.getHalfEdge() != InvalidIndex);
+
+  T retval = std::numeric_limits<T>::infinity();
+
+  if (this->isPointInsideFace(a_faceIdx, a_x0)) {
+    retval = face.getNormal().dot(a_x0 - face.getCentroid());
+  }
+  else {
+    const DCELIndex startEdge = face.getHalfEdge();
+    DCELIndex       cur       = startEdge;
+
+    while (true) {
+      const T curDist = this->signedDistanceToEdge(cur, a_x0);
+
+      retval = (std::abs(curDist) < std::abs(retval)) ? curDist : retval;
+
+      cur = m_edges[cur].getNextEdge();
+
+      if (cur == InvalidIndex || cur == startEdge) {
+        break;
+      }
+    }
+  }
+
+  return retval;
+}
+
+template <class T, class Meta>
+inline T
+MeshT<T, Meta>::unsignedDistance2ToFace(const DCELIndex a_faceIdx, const Vec3& a_x0) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_faceIdx >= 0 && a_faceIdx < static_cast<DCELIndex>(m_faces.size()));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
+
+  const Face& face = m_faces[a_faceIdx];
+
+  EBGEOMETRY_EXPECT(face.getHalfEdge() != InvalidIndex);
+
+  T retval = std::numeric_limits<T>::infinity();
+
+  if (this->isPointInsideFace(a_faceIdx, a_x0)) {
+    const T normDist = face.getNormal().dot(a_x0 - face.getCentroid());
+
+    retval = normDist * normDist;
+  }
+  else {
+    const DCELIndex startEdge = face.getHalfEdge();
+    DCELIndex       cur       = startEdge;
+
+    while (true) {
+      const T curDist2 = this->unsignedDistance2ToEdge(cur, a_x0);
+
+      retval = (curDist2 < retval) ? curDist2 : retval;
+
+      cur = m_edges[cur].getNextEdge();
+
+      if (cur == InvalidIndex || cur == startEdge) {
+        break;
+      }
+    }
+  }
+
+  return retval;
 }
 
 template <class T, class Meta>
@@ -485,10 +796,8 @@ MeshT<T, Meta>::unsignedDistance2(const Vec3& a_point) const noexcept
 
   T minDist2 = std::numeric_limits<T>::max();
 
-  for (const auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    const T curDist2 = f->unsignedDistance2(a_point);
+  for (size_t i = 0; i < m_faces.size(); i++) {
+    const T curDist2 = this->unsignedDistance2ToFace(static_cast<DCELIndex>(i), a_point);
 
     minDist2 = std::min(minDist2, curDist2);
   }
@@ -543,15 +852,11 @@ MeshT<T, Meta>::DirectSignedDistance(const Vec3& a_point) const noexcept
     return std::numeric_limits<T>::infinity();
   }
 
-  EBGEOMETRY_EXPECT(m_faces.front() != nullptr);
-
-  T minDist  = m_faces.front()->signedDistance(a_point);
+  T minDist  = this->signedDistanceToFace(0, a_point);
   T minDist2 = minDist * minDist;
 
-  for (const auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    const T curDist  = f->signedDistance(a_point);
+  for (size_t i = 0; i < m_faces.size(); i++) {
+    const T curDist  = this->signedDistanceToFace(static_cast<DCELIndex>(i), a_point);
     const T curDist2 = curDist * curDist;
 
     if (curDist2 < minDist2) {
@@ -575,23 +880,19 @@ MeshT<T, Meta>::DirectSignedDistance2(const Vec3& a_point) const noexcept
     return std::numeric_limits<T>::infinity();
   }
 
-  EBGEOMETRY_EXPECT(m_faces.front() != nullptr);
+  DCELIndex closest  = 0;
+  T         minDist2 = this->unsignedDistance2ToFace(0, a_point);
 
-  FacePtr closest  = m_faces.front();
-  T       minDist2 = closest->unsignedDistance2(a_point);
-
-  for (const auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    const T curDist2 = f->unsignedDistance2(a_point);
+  for (size_t i = 0; i < m_faces.size(); i++) {
+    const T curDist2 = this->unsignedDistance2ToFace(static_cast<DCELIndex>(i), a_point);
 
     if (curDist2 < minDist2) {
-      closest  = f;
+      closest  = static_cast<DCELIndex>(i);
       minDist2 = curDist2;
     }
   }
 
-  return closest->signedDistance(a_point);
+  return this->signedDistanceToFace(closest, a_point);
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_Vertex.hpp
+++ b/Source/EBGeometry_DCEL_Vertex.hpp
@@ -13,13 +13,11 @@
 #define EBGEOMETRY_DCEL_VERTEX_HPP
 
 // Std includes
-#include <memory>
 #include <type_traits>
 #include <vector>
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
-#include "EBGeometry_DCEL_Face.hpp"
 #include "EBGeometry_Vec.hpp"
 
 namespace EBGeometry {
@@ -30,9 +28,11 @@ namespace DCEL {
  * @brief Class which represents a vertex node in a double-edge connected list
  * (DCEL).
  * @details This class is used in DCEL functionality which stores polygonal
- * surfaces in a mesh. The VertexT class has a position, a normal vector, and a
- * pointer to one of the outgoing edges from the vertex. For performance reasons
- * we also include pointers to all the polygon faces that share this vertex.
+ * surfaces in a mesh. In the flat, index-based DCEL representation the vertex is a pure data
+ * holder: it stores a position, a normal vector, the index of one of the outgoing half-edges from
+ * the vertex, and the indices of the polygon faces that share this vertex (used only for the
+ * pseudonormal computation). All topological links are @c DCELIndex indices into the owning
+ * MeshT's flat arrays; @c InvalidIndex means "no link".
  * @note The normal vector is outgoing, i.e. a point x is "outside" the vertex if
  * the dot product between n and (x - x0) is positive.
  * @tparam T    Floating-point precision.
@@ -55,41 +55,11 @@ public:
   using Vertex = VertexT<T, Meta>;
 
   /**
-   * @brief Alias for edge type
-   */
-  using Edge = EdgeT<T, Meta>;
-
-  /**
-   * @brief Alias for face type
-   */
-  using Face = FaceT<T, Meta>;
-
-  /**
-   * @brief Alias for vertex pointer type
-   */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
-
-  /**
-   * @brief Alias for edge iterator
-   */
-  using EdgeIterator = EdgeIteratorT<T, Meta>;
-
-  /**
    * @brief Default constructor.
    * @details Defaulted: the position and normal vectors zero-initialize via Vec3T's own default
-   * constructor, the outgoing edge pointer defaults to null, the face list defaults to empty, and
-   * the meta-data value-initializes (see m_metaData). Not marked noexcept since Meta is an
-   * unconstrained template parameter whose default constructor is not guaranteed to be noexcept.
+   * constructor, the outgoing edge index defaults to InvalidIndex, the face list defaults to empty,
+   * and the meta-data value-initializes. Not marked noexcept since Meta is an unconstrained template
+   * parameter whose default constructor is not guaranteed to be noexcept.
    */
   VertexT() = default;
 
@@ -111,28 +81,17 @@ public:
   VertexT(const Vec3& a_position, const Vec3& a_normal);
 
   /**
-   * @brief Copy constructor.
+   * @brief Copy constructor (defaulted memberwise copy).
+   * @details The vertex is a flat data holder whose topological links are plain array indices, so
+   * an ordinary memberwise copy is well-defined and independent -- the indices remain valid in a
+   * copied MeshT array. Copies every field (position, normal, outgoing edge index, incident face
+   * indices, meta-data).
    * @param[in] a_otherVertex Other vertex.
-   * @details Copies only the position, normal vector, and outgoing edge pointer from the other
-   * vertex. The polygon face list (m_faces) and meta-data (m_metaData) are deliberately NOT
-   * copied -- they default-construct empty/default instead; use addFace()/setMetaData()
-   * afterwards if they need to be populated. Rationale: m_faces and m_outgoingEdge are
-   * back-references into a specific mesh's topology (the faces/edges they point to still
-   * reference the original vertex, not this copy), so copying them wholesale would not be
-   * topologically meaningful; only the geometric value (position, normal) survives a copy.
-   * operator=(const Vertex&) has identical semantics.
    */
-  VertexT(const Vertex& a_otherVertex);
+  VertexT(const Vertex& a_otherVertex) = default;
 
   /**
-   * @brief Move constructor.
-   * @details Unlike the copy constructor, this transfers the entire state (including m_faces and
-   * m_metaData) from a_otherVertex, since moving relocates a single object's identity rather than
-   * grafting a copy into a different mesh's topology. Defaulted (memberwise move) rather than
-   * hand-written: explicitly defaulting is required here since the presence of a user-declared
-   * copy constructor would otherwise suppress the implicitly-generated move constructor. Not
-   * marked noexcept since Meta is an unconstrained template parameter whose move constructor is
-   * not guaranteed to be noexcept.
+   * @brief Move constructor (defaulted memberwise move).
    * @param[in, out] a_otherVertex Other vertex.
    */
   VertexT(Vertex&& a_otherVertex) = default;
@@ -143,20 +102,15 @@ public:
   ~VertexT() = default;
 
   /**
-   * @brief Copy assignment operator.
-   * @details Has the same narrow-copy semantics as the copy constructor (including that m_faces
-   * and m_metaData are not copied; use addFace()/setMetaData() afterwards if they need to be
-   * populated). See the copy constructor's documentation for details.
+   * @brief Copy assignment operator (defaulted memberwise copy).
    * @param[in] a_otherVertex Other vertex.
    * @return Reference to (*this).
    */
   Vertex&
-  operator=(const Vertex& a_otherVertex);
+  operator=(const Vertex& a_otherVertex) = default;
 
   /**
-   * @brief Move assignment operator.
-   * @details Has the same full-state-transfer semantics as the move constructor (defaulted
-   * memberwise move; see its documentation for why this must be defaulted explicitly).
+   * @brief Move assignment operator (defaulted memberwise move).
    * @param[in, out] a_otherVertex Other vertex.
    * @return Reference to (*this).
    */
@@ -165,13 +119,13 @@ public:
 
   /**
    * @brief Define function
-   * @param[in] a_position    Vertex position
-   * @param[in] a_edge   Pointer to outgoing edge
-   * @param[in] a_normal Vertex normal vector
-   * @details This sets the position, normal vector, and edge pointer.
+   * @param[in] a_position Vertex position
+   * @param[in] a_edge     Index of the outgoing edge (InvalidIndex if none yet)
+   * @param[in] a_normal   Vertex normal vector
+   * @details This sets the position, normal vector, and outgoing-edge index.
    */
   inline void
-  define(const Vec3& a_position, const EdgePtr& a_edge, const Vec3& a_normal) noexcept;
+  define(const Vec3& a_position, const DCELIndex a_edge, const Vec3& a_normal) noexcept;
 
   /**
    * @brief Set the vertex position
@@ -188,11 +142,11 @@ public:
   setNormal(const Vec3& a_normal) noexcept;
 
   /**
-   * @brief Set the reference to the outgoing edge
-   * @param[in] a_edge Pointer to an outgoing edge
+   * @brief Set the index of the outgoing edge
+   * @param[in] a_edge Index of an outgoing edge (InvalidIndex if none)
    */
   inline void
-  setEdge(const EdgePtr& a_edge) noexcept;
+  setEdge(const DCELIndex a_edge) noexcept;
 
   /**
    * @brief Set the meta-data.
@@ -202,11 +156,11 @@ public:
   setMetaData(const Meta& a_metaData) noexcept;
 
   /**
-   * @brief Add a face to the polygon face list.
-   * @param[in] a_face Pointer to face.
+   * @brief Add a face index to the incident-face list.
+   * @param[in] a_face Index of the incident face.
    */
   inline void
-  addFace(const FacePtr& a_face);
+  addFace(const DCELIndex a_face);
 
   /**
    * @brief Normalize the normal vector, ensuring its length is 1
@@ -215,44 +169,6 @@ public:
    */
   inline void
   normalizeNormalVector() noexcept;
-
-  /**
-   * @brief Compute the vertex normal, using an average the normal vector in this
-   * vertex's face list (m_faces)
-   */
-  inline void
-  computeVertexNormalAverage() noexcept;
-
-  /**
-   * @brief Compute the vertex normal, using an average of the normal vectors in
-   * the input face list
-   * @param[in] a_faces Faces
-   * @note This computes the vertex normal as n = sum(normal(face))/num(faces)
-   */
-  inline void
-  computeVertexNormalAverage(const std::vector<FacePtr>& a_faces) noexcept;
-
-  /**
-   * @brief Compute the vertex normal, using the pseudonormal algorithm which
-   * weights the normal with the subtended angle to each connected face.
-   * @details This calls the other version with a_faces = m_faces
-   * @note This computes the normal vector using the pseudnormal algorithm from
-   * Baerentzen and Aanes in "Signed distance computation using the angle
-   * weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49)
-   */
-  inline void
-  computeVertexNormalAngleWeighted();
-
-  /**
-   * @brief Compute the vertex normal, using the pseudonormal algorithm which
-   * weights the normal with the subtended angle to each connected face.
-   * @param[in] a_faces Faces to use for computation.
-   * @note This computes the normal vector using the pseudnormal algorithm from
-   * Baerentzen and Aanes in "Signed distance computation using the angle
-   * weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49)
-   */
-  inline void
-  computeVertexNormalAngleWeighted(const std::vector<FacePtr>& a_faces);
 
   /**
    * @brief Flip the normal vector
@@ -289,41 +205,31 @@ public:
   getNormal() const noexcept;
 
   /**
-   * @brief Get the outgoing edge.
-   * @details Returns a shared_ptr obtained by locking the internal weak_ptr (see the class-level
-   * note on ownership near m_outgoingEdge). Returns nullptr if the edge has been destroyed, which
-   * should not happen while the owning mesh is alive.
-   * @return Outgoing edge, or nullptr.
+   * @brief Get the index of the outgoing edge.
+   * @return Outgoing-edge index, or InvalidIndex.
    */
-  [[nodiscard]] inline EdgePtr
-  getOutgoingEdge() noexcept;
-
-  /**
-   * @brief Get the outgoing edge (const overload).
-   * @return Outgoing edge, or nullptr.
-   */
-  [[nodiscard]] inline EdgePtr
+  [[nodiscard]] inline DCELIndex
   getOutgoingEdge() const noexcept;
 
   /**
-   * @brief Get modifiable polygon face list for this vertex.
+   * @brief Get modifiable incident-face index list for this vertex.
    * @return Reference to m_faces.
    */
-  [[nodiscard]] inline std::vector<FacePtr>&
+  [[nodiscard]] inline std::vector<DCELIndex>&
   getFaces() noexcept;
 
   /**
-   * @brief Get immutable polygon face list for this vertex.
+   * @brief Get immutable incident-face index list for this vertex.
    * @return Const reference to m_faces.
    */
-  [[nodiscard]] inline const std::vector<FacePtr>&
+  [[nodiscard]] inline const std::vector<DCELIndex>&
   getFaces() const noexcept;
 
   /**
    * @brief Get the signed distance to this vertex
    * @param[in] a_x0 Position in space.
    * @return The returned distance is |a_x0 - m_position| and the sign is given
-   * by the sign of m_normal * |a_x0 - m_position|.
+   * by the sign of m_normal * (a_x0 - m_position).
    */
   [[nodiscard]] inline T
   signedDistance(const Vec3& a_x0) const noexcept;
@@ -354,15 +260,6 @@ public:
 
 protected:
   /**
-   * @brief Pointer to an outgoing edge from this vertex.
-   * @details Stored as a weak_ptr: the edge is owned by the mesh's own edge list, and a plain
-   * shared_ptr here would form a reference cycle with EdgeT::m_vertex (and, transitively, with
-   * EdgeT::m_nextEdge/m_pairEdge/m_face and FaceT::m_halfEdge) that shared_ptr's reference
-   * counting can never collect.
-   */
-  std::weak_ptr<Edge> m_outgoingEdge;
-
-  /**
    * @brief Vertex position
    */
   Vec3 m_position;
@@ -373,17 +270,20 @@ protected:
   Vec3 m_normal;
 
   /**
-   * @brief List of faces connected to this vertex.
-   * @details These must be added by addFace(), and is used when computing the vertex
-   * normal vector.
+   * @brief Index of an outgoing edge from this vertex (InvalidIndex if none).
    */
-  std::vector<FacePtr> m_faces;
+  DCELIndex m_outgoingEdge = InvalidIndex;
+
+  /**
+   * @brief Indices of the faces incident on this vertex.
+   * @details These must be added by addFace(), and are used when computing the vertex
+   * normal vector (in particular the angle-weighted pseudonormal).
+   */
+  std::vector<DCELIndex> m_faces;
 
   /**
    * @brief Meta-data for this vertex
-   * @details Value-initialized so that every constructor leaves it in a defined state: for a
-   * fundamental Meta type (e.g. short, int), a member with no initializer and no explicit
-   * mention in a constructor's member-initializer list is left indeterminate, not zero.
+   * @details Value-initialized so that every constructor leaves it in a defined state.
    */
   Meta m_metaData{};
 };

--- a/Source/EBGeometry_DCEL_VertexImplem.hpp
+++ b/Source/EBGeometry_DCEL_VertexImplem.hpp
@@ -12,17 +12,11 @@
 #define EBGEOMETRY_DCEL_VERTEXIMPLEM_HPP
 
 // Std includes
-#include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <limits>
-#include <memory>
 #include <vector>
 
 // Our includes
-#include "EBGeometry_DCEL_Edge.hpp"
-#include "EBGeometry_DCEL_Face.hpp"
-#include "EBGeometry_DCEL_Iterator.hpp"
 #include "EBGeometry_DCEL_Vertex.hpp"
 #include "EBGeometry_Macros.hpp"
 
@@ -55,29 +49,8 @@ inline VertexT<T, Meta>::VertexT(const Vec3& a_position, const Vec3& a_normal) :
 }
 
 template <class T, class Meta>
-inline VertexT<T, Meta>::VertexT(const VertexT<T, Meta>& a_otherVertex)
-{
-  m_position     = a_otherVertex.m_position;
-  m_normal       = a_otherVertex.m_normal;
-  m_outgoingEdge = a_otherVertex.m_outgoingEdge;
-}
-
-template <class T, class Meta>
-inline VertexT<T, Meta>&
-VertexT<T, Meta>::operator=(const VertexT<T, Meta>& a_otherVertex)
-{
-  if (this != &a_otherVertex) {
-    m_position     = a_otherVertex.m_position;
-    m_normal       = a_otherVertex.m_normal;
-    m_outgoingEdge = a_otherVertex.m_outgoingEdge;
-  }
-
-  return *this;
-}
-
-template <class T, class Meta>
 inline void
-VertexT<T, Meta>::define(const Vec3& a_position, const EdgePtr& a_edge, const Vec3& a_normal) noexcept
+VertexT<T, Meta>::define(const Vec3& a_position, const DCELIndex a_edge, const Vec3& a_normal) noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_position[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_position[1]));
@@ -86,7 +59,7 @@ VertexT<T, Meta>::define(const Vec3& a_position, const EdgePtr& a_edge, const Ve
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[2]));
 
-  // a_edge == nullptr is valid here (e.g. a freshly-created vertex not yet wired into the mesh).
+  // a_edge == InvalidIndex is valid here (e.g. a freshly-created vertex not yet wired into the mesh).
   m_position     = a_position;
   m_outgoingEdge = a_edge;
   m_normal       = a_normal;
@@ -105,10 +78,10 @@ VertexT<T, Meta>::setPosition(const Vec3& a_position) noexcept
 
 template <class T, class Meta>
 inline void
-VertexT<T, Meta>::setEdge(const EdgePtr& a_edge) noexcept
+VertexT<T, Meta>::setEdge(const DCELIndex a_edge) noexcept
 {
-  // a_edge == nullptr is valid here; callers that dereference m_outgoingEdge are responsible for
-  // checking it first (see e.g. computeVertexNormalAngleWeighted).
+  // a_edge == InvalidIndex is valid here; callers that follow m_outgoingEdge are responsible for
+  // checking it first.
   m_outgoingEdge = a_edge;
 }
 
@@ -132,9 +105,9 @@ VertexT<T, Meta>::setNormal(const Vec3& a_normal) noexcept
 
 template <class T, class Meta>
 inline void
-VertexT<T, Meta>::addFace(const FacePtr& a_face)
+VertexT<T, Meta>::addFace(const DCELIndex a_face)
 {
-  EBGEOMETRY_EXPECT(a_face != nullptr);
+  EBGEOMETRY_EXPECT(a_face >= 0);
 
   m_faces.emplace_back(a_face);
 }
@@ -150,154 +123,6 @@ VertexT<T, Meta>::normalizeNormalVector() noexcept
   if (len > std::numeric_limits<T>::epsilon()) {
     m_normal = m_normal / len;
   }
-}
-
-template <class T, class Meta>
-inline void
-VertexT<T, Meta>::computeVertexNormalAverage() noexcept
-{
-  this->computeVertexNormalAverage(m_faces);
-}
-
-template <class T, class Meta>
-inline void
-VertexT<T, Meta>::computeVertexNormalAverage(const std::vector<FacePtr>& a_faces) noexcept
-{
-  EBGEOMETRY_EXPECT(!a_faces.empty());
-
-  m_normal = Vec3::zeros();
-
-  // TLDR: We simply compute the sum of the normal vectors for each face in
-  // a_faces and then normalize. This
-  //       will yield an "average" of the normal vectors of the faces
-  //       circulating this vertex.
-  for (const auto& f : a_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    m_normal += f->getNormal();
-  }
-
-  this->normalizeNormalVector();
-}
-
-template <class T, class Meta>
-inline void
-VertexT<T, Meta>::computeVertexNormalAngleWeighted()
-{
-  this->computeVertexNormalAngleWeighted(m_faces);
-}
-
-template <class T, class Meta>
-inline void
-VertexT<T, Meta>::computeVertexNormalAngleWeighted(const std::vector<FacePtr>& a_faces)
-{
-  m_normal = Vec3::zeros();
-
-  // This routine computes the pseudonormal from pseudnormal algorithm from
-  // Baerentzen and Aanes in "Signed distance computation using the angle
-  // weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49). This algorithm computes
-  // an average normal vector using the normal vectors of each face connected to
-  // this vertex, i.e. in the form
-  //
-  //    n = sum(w * n(face))/sum(w)
-  //
-  // where w are weights for each face. This weight is given by the subtended
-  // angle of the face, which means the angle spanned by the incoming/outgoing
-  // edges of the face that pass through this vertex.
-  //
-  //
-  // The below code is more complicated than it looks. It happens because we
-  // want the two half edges that has the current vertex as a mutual vertex
-  // (i.e. the "incoming" and "outgoing" edges into this vertex). Normally we'd
-  // just iterate through edges, but if it happens that an input face is
-  // flipped, this will result in infinite iteration. Instead, we have stored
-  // the pointers to each face connected to this vertex. We look through each
-  // face to find the endpoints of the edges the have the current vertex as the
-  // common vertex, and then compute the subtended angle between those. Sigh...
-
-  EBGEOMETRY_EXPECT(!a_faces.empty());
-  EBGEOMETRY_EXPECT(!m_outgoingEdge.expired());
-  const VertexPtr originVertex = m_outgoingEdge.lock()->getVertex(); // AKA 'this'
-
-  for (const auto& f : a_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    std::vector<VertexPtr> inoutVertices(0);
-    for (EdgeIterator edgeIt(f->getHalfEdge()); edgeIt.ok(); ++edgeIt) {
-      const auto& e = edgeIt();
-
-      const auto& v1 = e->getVertex();
-      const auto& v2 = e->getOtherVertex();
-
-      EBGEOMETRY_EXPECT(v1 != nullptr);
-      EBGEOMETRY_EXPECT(v2 != nullptr);
-
-      if (v1 == originVertex || v2 == originVertex) {
-        if (v1 == originVertex) {
-          inoutVertices.emplace_back(v2);
-        }
-        else if (v2 == originVertex) {
-          inoutVertices.emplace_back(v1);
-        }
-        else {
-          std::cerr << "VertexT<T, Meta>::computeVertexNormalAngleWeighted(): unreachable branch "
-                       "hit -- a half-edge of face f was found to have originVertex as one of its "
-                       "two endpoints, but neither v1 nor v2 compares equal to it. This points to "
-                       "a corrupted or inconsistent half-edge/vertex topology (e.g. a stale vertex "
-                       "pointer) rather than a normal mesh-quality issue.\n";
-        }
-      }
-    }
-
-    if (inoutVertices.size() != 2) {
-      std::cerr << "VertexT<T, Meta>::computeVertexNormalAngleWeighted(): face f should be incident "
-                   "on the origin vertex through exactly 2 half-edges (one incoming, one "
-                   "outgoing), but "
-                << inoutVertices.size()
-                << " were found. This means f is not a well-formed triangle sharing this vertex "
-                   "(e.g. the origin vertex appears more than once on f's boundary, or not at "
-                   "all) -- check the mesh for degenerate or non-manifold faces.\n";
-    }
-
-    // The cerr above only warns; this used to fall through to indexing inoutVertices[0]/[1]
-    // unconditionally, which is undefined behaviour (out-of-bounds read) if the face isn't a
-    // well-formed triangle incident on exactly two edges at this vertex.
-    EBGEOMETRY_EXPECT(inoutVertices.size() == 2);
-
-    const Vec3& x0 = originVertex->getPosition();
-    const Vec3& x1 = inoutVertices[0]->getPosition();
-    const Vec3& x2 = inoutVertices[1]->getPosition();
-
-    if (x0 == x1 || x0 == x2 || x1 == x2) {
-      std::cerr << "VertexT<T, Meta>::computeVertexNormalAngleWeighted(): degenerate face f -- two "
-                   "of the origin vertex position ("
-                << x0 << ") and its two neighboring vertex positions (" << x1 << ", " << x2
-                << ") coincide. This produces a zero-length edge, which has no well-defined "
-                   "subtended angle -- check the mesh for duplicate/collapsed vertices.\n";
-    }
-
-    // Likewise, the cerr above only warns; this used to fall through to dividing by
-    // v1.length()/v2.length() unconditionally, which is a division by zero if x0 coincides with
-    // x1 or x2 (a degenerate/zero-length edge).
-    EBGEOMETRY_EXPECT(x0 != x1);
-    EBGEOMETRY_EXPECT(x0 != x2);
-    EBGEOMETRY_EXPECT(x1 != x2);
-
-    Vec3 v1 = x1 - x0;
-    Vec3 v2 = x2 - x0;
-
-    v1 = v1 / v1.length();
-    v2 = v2 / v2.length();
-
-    const Vec3& norm = f->getNormal();
-
-    // Clamp to [-1,1] to guard against std::acos(NaN) from floating-point rounding.
-    const T alpha = std::acos(std::clamp(v1.dot(v2), T(-1), T(1)));
-
-    m_normal += alpha * norm;
-  }
-
-  this->normalizeNormalVector();
 }
 
 template <class T, class Meta>
@@ -336,28 +161,21 @@ VertexT<T, Meta>::getNormal() const noexcept
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-VertexT<T, Meta>::getOutgoingEdge() noexcept
-{
-  return m_outgoingEdge.lock();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
+inline DCELIndex
 VertexT<T, Meta>::getOutgoingEdge() const noexcept
 {
-  return m_outgoingEdge.lock();
+  return m_outgoingEdge;
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<FaceT<T, Meta>>>&
+inline std::vector<DCELIndex>&
 VertexT<T, Meta>::getFaces() noexcept
 {
   return m_faces;
 }
 
 template <class T, class Meta>
-inline const std::vector<std::shared_ptr<FaceT<T, Meta>>>&
+inline const std::vector<DCELIndex>&
 VertexT<T, Meta>::getFaces() const noexcept
 {
   return m_faces;

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -132,15 +132,13 @@ protected:
 /**
  * @brief Signed distance function for a DCEL mesh. Stores the mesh in a PackedBVH for
  * SIMD-accelerated traversal. Accepts any polygon, not just triangles.
- * @details The mesh faces are packed into a flat-array PackedBVH. SIMD traversal
- * is used when T and K match an available ISA path. Unlike TriMeshSDF, MeshSDF does not expose a
- * PackedBVH StoragePolicy choice: its PackedBVH always uses BVH::SharedPtrStorage<Face>, sharing
- * each packed face with the DCEL mesh's own face list rather than copying it. This is not just a
- * default -- DCEL::FaceT's copy constructor deliberately does not copy its cached 2D polygon
- * embedding (m_poly2, used by signedDistance()'s point-in-face test), so a naive by-value copy
- * (as BVH::ValueStorage would produce) is left with a null embedding and crashes on first query;
- * see FaceT's copy-constructor documentation. See the user documentation for the full rationale,
- * including why TriMeshSDF's SoA groups do not have this restriction.
+ * @details The mesh faces are packed into a flat-array PackedBVH whose primitive is the face INDEX
+ * (a @c DCEL::DCELIndex) into the retained DCEL mesh's face array, stored by value
+ * (BVH::ValueStorage<DCELIndex>). SIMD traversal is used when T and K match an available ISA path.
+ * Each distance query resolves a face index against the retained mesh and calls
+ * MeshT::signedDistanceToFace()/unsignedDistance2ToFace(). Storing indices rather than face objects
+ * keeps the packed representation flat and trivially copyable, and avoids duplicating the DCEL
+ * topology.
  * @tparam T    Floating-point precision type (float or double).
  * @tparam Meta Triangle metadata type stored on each DCEL face.
  * @tparam K    BVH branching factor (number of children per internal node).
@@ -163,9 +161,14 @@ public:
   using Mesh = typename EBGeometry::DCEL::MeshT<T, Meta>;
 
   /**
-   * @brief Alias for the linearized BVH root
+   * @brief Alias for the BVH primitive type: a face index into the DCEL mesh's face array.
    */
-  using Root = EBGeometry::BVH::PackedBVH<T, Face, K>;
+  using PrimIndex = EBGeometry::DCEL::DCELIndex;
+
+  /**
+   * @brief Alias for the linearized BVH root. Primitives are face indices stored by value.
+   */
+  using Root = EBGeometry::BVH::PackedBVH<T, PrimIndex, K, EBGeometry::BVH::ValueStorage<PrimIndex>>;
 
   /**
    * @brief Alias for a single linearized node
@@ -235,13 +238,14 @@ public:
   /**
    * @brief Return faces within BVH-pruned candidate distance of a_point.
    * @details Traverses the PackedBVH and collects candidate faces.  The
-   * result pairs each face with its unsigned distance to a_point.
+   * result pairs each face INDEX (into the retained DCEL mesh) with its unsigned distance to
+   * a_point.
    * @param[in] a_point  Query point.
    * @param[in] a_sorted If true, the returned vector is sorted by ascending
    * unsigned distance (closest face first).
-   * @return Vector of (face, unsigned_distance) pairs, optionally sorted.
+   * @return Vector of (face index, unsigned_distance) pairs, optionally sorted.
    */
-  [[nodiscard]] virtual std::vector<std::pair<std::shared_ptr<const Face>, T>>
+  [[nodiscard]] virtual std::vector<std::pair<PrimIndex, T>>
   getClosestFaces(const Vec3T<T>& a_point, const bool a_sorted) const;
 
   /**
@@ -273,9 +277,8 @@ protected:
 
   /**
    * @brief Source DCEL mesh.
-   * @details Retained so that the faces held by m_bvh -- whose half-edges (and the edges/vertices
-   * reachable from them) are only weakly referenced, not owned, see DCEL::FaceT::m_halfEdge -- stay
-   * valid. The mesh's own vertex/edge/face vectors are the sole owners of that topology.
+   * @details Retained because m_bvh stores only face INDICES into this mesh's face array; every
+   * distance query resolves an index against this mesh. It must therefore outlive the BVH.
    */
   std::shared_ptr<Mesh> m_mesh;
 };

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -263,6 +263,15 @@ public:
   getRoot() const noexcept;
 
   /**
+   * @brief Get the source DCEL mesh that the BVH's face indices refer to.
+   * @details The BVH stores only face indices; callers of getClosestFaces() resolve those indices
+   * against this mesh (e.g. to read a face's metadata or vertices).
+   * @return Const reference to the shared pointer owning the DCEL mesh.
+   */
+  [[nodiscard]] const std::shared_ptr<Mesh>&
+  getMesh() const noexcept;
+
+  /**
    * @brief Compute the AABB enclosing the entire mesh.
    * @return Axis-aligned bounding box of the mesh.
    */

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -27,6 +27,7 @@
 // Our includes
 #include "EBGeometry_DCEL_Edge.hpp"
 #include "EBGeometry_DCEL_Face.hpp"
+#include "EBGeometry_DCEL_Iterator.hpp"
 #include "EBGeometry_DCEL_Mesh.hpp"
 #include "EBGeometry_DCEL_Vertex.hpp"
 #include "EBGeometry_Macros.hpp"
@@ -42,7 +43,8 @@ namespace MeshDistanceFunctionsDetail {
 
 /**
  * @brief Build a tree BVH from a DCEL mesh.
- * @details Internal helper; not part of the public API.
+ * @details Internal helper; not part of the public API. The BVH primitive is the face INDEX into
+ * the mesh's face array; each face's bounding volume is built from that face's vertex coordinates.
  * @tparam T    Floating-point precision type.
  * @tparam Meta Face and vertex metadata type.
  * @tparam BV   Bounding-volume type (e.g. AABBT<T>).
@@ -52,7 +54,7 @@ namespace MeshDistanceFunctionsDetail {
  * @return Shared pointer to the root of the resulting tree BVH.
  */
 template <class T, class Meta, class BV, size_t K>
-[[nodiscard]] std::shared_ptr<EBGeometry::BVH::TreeBVH<T, DCEL::FaceT<T, Meta>, BV, K>>
+[[nodiscard]] std::shared_ptr<EBGeometry::BVH::TreeBVH<T, EBGeometry::DCEL::DCELIndex, BV, K>>
 buildDCELTreeBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcelMesh,
                  const BVH::Build                                         a_build = BVH::Build::SAH)
 {
@@ -63,16 +65,17 @@ buildDCELTreeBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcel
   EBGEOMETRY_EXPECT(a_dcelMesh != nullptr);
   EBGEOMETRY_EXPECT(!a_dcelMesh->getFaces().empty());
 
-  using Prim          = EBGeometry::DCEL::FaceT<T, Meta>;
+  using Prim          = EBGeometry::DCEL::DCELIndex;
   using PrimAndBVList = std::vector<std::pair<std::shared_ptr<const Prim>, BV>>;
 
-  // Create a pair-wise list of DCEL faces and their bounding volumes.
+  // Create a pair-wise list of DCEL face indices and their bounding volumes.
   PrimAndBVList primsAndBVs;
 
-  for (const auto& f : a_dcelMesh->getFaces()) {
-    EBGEOMETRY_EXPECT(f != nullptr);
+  for (size_t i = 0; i < a_dcelMesh->getFaces().size(); i++) {
+    const Prim faceIdx = static_cast<Prim>(i);
 
-    primsAndBVs.emplace_back(std::make_pair(f, BV(f->getAllVertexCoordinates())));
+    primsAndBVs.emplace_back(
+      std::make_pair(std::make_shared<const Prim>(faceIdx), BV(a_dcelMesh->getFaceVertexCoordinates(faceIdx))));
   }
 
   // Partition the BVH using the default input arguments.
@@ -254,14 +257,11 @@ MeshSDF<T, Meta, K>::MeshSDF(const std::shared_ptr<Mesh>& a_mesh, const BVH::Bui
   using AABB     = EBGeometry::BoundingVolumes::AABBT<T>;
   const auto bvh = EBGeometry::MeshDistanceFunctionsDetail::buildDCELTreeBVH<T, Meta, AABB, K>(a_mesh, a_build);
 
-  m_bvh = bvh->pack();
+  m_bvh = bvh->template pack<EBGeometry::BVH::ValueStorage<PrimIndex>>();
 
-  // DCEL::FaceT/EdgeT/VertexT only hold weak_ptr back-references to their neighboring
-  // half-edges/vertices/faces (to avoid reference cycles); the mesh's own vertex/edge/face
-  // vectors are the sole owners keeping them alive. m_bvh only keeps the faces themselves
-  // alive (as its primitives), so the source mesh must be retained here too, or every face's
-  // half-edge (and the rest of its edge loop) would dangle as soon as the caller's mesh
-  // shared_ptr goes out of scope.
+  // m_bvh stores only face INDICES into a_mesh's face array; every distance query resolves an
+  // index against the mesh. The source mesh must therefore be retained here, or those indices
+  // would dangle as soon as the caller's mesh shared_ptr goes out of scope.
   m_mesh = a_mesh;
 }
 
@@ -276,10 +276,11 @@ MeshSDF<T, Meta, K>::signedDistance(const Vec3T<T>& a_point) const noexcept
 
   T           minDist = std::numeric_limits<T>::max();
   const auto& faces   = m_bvh->getPrimitives();
+  const Mesh& mesh    = *m_mesh;
 
-  const auto evalLeaf = [&faces, &a_point](T& a_state, size_t a_offset, size_t a_count) noexcept {
+  const auto evalLeaf = [&faces, &mesh, &a_point](T& a_state, size_t a_offset, size_t a_count) noexcept {
     for (size_t i = a_offset; i < a_offset + a_count; i++) {
-      const T curDist = faces[i]->signedDistance(a_point);
+      const T curDist = mesh.signedDistanceToFace(faces[i], a_point);
 
       EBGEOMETRY_EXPECT(!std::isnan(curDist));
 
@@ -295,7 +296,7 @@ MeshSDF<T, Meta, K>::signedDistance(const Vec3T<T>& a_point) const noexcept
 }
 
 template <class T, class Meta, size_t K>
-std::vector<std::pair<std::shared_ptr<const EBGeometry::DCEL::FaceT<T, Meta>>, T>>
+std::vector<std::pair<typename MeshSDF<T, Meta, K>::PrimIndex, T>>
 MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorted) const
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
@@ -303,10 +304,12 @@ MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorte
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  using FaceAndDist = std::pair<std::shared_ptr<const Face>, T>;
+  using FaceAndDist = std::pair<PrimIndex, T>;
 
-  // List of candidate faces.
+  // List of candidate face indices.
   std::vector<FaceAndDist> candidateFaces;
+
+  const Mesh& mesh = *m_mesh;
 
   // Declaration of the BVH metadata attached to each node - this will be the distance to the node itself.
   using BVHNodeKey = T;
@@ -330,11 +333,11 @@ MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorte
   const EBGeometry::BVH::NodeKeyFactory<Node, BVHNodeKey> nodeKeyFactory =
     [&a_point](const Node& a_node) noexcept -> BVHNodeKey { return a_node.getDistanceToBoundingVolume(a_point); };
 
-  const EBGeometry::BVH::PackedLeafEvaluator<Face> leafEvaluator =
-    [&shortestDistanceSoFar, &a_point, &candidateFaces](
-      const std::vector<std::shared_ptr<const Face>>& a_faces, size_t offset, size_t count) noexcept -> void {
+  const EBGeometry::BVH::PackedLeafEvaluator<PrimIndex, EBGeometry::BVH::ValueStorage<PrimIndex>> leafEvaluator =
+    [&shortestDistanceSoFar, &mesh, &a_point, &candidateFaces](
+      const std::vector<PrimIndex>& a_faces, size_t offset, size_t count) noexcept -> void {
     for (size_t i = offset; i < offset + count; i++) {
-      const T distToFace = std::sqrt(a_faces[i]->unsignedDistance2(a_point));
+      const T distToFace = std::sqrt(mesh.unsignedDistance2ToFace(a_faces[i], a_point));
 
       EBGEOMETRY_EXPECT(!std::isnan(distToFace));
 
@@ -357,7 +360,7 @@ MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorte
 }
 
 template <class T, class Meta, size_t K>
-std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::DCEL::FaceT<T, Meta>, K>>&
+std::shared_ptr<typename MeshSDF<T, Meta, K>::Root>&
 MeshSDF<T, Meta, K>::getRoot() noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
@@ -366,7 +369,7 @@ MeshSDF<T, Meta, K>::getRoot() noexcept
 }
 
 template <class T, class Meta, size_t K>
-const std::shared_ptr<EBGeometry::BVH::PackedBVH<T, EBGeometry::DCEL::FaceT<T, Meta>, K>>&
+const std::shared_ptr<typename MeshSDF<T, Meta, K>::Root>&
 MeshSDF<T, Meta, K>::getRoot() const noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
@@ -426,27 +429,41 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>
 
   std::vector<std::shared_ptr<Tri>> triangles;
 
+  const auto& meshVertices = a_mesh->getVertices();
+  const auto& meshEdges    = a_mesh->getEdges();
+
   for (const auto& f : a_mesh->getFaces()) {
-    EBGEOMETRY_EXPECT(f != nullptr);
+    const auto normal = f.getNormal();
 
-    const auto normal   = f->getNormal();
-    const auto vertices = f->gatherVertices();
-    const auto edges    = f->gatherEdges();
+    // Gather the face's vertex and edge indices in half-edge order.
+    std::vector<EBGeometry::DCEL::DCELIndex> vertexIndices;
+    std::vector<EBGeometry::DCEL::DCELIndex> edgeIndices;
 
-    EBGEOMETRY_EXPECT(vertices.size() == 3);
-    EBGEOMETRY_EXPECT(edges.size() == 3);
+    for (EBGeometry::DCEL::EdgeIteratorT<T, Meta> it(meshEdges, f.getHalfEdge()); it.ok(); ++it) {
+      edgeIndices.emplace_back(it());
+      vertexIndices.emplace_back(meshEdges[it()].getVertex());
+    }
 
-    if ((vertices.size() != 3) || (edges.size() != 3)) {
+    EBGEOMETRY_EXPECT(vertexIndices.size() == 3);
+    EBGEOMETRY_EXPECT(edgeIndices.size() == 3);
+
+    if ((vertexIndices.size() != 3) || (edgeIndices.size() != 3)) {
       std::cerr << "TriMeshSDF -- mesh not triangulated!\n";
     }
 
     auto tri = std::make_shared<Tri>();
 
     tri->setNormal(normal);
-    tri->setVertexPositions({vertices[0]->getPosition(), vertices[1]->getPosition(), vertices[2]->getPosition()});
-    tri->setVertexNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
-    tri->setEdgeNormals({edges[0]->getNormal(), edges[1]->getNormal(), edges[2]->getNormal()});
-    tri->setMetaData(f->getMetaData());
+    tri->setVertexPositions({meshVertices[vertexIndices[0]].getPosition(),
+                             meshVertices[vertexIndices[1]].getPosition(),
+                             meshVertices[vertexIndices[2]].getPosition()});
+    tri->setVertexNormals({meshVertices[vertexIndices[0]].getNormal(),
+                           meshVertices[vertexIndices[1]].getNormal(),
+                           meshVertices[vertexIndices[2]].getNormal()});
+    tri->setEdgeNormals({meshEdges[edgeIndices[0]].getNormal(),
+                         meshEdges[edgeIndices[1]].getNormal(),
+                         meshEdges[edgeIndices[2]].getNormal()});
+    tri->setMetaData(f.getMetaData());
 
     triangles.emplace_back(tri);
   }

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -378,6 +378,15 @@ MeshSDF<T, Meta, K>::getRoot() const noexcept
 }
 
 template <class T, class Meta, size_t K>
+const std::shared_ptr<typename MeshSDF<T, Meta, K>::Mesh>&
+MeshSDF<T, Meta, K>::getMesh() const noexcept
+{
+  EBGEOMETRY_EXPECT(m_mesh != nullptr);
+
+  return (m_mesh);
+}
+
+template <class T, class Meta, size_t K>
 EBGeometry::BoundingVolumes::AABBT<T>
 MeshSDF<T, Meta, K>::computeBoundingVolume() const noexcept
 {

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -1847,12 +1847,20 @@ Parser::readIntoTriangles(const std::string a_filename)
 
   bool onlyTriangles = true;
 
-  for (const auto& f : mesh->getFaces()) {
-    const auto normal   = f->getNormal();
-    const auto vertices = f->gatherVertices();
-    const auto edges    = f->gatherEdges();
+  const auto& meshVertices = mesh->getVertices();
+  const auto& meshEdges    = mesh->getEdges();
 
-    if (vertices.size() != 3) {
+  for (const auto& f : mesh->getFaces()) {
+    const auto normal = f.getNormal();
+
+    // Gather the face's vertex indices in half-edge order.
+    std::vector<EBGeometry::DCEL::DCELIndex> vertexIndices;
+
+    for (EBGeometry::DCEL::EdgeIteratorT<T, Meta> it(meshEdges, f.getHalfEdge()); it.ok(); ++it) {
+      vertexIndices.emplace_back(meshEdges[it()].getVertex());
+    }
+
+    if (vertexIndices.size() != 3) {
       onlyTriangles = false;
     }
 
@@ -1860,9 +1868,15 @@ Parser::readIntoTriangles(const std::string a_filename)
     auto tri = std::make_shared<Triangle<T, Meta>>();
 
     tri->setNormal(normal);
-    tri->setVertexPositions({vertices[0]->getPosition(), vertices[1]->getPosition(), vertices[2]->getPosition()});
-    tri->setVertexNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
-    tri->setEdgeNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
+    tri->setVertexPositions({meshVertices[vertexIndices[0]].getPosition(),
+                             meshVertices[vertexIndices[1]].getPosition(),
+                             meshVertices[vertexIndices[2]].getPosition()});
+    tri->setVertexNormals({meshVertices[vertexIndices[0]].getNormal(),
+                           meshVertices[vertexIndices[1]].getNormal(),
+                           meshVertices[vertexIndices[2]].getNormal()});
+    tri->setEdgeNormals({meshVertices[vertexIndices[0]].getNormal(),
+                         meshVertices[vertexIndices[1]].getNormal(),
+                         meshVertices[vertexIndices[2]].getNormal()});
 
     triangles.emplace_back(tri);
   }

--- a/Source/EBGeometry_Polygon2D.hpp
+++ b/Source/EBGeometry_Polygon2D.hpp
@@ -75,9 +75,13 @@ public:
   using Vec3 = Vec3T<T>;
 
   /**
-   * @brief Disallowed constructor, use the one with the normal vector and points
+   * @brief Default constructor, creating an empty polygon (no projected points).
+   * @details Needed so that DCEL::FaceT can store a Polygon2D by value and be default-constructible
+   * before the mesh is reconciled. An empty polygon must not be queried with isPointInside() until
+   * it has been assigned a properly-defined polygon (via the full constructor); the DCEL reconcile
+   * step does exactly that for every face before any distance query.
    */
-  Polygon2D() = delete;
+  Polygon2D() noexcept = default;
 
   /**
    * @brief Full constructor

--- a/Source/EBGeometry_Soup.hpp
+++ b/Source/EBGeometry_Soup.hpp
@@ -73,16 +73,16 @@ soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
 
 /**
  * @brief Reconcile pair edges: link each half-edge with its reverse.
- * @details For every half-edge (u→v) the function finds the corresponding reverse
- * half-edge (v→u) by iterating over all faces incident to u and sets the pair-edge
- * pointer on both.
+ * @details For every half-edge (u→v) the function finds the corresponding reverse half-edge (v→u)
+ * using a map keyed on the undirected vertex-index pair (min(u,v), max(u,v)), and sets the
+ * pair-edge index on both. This replaces the old O(n^2) incident-face scan.
  * @tparam T    Floating-point precision type.
  * @tparam Meta Metadata type attached to DCEL edges.
- * @param[in,out] a_edges Collection of all half-edges to reconcile.
+ * @param[in,out] a_edges Flat array of all half-edges to reconcile.
  */
 template <typename T, typename Meta>
 inline static void
-reconcilePairEdgesDCEL(std::vector<std::shared_ptr<EBGeometry::DCEL::EdgeT<T, Meta>>>& a_edges) noexcept;
+reconcilePairEdgesDCEL(std::vector<EBGeometry::DCEL::EdgeT<T, Meta>>& a_edges) noexcept;
 
 } // namespace Soup
 

--- a/Source/EBGeometry_SoupImplem.hpp
+++ b/Source/EBGeometry_SoupImplem.hpp
@@ -153,68 +153,56 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
 {
   static_assert(std::is_floating_point_v<T>, "Soup::soupToDCEL requires a floating-point T");
 
-  using Vec3   = EBGeometry::Vec3T<T>;
-  using Vertex = EBGeometry::DCEL::VertexT<T, Meta>;
-  using Edge   = EBGeometry::DCEL::EdgeT<T, Meta>;
-  using Face   = EBGeometry::DCEL::FaceT<T, Meta>;
+  using Vec3      = EBGeometry::Vec3T<T>;
+  using Vertex    = EBGeometry::DCEL::VertexT<T, Meta>;
+  using Edge      = EBGeometry::DCEL::EdgeT<T, Meta>;
+  using Face      = EBGeometry::DCEL::FaceT<T, Meta>;
+  using DCELIndex = EBGeometry::DCEL::DCELIndex;
 
-  std::vector<std::shared_ptr<Vertex>>& vertices = a_mesh.getVertices();
-  std::vector<std::shared_ptr<Edge>>&   edges    = a_mesh.getEdges();
-  std::vector<std::shared_ptr<Face>>&   faces    = a_mesh.getFaces();
+  std::vector<Vertex>& vertices = a_mesh.getVertices();
+  std::vector<Edge>&   edges    = a_mesh.getEdges();
+  std::vector<Face>&   faces    = a_mesh.getFaces();
 
-  // Build the vertex vectors from the input vertices.
+  // Build the vertex array from the input vertices.
+  vertices.reserve(a_vertices.size());
   for (const auto& v : a_vertices) {
-    vertices.emplace_back(std::make_shared<Vertex>(v, Vec3::zeros()));
+    vertices.emplace_back(v, Vec3::zeros());
   }
 
-  // Now build the faces.
+  // Now build the faces and their half-edges directly into the flat arrays.
   for (const auto& curFacet : a_facets) {
     if (curFacet.size() < 3) {
-      std::cerr << "Parser::soupToDCEL -- not enough vertices in face, skipping it\n";
+      std::cerr << "Soup::soupToDCEL -- not enough vertices in face, skipping it\n";
 
-      // The cerr above only warns; falling through here would reach halfEdges.front() on a
-      // possibly-empty vector below, which is undefined behavior for a 0-vertex facet.
+      // The cerr above only warns; falling through would create a malformed face below.
       EBGEOMETRY_EXPECT(curFacet.size() >= 3);
 
       continue;
     }
 
-    // Figure out which vertices are involved here.
-    std::vector<std::shared_ptr<Vertex>> faceVertices;
-    faceVertices.reserve(curFacet.size());
-    for (const size_t i : curFacet) {
-      EBGEOMETRY_EXPECT(i < vertices.size());
+    const DCELIndex firstEdge = static_cast<DCELIndex>(edges.size());
+    const DCELIndex faceIdx   = static_cast<DCELIndex>(faces.size());
+    const size_t    nEdges    = curFacet.size();
 
-      faceVertices.emplace_back(vertices[i]);
+    // Create one half-edge per corner, with the corner's vertex as its origin.
+    for (size_t i = 0; i < nEdges; i++) {
+      EBGEOMETRY_EXPECT(curFacet[i] < vertices.size());
+
+      const DCELIndex vertexIdx = static_cast<DCELIndex>(curFacet[i]);
+      const DCELIndex edgeIdx   = firstEdge + static_cast<DCELIndex>(i);
+
+      edges.emplace_back(vertexIdx);
+
+      // Wire up next-edge ring cyclically and the owning face.
+      edges[edgeIdx].setNextEdge(firstEdge + static_cast<DCELIndex>((i + 1) % nEdges));
+      edges[edgeIdx].setFace(faceIdx);
+
+      // Give the vertex an outgoing edge and register the incident face.
+      vertices[vertexIdx].setEdge(edgeIdx);
+      vertices[vertexIdx].addFace(faceIdx);
     }
 
-    // Build the half-edges for this polygon.
-    std::vector<std::shared_ptr<Edge>> halfEdges;
-    for (const auto& v : faceVertices) {
-      halfEdges.emplace_back(std::make_shared<Edge>(v));
-      v->setEdge(halfEdges.back());
-    }
-
-    for (size_t i = 0; i < halfEdges.size(); i++) {
-      auto& curEdge  = halfEdges[i];
-      auto& nextEdge = halfEdges[(i + 1) % halfEdges.size()];
-
-      curEdge->setNextEdge(nextEdge);
-    }
-
-    edges.insert(edges.end(), halfEdges.begin(), halfEdges.end());
-
-    faces.emplace_back(std::make_shared<Face>(halfEdges.front()));
-    auto& curFace = faces.back();
-
-    for (auto& e : halfEdges) {
-      e->setFace(curFace);
-    }
-
-    // Must give vertices access to all faces associated them.
-    for (const auto& v : faceVertices) {
-      v->addFace(curFace);
-    }
+    faces.emplace_back(firstEdge);
   }
 
   // Reconcile the pair edges and run a sanity check.
@@ -227,38 +215,39 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
 
 template <typename T, typename Meta>
 inline void
-Soup::reconcilePairEdgesDCEL(std::vector<std::shared_ptr<EBGeometry::DCEL::EdgeT<T, Meta>>>& a_edges) noexcept
+Soup::reconcilePairEdgesDCEL(std::vector<EBGeometry::DCEL::EdgeT<T, Meta>>& a_edges) noexcept
 {
   static_assert(std::is_floating_point_v<T>, "Soup::reconcilePairEdgesDCEL requires a floating-point T");
 
-  for (auto& curEdge : a_edges) {
-    EBGEOMETRY_EXPECT(curEdge != nullptr);
+  using DCELIndex = EBGeometry::DCEL::DCELIndex;
 
-    const auto& nextEdge = curEdge->getNextEdge();
-    EBGEOMETRY_EXPECT(nextEdge != nullptr);
+  // Map each undirected vertex pair (min,max) to the first half-edge seen with that pair. When a
+  // second half-edge with the same undirected pair appears, the two are each other's twins.
+  std::map<std::pair<DCELIndex, DCELIndex>, DCELIndex> edgeMap;
 
-    const auto& vertexStart = curEdge->getVertex();
-    const auto& vertexEnd   = nextEdge->getVertex();
-    EBGEOMETRY_EXPECT(vertexStart != nullptr);
+  for (size_t i = 0; i < a_edges.size(); i++) {
+    const DCELIndex edgeIdx  = static_cast<DCELIndex>(i);
+    const DCELIndex nextEdge = a_edges[edgeIdx].getNextEdge();
 
-    for (const auto& p : vertexStart->getFaces()) {
-      EBGEOMETRY_EXPECT(p != nullptr);
+    EBGEOMETRY_EXPECT(nextEdge != EBGeometry::DCEL::InvalidIndex);
 
-      for (EBGeometry::DCEL::EdgeIteratorT<T, Meta> edgeIt(*p); edgeIt.ok(); ++edgeIt) {
-        const auto& polyCurEdge = edgeIt();
-        EBGEOMETRY_EXPECT(polyCurEdge != nullptr);
+    const DCELIndex u = a_edges[edgeIdx].getVertex();
+    const DCELIndex w = a_edges[nextEdge].getVertex();
 
-        const auto& polyNextEdge = polyCurEdge->getNextEdge();
-        EBGEOMETRY_EXPECT(polyNextEdge != nullptr);
+    EBGEOMETRY_EXPECT(u != EBGeometry::DCEL::InvalidIndex);
+    EBGEOMETRY_EXPECT(w != EBGeometry::DCEL::InvalidIndex);
 
-        const auto& polyVertexStart = polyCurEdge->getVertex();
-        const auto& polyVertexEnd   = polyNextEdge->getVertex();
+    const std::pair<DCELIndex, DCELIndex> key = std::minmax(u, w);
 
-        if (vertexStart == polyVertexEnd && polyVertexStart == vertexEnd) { // Found the pair edge
-          curEdge->setPairEdge(polyCurEdge);
-          polyCurEdge->setPairEdge(curEdge);
-        }
-      }
+    const auto it = edgeMap.find(key);
+    if (it == edgeMap.end()) {
+      edgeMap.emplace(key, edgeIdx);
+    }
+    else {
+      const DCELIndex otherEdge = it->second;
+
+      a_edges[edgeIdx].setPairEdge(otherEdge);
+      a_edges[otherEdge].setPairEdge(edgeIdx);
     }
   }
 }

--- a/Source/EBGeometry_SoupImplem.hpp
+++ b/Source/EBGeometry_SoupImplem.hpp
@@ -221,8 +221,11 @@ Soup::reconcilePairEdgesDCEL(std::vector<EBGeometry::DCEL::EdgeT<T, Meta>>& a_ed
 
   using DCELIndex = EBGeometry::DCEL::DCELIndex;
 
-  // Map each undirected vertex pair (min,max) to the first half-edge seen with that pair. When a
-  // second half-edge with the same undirected pair appears, the two are each other's twins.
+  // Map each DIRECTED half-edge (origin, other) to its index. A half-edge (u -> w) is the twin of the
+  // anti-parallel half-edge (w -> u), so when we encounter (u -> w) we look for a previously seen
+  // (w -> u) and pair the two. This is orientation-aware: two half-edges with the SAME direction are
+  // never paired, so an inconsistently oriented or non-watertight mesh correctly leaves the affected
+  // edges unpaired (which MeshT::sanityCheck then reports).
   std::map<std::pair<DCELIndex, DCELIndex>, DCELIndex> edgeMap;
 
   for (size_t i = 0; i < a_edges.size(); i++) {
@@ -237,17 +240,19 @@ Soup::reconcilePairEdgesDCEL(std::vector<EBGeometry::DCEL::EdgeT<T, Meta>>& a_ed
     EBGEOMETRY_EXPECT(u != EBGeometry::DCEL::InvalidIndex);
     EBGEOMETRY_EXPECT(w != EBGeometry::DCEL::InvalidIndex);
 
-    const std::pair<DCELIndex, DCELIndex> key = std::minmax(u, w);
-
-    const auto it = edgeMap.find(key);
-    if (it == edgeMap.end()) {
-      edgeMap.emplace(key, edgeIdx);
-    }
-    else {
+    // Look for the anti-parallel half-edge (w -> u).
+    const auto it = edgeMap.find(std::make_pair(w, u));
+    if (it != edgeMap.end()) {
       const DCELIndex otherEdge = it->second;
 
       a_edges[edgeIdx].setPairEdge(otherEdge);
       a_edges[otherEdge].setPairEdge(edgeIdx);
+
+      // Consume the match so a third half-edge over the same undirected edge cannot re-pair it.
+      edgeMap.erase(it);
+    }
+    else {
+      edgeMap.emplace(std::make_pair(u, w), edgeIdx);
     }
   }
 }

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -95,6 +95,7 @@ using Meta = short;
   template class FaceT<PREC, Meta>;                                         \
   template class EdgeT<PREC, Meta>;                                         \
   template class VertexT<PREC, Meta>;                                       \
+  template class EdgeIteratorT<PREC, Meta>;                                 \
   }
 
 EBGEOMETRY_INSTANTIATE_ALL(double)

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -212,6 +212,9 @@ TEMPLATE_TEST_CASE("MeshSDF: signedDistance agrees with FlatMeshSDF for every BV
   for (const auto build : {BVH::Build::TopDown, BVH::Build::Morton, BVH::Build::Nested, BVH::Build::SAH}) {
     const MeshSDF<T, Meta, K> packed(mesh, build);
 
+    // The BVH stores face indices into the retained mesh; getMesh() exposes it for index resolution.
+    REQUIRE(packed.getMesh() == mesh);
+
     for (const auto& p : queryPoints<T>()) {
       REQUIRE_THAT(packed.signedDistance(p), withinAbsT(flat.signedDistance(p), traversalMargin<T>()));
     }

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -95,7 +95,7 @@ TEMPLATE_TEST_CASE("Dodecahedron: all four file formats parse into an identical,
     REQUIRE(mesh->getEdges().size() == 108); // 54 undirected edges * 2 half-edges each.
 
     for (const auto& e : mesh->getEdges()) {
-      REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+      REQUIRE(e.getPairEdge() != DCEL::InvalidIndex); // Watertight: every half-edge has a pair.
     }
   }
 
@@ -122,11 +122,14 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
   const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.obj"));
   REQUIRE(mesh != nullptr);
 
-  using Face = DCEL::FaceT<T, Meta>;
+  // The BVH primitive is the DCEL face index; each distance query resolves it against the mesh,
+  // exactly as MeshSDF does internally.
+  using Prim = DCEL::DCELIndex;
 
-  BVH::PrimAndBVList<Face, AABB> primsAndBVs;
-  for (const auto& f : mesh->getFaces()) {
-    primsAndBVs.emplace_back(f, AABB(f->getAllVertexCoordinates()));
+  BVH::PrimAndBVList<Prim, AABB> primsAndBVs;
+  for (size_t i = 0; i < mesh->getFaces().size(); i++) {
+    const Prim faceIdx = static_cast<Prim>(i);
+    primsAndBVs.emplace_back(std::make_shared<const Prim>(faceIdx), AABB(mesh->getFaceVertexCoordinates(faceIdx)));
   }
   REQUIRE(primsAndBVs.size() == 36);
 
@@ -139,7 +142,7 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
   auto buildAndCheck = [&](const char* a_label, auto&& a_partitionFunction) {
     INFO("Build strategy: " << a_label);
 
-    auto tree = std::make_shared<BVH::TreeBVH<T, Face, AABB, K>>(primsAndBVs);
+    auto tree = std::make_shared<BVH::TreeBVH<T, Prim, AABB, K>>(primsAndBVs);
     a_partitionFunction(*tree);
 
     const auto packed = tree->pack();
@@ -148,14 +151,14 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
 
     // PackedBVH has no signedDistance() of its own -- callers build their own thin wrapper
     // around pruneTraverse(), exactly as MeshSDF/TriMeshSDF::signedDistance() do.
-    const auto& faces = packed->getPrimitives();
+    const auto& faceIndices = packed->getPrimitives();
 
     for (const auto& p : queryPoints<T>()) {
       T state = std::numeric_limits<T>::max();
 
-      const auto evalLeaf = [&faces, &p](T& a_state, size_t a_offset, size_t a_count) noexcept {
+      const auto evalLeaf = [&faceIndices, &mesh, &p](T& a_state, size_t a_offset, size_t a_count) noexcept {
         for (size_t i = 0; i < a_count; i++) {
-          const T d = faces[a_offset + i]->signedDistance(p);
+          const T d = mesh->signedDistanceToFace(*faceIndices[a_offset + i], p);
           if (std::abs(d) < std::abs(a_state)) {
             a_state = d;
           }
@@ -173,19 +176,19 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
   buildAndCheck("TopDown (default BVCentroidPartitioner)", [](auto& a_tree) { a_tree.topDownSortAndPartition(); });
 
   buildAndCheck("TopDown (BinnedSAHPartitioner)", [](auto& a_tree) {
-    using Node              = BVH::TreeBVH<T, Face, AABB, K>;
+    using Node              = BVH::TreeBVH<T, Prim, AABB, K>;
     using LeafPred          = typename Node::LeafPredicate;
     const LeafPred stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
 
-    a_tree.topDownSortAndPartition(BVH::BinnedSAHPartitioner<T, Face, AABB, K>, stopCrit);
+    a_tree.topDownSortAndPartition(BVH::BinnedSAHPartitioner<T, Prim, AABB, K>, stopCrit);
   });
 
   buildAndCheck("TopDown (BinnedSAHPartitioner, longest-axis)", [](auto& a_tree) {
-    using Node              = BVH::TreeBVH<T, Face, AABB, K>;
+    using Node              = BVH::TreeBVH<T, Prim, AABB, K>;
     using LeafPred          = typename Node::LeafPredicate;
     const LeafPred stopCrit = [](const Node& n) noexcept -> bool { return n.getPrimitives().size() < K; };
 
-    a_tree.topDownSortAndPartition(BVH::BinnedSAHPartitioner<T, Face, AABB, K, true>, stopCrit);
+    a_tree.topDownSortAndPartition(BVH::BinnedSAHPartitioner<T, Prim, AABB, K, true>, stopCrit);
   });
 
   buildAndCheck("BottomUp (Morton)", [](auto& a_tree) { a_tree.template bottomUpSortAndPartition<SFC::Morton>(); });
@@ -941,8 +944,8 @@ TEMPLATE_TEST_CASE("StoragePolicy: appendAliased genuinely appends for both poli
   }
 }
 
-TEMPLATE_TEST_CASE("TriMeshSDF: default StoragePolicy is BVH::ValueStorage<TriSoA>; MeshSDF has no "
-                   "StoragePolicy choice at all",
+TEMPLATE_TEST_CASE("TriMeshSDF: default StoragePolicy is BVH::ValueStorage<TriSoA>; MeshSDF stores "
+                   "face indices by value",
                    "[BVH][StoragePolicy]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
@@ -951,17 +954,14 @@ TEMPLATE_TEST_CASE("TriMeshSDF: default StoragePolicy is BVH::ValueStorage<TriSo
   constexpr size_t K = 4;
   constexpr size_t W = 4;
 
-  using Face     = DCEL::FaceT<T, Meta>;
   using TriAoSoA = TriangleAoSoA<T, Meta, W>;
 
-  // MeshSDF always shares each packed face with the DCEL mesh's own face list (no copy, and no
-  // StoragePolicy template parameter to override it): DCEL::FaceT's copy constructor deliberately
-  // does not copy its cached 2D polygon embedding (m_poly2, needed by signedDistance()'s
-  // point-in-face test), so a naive by-value copy is unsafe -- see FaceT's copy-constructor
-  // documentation. TriMeshSDF's SoA groups have no such restriction (freshly built by packing,
-  // shared with nothing else), so it defaults to storing them inline with no indirection. See
-  // ImplemBVH.rst's "Storage policy" section for the full rationale.
-  static_assert(std::is_same_v<typename MeshSDF<T, Meta, K>::Root::StorageType, std::shared_ptr<const Face>>);
+  // MeshSDF stores the DCEL face INDEX (a DCEL::DCELIndex) as its BVH primitive, by value: the
+  // flat index-based DCEL keeps the topology in the retained mesh, so the BVH need only carry a
+  // trivially-copyable face index. TriMeshSDF's SoA groups are likewise stored inline with no
+  // indirection (freshly built by packing, shared with nothing else). See ImplemBVH.rst's
+  // "Storage policy" section for the full rationale.
+  static_assert(std::is_same_v<typename MeshSDF<T, Meta, K>::Root::StorageType, DCEL::DCELIndex>);
   static_assert(std::is_same_v<typename TriMeshSDF<T, Meta, K, W>::Root::StorageType, TriAoSoA>);
 }
 
@@ -1477,9 +1477,9 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
   buildAndCheckTree("BottomUp (Nested)", [](auto& a_tree) { a_tree.template bottomUpSortAndPartition<SFC::Nested>(); });
 
   // Remaining build methods go straight to PackedBVH, bypassing TreeBVH entirely -- Triangle<T,
-  // Meta> (unlike DCEL::FaceT) has a genuine memberwise copy constructor -- see its class
-  // declaration -- so it is safe to use with constructors that take primitives by value; see
-  // MeshSDF's own class doc for why DCEL::FaceT is not.
+  // Meta> is a self-contained value type, so it is safe to use with constructors that take
+  // primitives by value. MeshSDF instead stores DCEL face indices as its primitive -- see its
+  // class doc.
   auto checkDirect = [&](const char* a_label, const BVH::PackedBVH<T, Tri, K>& a_packed) {
     INFO(a_label);
     REQUIRE(a_packed.getPrimitives().size() == 4);
@@ -1941,16 +1941,17 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 {
   using T    = TestType;
   using AABB = BoundingVolumes::AABBT<T>;
-  using Face = DCEL::FaceT<T, Meta>;
+  using Prim = DCEL::DCELIndex;
 
   constexpr size_t K = 4;
 
   const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
   REQUIRE(mesh != nullptr);
 
-  BVH::PrimAndBVList<Face, AABB> primsAndBVs;
-  for (const auto& f : mesh->getFaces()) {
-    primsAndBVs.emplace_back(f, AABB(f->getAllVertexCoordinates()));
+  BVH::PrimAndBVList<Prim, AABB> primsAndBVs;
+  for (size_t i = 0; i < mesh->getFaces().size(); i++) {
+    const Prim faceIdx = static_cast<Prim>(i);
+    primsAndBVs.emplace_back(std::make_shared<const Prim>(faceIdx), AABB(mesh->getFaceVertexCoordinates(faceIdx)));
   }
 
   const FlatMeshSDF<T, Meta> flat(mesh);
@@ -1958,14 +1959,14 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 
   // Pack a (partitioned) tree and query it the way MeshSDF does, comparing to the brute-force scan.
   const auto packAndCheck = [&](const auto& a_tree) {
-    const auto  packed = a_tree->pack();
-    const auto& faces  = packed->getPrimitives();
+    const auto  packed      = a_tree->pack();
+    const auto& faceIndices = packed->getPrimitives();
 
     for (const auto& p : queryPoints<T>()) {
       T          state    = std::numeric_limits<T>::max();
-      const auto evalLeaf = [&faces, &p](T& a_state, size_t a_offset, size_t a_count) noexcept {
+      const auto evalLeaf = [&faceIndices, &mesh, &p](T& a_state, size_t a_offset, size_t a_count) noexcept {
         for (size_t i = 0; i < a_count; i++) {
-          const T d = faces[a_offset + i]->signedDistance(p);
+          const T d = mesh->signedDistanceToFace(*faceIndices[a_offset + i], p);
           if (std::abs(d) < std::abs(a_state)) {
             a_state = d;
           }
@@ -1981,7 +1982,7 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 
   SECTION("clone of an unpartitioned tree shares primitives; the copies then partition independently")
   {
-    auto tree = std::make_shared<BVH::TreeBVH<T, Face, AABB, K>>(primsAndBVs);
+    auto tree = std::make_shared<BVH::TreeBVH<T, Prim, AABB, K>>(primsAndBVs);
     REQUIRE_FALSE(tree->isPartitioned());
 
     const auto clone = tree->deepCopy();
@@ -1989,7 +1990,7 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
     REQUIRE(clone.get() != tree.get());
     REQUIRE(clone->isPartitioned() == tree->isPartitioned());
 
-    // Primitives are shared by handle, not cloned: same underlying Face objects, same order.
+    // Primitives are shared by handle, not cloned: same underlying face-index handles, same order.
     // (std::as_const selects the public const getPrimitives() overload; the mutable one is protected.)
     const auto& treePrims  = std::as_const(*tree).getPrimitives();
     const auto& clonePrims = std::as_const(*clone).getPrimitives();
@@ -2011,7 +2012,7 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 
   SECTION("clone of a partitioned tree duplicates the node hierarchy but shares primitives")
   {
-    auto tree = std::make_shared<BVH::TreeBVH<T, Face, AABB, K>>(primsAndBVs);
+    auto tree = std::make_shared<BVH::TreeBVH<T, Prim, AABB, K>>(primsAndBVs);
     tree->topDownSortAndPartition();
     REQUIRE(tree->isPartitioned());
 

--- a/Tests/TestDCEL.cpp
+++ b/Tests/TestDCEL.cpp
@@ -779,6 +779,42 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy preserves a prior flip() instead of silently
   }
 }
 
+TEMPLATE_TEST_CASE("MeshT: reconcile gives boundary half-edges their own face normal",
+                   "[DCEL][Mesh]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // A single open triangle in the z = 0 plane: three boundary half-edges, no twins. This exercises
+  // the boundary branch of the edge pseudonormal (a half-edge with no pair edge uses only its own
+  // face normal) that a closed, watertight mesh never reaches.
+  std::vector<TestVertex<T>> vertices = {
+    TestVertex<T>(Vec3T<T>(0, 0, 0)), TestVertex<T>(Vec3T<T>(1, 0, 0)), TestVertex<T>(Vec3T<T>(0, 1, 0))};
+  std::vector<TestEdge<T>> edges(3);
+  std::vector<TestFace<T>> faces = {TestFace<T>(0)};
+
+  for (DCELIndex i = 0; i < 3; i++) {
+    edges[i].define(i, InvalidIndex, (i + 1) % 3); // origin vertex i, no pair, next edge (i+1)%3
+    edges[i].setFace(0);
+
+    vertices[i].setEdge(i);
+    vertices[i].addFace(0);
+  }
+
+  MeshT<T, DefaultMetaData> mesh(faces, edges, vertices);
+  mesh.reconcile(VertexNormalWeight::None);
+
+  const auto&     meshEdges  = mesh.getEdges();
+  const Vec3T<T>& faceNormal = mesh.getFaces()[0].getNormal();
+
+  REQUIRE_THAT(faceNormal.length(), withinAbsT(T(1.0), exactMargin<T>()));
+
+  for (DCELIndex i = 0; i < 3; i++) {
+    REQUIRE(meshEdges[i].getPairEdge() == InvalidIndex);                             // boundary edge, no twin
+    REQUIRE((meshEdges[i].getNormal() - faceNormal).length() < T(exactMargin<T>())); // uses own face normal
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Soup tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/Tests/TestDCEL.cpp
+++ b/Tests/TestDCEL.cpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -94,7 +95,7 @@ traversalMargin()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// VertexT tests
+// Type aliases used throughout
 // ─────────────────────────────────────────────────────────────────────────────
 
 template <class T>
@@ -109,6 +110,13 @@ using TestEdge = EdgeT<T, DefaultMetaData>;
 template <class T>
 using TestMesh = MeshT<T, DefaultMetaData>;
 
+template <class T>
+using TestEdgeIterator = EdgeIteratorT<T, DefaultMetaData>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VertexT tests
+// ─────────────────────────────────────────────────────────────────────────────
+
 TEMPLATE_TEST_CASE("VertexT: default construction leaves defined, zeroed state",
                    "[DCEL][Vertex]",
                    EBGEOMETRY_TEST_PRECISIONS)
@@ -118,7 +126,7 @@ TEMPLATE_TEST_CASE("VertexT: default construction leaves defined, zeroed state",
 
   REQUIRE(v.getPosition() == Vec3T<T>::zeros());
   REQUIRE(v.getNormal() == Vec3T<T>::zeros());
-  REQUIRE(v.getOutgoingEdge() == nullptr);
+  REQUIRE(v.getOutgoingEdge() == InvalidIndex);
   REQUIRE(v.getFaces().empty());
   REQUIRE(v.getMetaData() == 0);
 }
@@ -145,7 +153,6 @@ TEMPLATE_TEST_CASE("VertexT: setPosition, setNormal, setEdge, define", "[DCEL][V
 {
   using T = TestType;
   TestVertex<T> v;
-  auto          edge = std::make_shared<TestEdge<T>>();
 
   v.setPosition(Vec3T<T>(4, 5, 6));
   REQUIRE(v.getPosition() == Vec3T<T>(4, 5, 6));
@@ -153,29 +160,28 @@ TEMPLATE_TEST_CASE("VertexT: setPosition, setNormal, setEdge, define", "[DCEL][V
   v.setNormal(Vec3T<T>(1, 0, 0));
   REQUIRE(v.getNormal() == Vec3T<T>(1, 0, 0));
 
-  v.setEdge(edge);
-  REQUIRE(v.getOutgoingEdge() == edge);
+  v.setEdge(7);
+  REQUIRE(v.getOutgoingEdge() == 7);
 
-  // Setting the edge pointer to nullptr is explicitly valid.
-  v.setEdge(nullptr);
-  REQUIRE(v.getOutgoingEdge() == nullptr);
+  // Setting the edge index to InvalidIndex is explicitly valid.
+  v.setEdge(InvalidIndex);
+  REQUIRE(v.getOutgoingEdge() == InvalidIndex);
 
-  v.define(Vec3T<T>(7, 8, 9), edge, Vec3T<T>(0, 1, 0));
+  v.define(Vec3T<T>(7, 8, 9), 3, Vec3T<T>(0, 1, 0));
   REQUIRE(v.getPosition() == Vec3T<T>(7, 8, 9));
-  REQUIRE(v.getOutgoingEdge() == edge);
+  REQUIRE(v.getOutgoingEdge() == 3);
   REQUIRE(v.getNormal() == Vec3T<T>(0, 1, 0));
 }
 
-TEMPLATE_TEST_CASE("VertexT: addFace appends to the face list", "[DCEL][Vertex]", EBGEOMETRY_TEST_PRECISIONS)
+TEMPLATE_TEST_CASE("VertexT: addFace appends to the face index list", "[DCEL][Vertex]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
   TestVertex<T> v;
-  auto          face = std::make_shared<TestFace<T>>();
 
   REQUIRE(v.getFaces().empty());
-  v.addFace(face);
+  v.addFace(5);
   REQUIRE(v.getFaces().size() == 1);
-  REQUIRE(v.getFaces()[0] == face);
+  REQUIRE(v.getFaces()[0] == 5);
 }
 
 TEMPLATE_TEST_CASE("VertexT: normalizeNormalVector produces a unit vector",
@@ -227,81 +233,37 @@ TEMPLATE_TEST_CASE("VertexT: getMetaData reads and writes", "[DCEL][Vertex]", EB
   REQUIRE(v.getMetaData() == 9);
 }
 
-TEMPLATE_TEST_CASE("VertexT: copy construction only copies position, normal, and outgoing edge",
+TEMPLATE_TEST_CASE("VertexT: copy and move perform a full memberwise copy of the flat data",
                    "[DCEL][Vertex]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  auto edge = std::make_shared<TestEdge<T>>();
+  using T = TestType;
 
   TestVertex<T> src(Vec3T<T>(1, 2, 3), Vec3T<T>(0, 0, 1));
-  src.setEdge(edge);
-  src.addFace(face);
+  src.setEdge(4);
+  src.addFace(6);
   src.getMetaData() = 42;
 
+  // Copy carries every field (the topology links are plain array indices).
   TestVertex<T> copy(src);
-
   REQUIRE(copy.getPosition() == src.getPosition());
   REQUIRE(copy.getNormal() == src.getNormal());
-  REQUIRE(copy.getOutgoingEdge() == edge);
-  REQUIRE(copy.getFaces().empty());
-  REQUIRE(copy.getMetaData() == 0);
-}
+  REQUIRE(copy.getOutgoingEdge() == 4);
+  REQUIRE(copy.getFaces().size() == 1);
+  REQUIRE(copy.getFaces()[0] == 6);
+  REQUIRE(copy.getMetaData() == 42);
 
-TEMPLATE_TEST_CASE("VertexT: copy assignment has the same narrow semantics as copy construction",
-                   "[DCEL][Vertex]",
-                   EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  auto edge = std::make_shared<TestEdge<T>>();
+  TestVertex<T> assigned;
+  assigned = src;
+  REQUIRE(assigned.getOutgoingEdge() == 4);
+  REQUIRE(assigned.getFaces().size() == 1);
+  REQUIRE(assigned.getMetaData() == 42);
 
-  TestVertex<T> src(Vec3T<T>(1, 2, 3), Vec3T<T>(0, 0, 1));
-  src.setEdge(edge);
-  src.addFace(face);
-  src.getMetaData() = 42;
-
-  TestVertex<T> dst;
-  dst = src;
-
-  REQUIRE(dst.getPosition() == src.getPosition());
-  REQUIRE(dst.getNormal() == src.getNormal());
-  REQUIRE(dst.getOutgoingEdge() == edge);
-  REQUIRE(dst.getFaces().empty());
-  REQUIRE(dst.getMetaData() == 0);
-}
-
-TEMPLATE_TEST_CASE("VertexT: move construction and move assignment transfer the entire state",
-                   "[DCEL][Vertex]",
-                   EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  auto edge = std::make_shared<TestEdge<T>>();
-
-  TestVertex<T> moveCtorSrc(Vec3T<T>(1, 2, 3), Vec3T<T>(0, 0, 1));
-  moveCtorSrc.setEdge(edge);
-  moveCtorSrc.addFace(face);
-  moveCtorSrc.getMetaData() = 42;
-
-  TestVertex<T> moved(std::move(moveCtorSrc));
+  TestVertex<T> moved(std::move(copy));
   REQUIRE(moved.getPosition() == Vec3T<T>(1, 2, 3));
-  REQUIRE(moved.getOutgoingEdge() == edge);
+  REQUIRE(moved.getOutgoingEdge() == 4);
   REQUIRE(moved.getFaces().size() == 1);
   REQUIRE(moved.getMetaData() == 42);
-
-  TestVertex<T> moveAssignSrc(Vec3T<T>(4, 5, 6), Vec3T<T>(1, 0, 0));
-  moveAssignSrc.setEdge(edge);
-  moveAssignSrc.addFace(face);
-  moveAssignSrc.getMetaData() = 7;
-
-  TestVertex<T> moveAssignDst;
-  moveAssignDst = std::move(moveAssignSrc);
-  REQUIRE(moveAssignDst.getPosition() == Vec3T<T>(4, 5, 6));
-  REQUIRE(moveAssignDst.getOutgoingEdge() == edge);
-  REQUIRE(moveAssignDst.getFaces().size() == 1);
-  REQUIRE(moveAssignDst.getMetaData() == 7);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -316,26 +278,25 @@ TEMPLATE_TEST_CASE("EdgeT: default construction leaves defined, zeroed state",
   TestEdge<T> e;
 
   REQUIRE(e.getNormal() == Vec3T<T>::zeros());
-  REQUIRE(e.getVertex() == nullptr);
-  REQUIRE(e.getPairEdge() == nullptr);
-  REQUIRE(e.getNextEdge() == nullptr);
-  REQUIRE(e.getFace() == nullptr);
+  REQUIRE(e.getVertex() == InvalidIndex);
+  REQUIRE(e.getPairEdge() == InvalidIndex);
+  REQUIRE(e.getNextEdge() == InvalidIndex);
+  REQUIRE(e.getFace() == InvalidIndex);
   REQUIRE(e.getMetaData() == 0);
   REQUIRE(e.size() == 2);
 }
 
-TEMPLATE_TEST_CASE("EdgeT: partial (vertex) constructor sets only the starting vertex",
+TEMPLATE_TEST_CASE("EdgeT: partial (vertex) constructor sets only the origin-vertex index",
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
-  auto v  = std::make_shared<TestVertex<T>>(Vec3T<T>(1, 2, 3));
 
-  TestEdge<T> e(v);
-  REQUIRE(e.getVertex() == v);
-  REQUIRE(e.getPairEdge() == nullptr);
-  REQUIRE(e.getNextEdge() == nullptr);
-  REQUIRE(e.getFace() == nullptr);
+  TestEdge<T> e(2);
+  REQUIRE(e.getVertex() == 2);
+  REQUIRE(e.getPairEdge() == InvalidIndex);
+  REQUIRE(e.getNextEdge() == InvalidIndex);
+  REQUIRE(e.getFace() == InvalidIndex);
   REQUIRE(e.getNormal() == Vec3T<T>::zeros());
 }
 
@@ -343,224 +304,138 @@ TEMPLATE_TEST_CASE("EdgeT: define, setVertex, setPairEdge, setNextEdge, setFace,
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto v1   = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
+  using T = TestType;
 
   TestEdge<T> e;
-  e.define(v1, pair, next);
-  REQUIRE(e.getVertex() == v1);
-  REQUIRE(e.getPairEdge() == pair);
-  REQUIRE(e.getNextEdge() == next);
+  e.define(1, 2, 3);
+  REQUIRE(e.getVertex() == 1);
+  REQUIRE(e.getPairEdge() == 2);
+  REQUIRE(e.getNextEdge() == 3);
 
-  e.setFace(face);
-  REQUIRE(e.getFace() == face);
+  e.setFace(4);
+  REQUIRE(e.getFace() == 4);
 
   e.setMetaData(9);
   REQUIRE(e.getMetaData() == 9);
 
-  // Setting pointers to nullptr is explicitly valid.
-  e.setVertex(nullptr);
-  e.setPairEdge(nullptr);
-  e.setNextEdge(nullptr);
-  e.setFace(nullptr);
-  REQUIRE(e.getVertex() == nullptr);
-  REQUIRE(e.getPairEdge() == nullptr);
-  REQUIRE(e.getNextEdge() == nullptr);
-  REQUIRE(e.getFace() == nullptr);
+  // Setting indices to InvalidIndex is explicitly valid.
+  e.setVertex(InvalidIndex);
+  e.setPairEdge(InvalidIndex);
+  e.setNextEdge(InvalidIndex);
+  e.setFace(InvalidIndex);
+  REQUIRE(e.getVertex() == InvalidIndex);
+  REQUIRE(e.getPairEdge() == InvalidIndex);
+  REQUIRE(e.getNextEdge() == InvalidIndex);
+  REQUIRE(e.getFace() == InvalidIndex);
 }
 
 TEMPLATE_TEST_CASE("EdgeT: flipNormal negates the normal vector", "[DCEL][Edge]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(0, 0, 1), nullptr);
-
+  using T = TestType;
   TestEdge<T> e;
-  e.setFace(face);
-  e.reconcile();
+  e.getNormal() = Vec3T<T>(0, 0, 1);
 
   REQUIRE(e.getNormal() == Vec3T<T>(0, 0, 1));
   e.flipNormal();
   REQUIRE(e.getNormal() == Vec3T<T>(0, 0, -1));
 }
 
-TEMPLATE_TEST_CASE("EdgeT: computeNormal with a single face returns that face's normal",
-                   "[DCEL][Edge]",
-                   EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(1, 0, 0), nullptr);
-
-  TestEdge<T> e;
-  e.setFace(face);
-
-  REQUIRE(e.computeNormal() == Vec3T<T>(1, 0, 0));
-}
-
-TEMPLATE_TEST_CASE("EdgeT: computeNormal averages both incident faces' normals",
-                   "[DCEL][Edge]",
-                   EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T       = TestType;
-  auto face     = std::make_shared<TestFace<T>>();
-  auto pairFace = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(1, 0, 0), nullptr);
-  pairFace->define(Vec3T<T>(0, 1, 0), nullptr);
-
-  auto pairEdge = std::make_shared<TestEdge<T>>();
-  pairEdge->setFace(pairFace);
-
-  TestEdge<T> e;
-  e.setFace(face);
-  e.setPairEdge(pairEdge);
-
-  const Vec3T<T> expected = Vec3T<T>(1, 1, 0) / Vec3T<T>(1, 1, 0).length();
-  const Vec3T<T> actual   = e.computeNormal();
-
-  REQUIRE_THAT(actual[0], withinAbsT(expected[0], exactMargin<T>()));
-  REQUIRE_THAT(actual[1], withinAbsT(expected[1], exactMargin<T>()));
-  REQUIRE_THAT(actual[2], withinAbsT(expected[2], exactMargin<T>()));
-}
-
-TEMPLATE_TEST_CASE("EdgeT: reconcile stores computeNormal's result", "[DCEL][Edge]", EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(0, 1, 0), nullptr);
-
-  TestEdge<T> e;
-  e.setFace(face);
-  e.reconcile();
-
-  REQUIRE(e.getNormal() == Vec3T<T>(0, 1, 0));
-}
-
-TEMPLATE_TEST_CASE("EdgeT: signedDistance and unsignedDistance2 on a simple segment",
+TEMPLATE_TEST_CASE("EdgeT: copy and move perform a full memberwise copy of the flat data",
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
-  // Build a two-vertex chain: e1 (start v1) -> e2 (start v2), so e1's "other vertex" is v2.
-  auto v1 = std::make_shared<TestVertex<T>>(Vec3T<T>(0, 0, 0));
-  auto v2 = std::make_shared<TestVertex<T>>(Vec3T<T>(1, 0, 0));
-
-  auto e1 = std::make_shared<TestEdge<T>>();
-  auto e2 = std::make_shared<TestEdge<T>>();
-  e1->define(v1, nullptr, e2);
-  e2->setVertex(v2);
-
-  // Outward normal perpendicular to the edge, pointing +y.
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(0, 1, 0), nullptr);
-  e1->setFace(face);
-  e1->reconcile();
-
-  REQUIRE(e1->getOtherVertex() == v2);
-
-  // Point above the middle of the edge: on the normal side, distance 2.
-  REQUIRE_THAT(e1->signedDistance(Vec3T<T>(0.5, 2, 0)), WithinRel(T(2.0)));
-
-  // Point below the middle of the edge: against the normal, negative distance.
-  REQUIRE_THAT(e1->signedDistance(Vec3T<T>(0.5, -2, 0)), WithinRel(T(-2.0)));
-
-  // unsignedDistance2 clamps the projection to the segment.
-  REQUIRE_THAT(e1->unsignedDistance2(Vec3T<T>(0.5, 3, 0)), WithinRel(T(9.0)));
-}
-
-TEMPLATE_TEST_CASE("EdgeT: copy construction copies topology pointers but not meta-data",
-                   "[DCEL][Edge]",
-                   EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T   = TestType;
-  auto v    = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
 
   TestEdge<T> src;
-  src.define(v, pair, next);
-  src.setFace(face);
+  src.define(1, 2, 3);
+  src.setFace(4);
+  src.getNormal() = Vec3T<T>(0, 1, 0);
   src.setMetaData(42);
 
   TestEdge<T> copy(src);
-  REQUIRE(copy.getVertex() == v);
-  REQUIRE(copy.getPairEdge() == pair);
-  REQUIRE(copy.getNextEdge() == next);
-  REQUIRE(copy.getFace() == face);
-  REQUIRE(copy.getMetaData() == 0);
-}
+  REQUIRE(copy.getVertex() == 1);
+  REQUIRE(copy.getPairEdge() == 2);
+  REQUIRE(copy.getNextEdge() == 3);
+  REQUIRE(copy.getFace() == 4);
+  REQUIRE(copy.getNormal() == Vec3T<T>(0, 1, 0));
+  REQUIRE(copy.getMetaData() == 42);
 
-TEMPLATE_TEST_CASE("EdgeT: copy assignment has the same semantics as copy construction",
-                   "[DCEL][Edge]",
-                   EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T   = TestType;
-  auto v    = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
+  TestEdge<T> assigned;
+  assigned = src;
+  REQUIRE(assigned.getFace() == 4);
+  REQUIRE(assigned.getMetaData() == 42);
 
-  TestEdge<T> src;
-  src.define(v, pair, next);
-  src.setFace(face);
-  src.setMetaData(42);
-
-  TestEdge<T> dst;
-  dst = src;
-
-  REQUIRE(dst.getVertex() == v);
-  REQUIRE(dst.getPairEdge() == pair);
-  REQUIRE(dst.getNextEdge() == next);
-  REQUIRE(dst.getFace() == face);
-  REQUIRE(dst.getMetaData() == 0);
-}
-
-TEMPLATE_TEST_CASE("EdgeT: move construction and move assignment transfer the entire state",
-                   "[DCEL][Edge]",
-                   EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T   = TestType;
-  auto v    = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
-
-  TestEdge<T> moveCtorSrc;
-  moveCtorSrc.define(v, pair, next);
-  moveCtorSrc.setFace(face);
-  moveCtorSrc.setMetaData(42);
-
-  TestEdge<T> moved(std::move(moveCtorSrc));
-  REQUIRE(moved.getVertex() == v);
-  REQUIRE(moved.getPairEdge() == pair);
-  REQUIRE(moved.getNextEdge() == next);
-  REQUIRE(moved.getFace() == face);
+  TestEdge<T> moved(std::move(copy));
+  REQUIRE(moved.getVertex() == 1);
+  REQUIRE(moved.getFace() == 4);
   REQUIRE(moved.getMetaData() == 42);
-
-  TestEdge<T> moveAssignSrc;
-  moveAssignSrc.define(v, pair, next);
-  moveAssignSrc.setFace(face);
-  moveAssignSrc.setMetaData(7);
-
-  TestEdge<T> moveAssignDst;
-  moveAssignDst = std::move(moveAssignSrc);
-  REQUIRE(moveAssignDst.getVertex() == v);
-  REQUIRE(moveAssignDst.getPairEdge() == pair);
-  REQUIRE(moveAssignDst.getNextEdge() == next);
-  REQUIRE(moveAssignDst.getFace() == face);
-  REQUIRE(moveAssignDst.getMetaData() == 7);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// EdgeIteratorT tests
+// MeshT edge/vertex geometric-query tests (logic relocated onto MeshT)
 // ─────────────────────────────────────────────────────────────────────────────
 
-template <class T>
-using TestEdgeIterator = EdgeIteratorT<T, DefaultMetaData>;
+TEMPLATE_TEST_CASE("MeshT: signedDistanceToEdge / unsignedDistance2ToEdge on a simple segment",
+                   "[DCEL][Edge]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // Two-vertex chain: e0 (origin v0) -> e1 (origin v1), so e0's "other vertex" is v1.
+  TestMesh<T> mesh;
+
+  mesh.getVertices() = {TestVertex<T>(Vec3T<T>(0, 0, 0)), TestVertex<T>(Vec3T<T>(1, 0, 0))};
+
+  TestEdge<T> e0;
+  e0.define(0, InvalidIndex, 1); // origin v0, no pair, next = e1
+  e0.getNormal() = Vec3T<T>(0, 1, 0);
+
+  TestEdge<T> e1;
+  e1.setVertex(1);
+
+  mesh.getEdges() = {e0, e1};
+
+  REQUIRE(mesh.getOtherVertex(0) == 1);
+
+  // Point above the middle of the edge: on the normal side, distance 2.
+  REQUIRE_THAT(mesh.signedDistanceToEdge(0, Vec3T<T>(0.5, 2, 0)), WithinRel(T(2.0)));
+
+  // Point below the middle of the edge: against the normal, negative distance.
+  REQUIRE_THAT(mesh.signedDistanceToEdge(0, Vec3T<T>(0.5, -2, 0)), WithinRel(T(-2.0)));
+
+  // unsignedDistance2ToEdge clamps the projection to the segment.
+  REQUIRE_THAT(mesh.unsignedDistance2ToEdge(0, Vec3T<T>(0.5, 3, 0)), WithinRel(T(9.0)));
+}
+
+TEMPLATE_TEST_CASE("MeshT: reconcile produces unit edge normals equal to the incident faces' average",
+                   "[DCEL][Edge]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T   = TestType;
+  auto mesh = buildTetrahedron<T>();
+
+  const auto& faces = mesh->getFaces();
+  const auto& edges = mesh->getEdges();
+
+  for (const auto& e : edges) {
+    // Watertight tetrahedron: every half-edge has a pair.
+    REQUIRE(e.getPairEdge() != InvalidIndex);
+
+    REQUIRE_THAT(e.getNormal().length(), withinAbsT(T(1.0), formulaMargin<T>()));
+
+    const Vec3T<T> faceNormal     = faces[e.getFace()].getNormal();
+    const Vec3T<T> pairFaceNormal = faces[edges[e.getPairEdge()].getFace()].getNormal();
+
+    Vec3T<T> expected = faceNormal + pairFaceNormal;
+    expected          = expected / expected.length();
+
+    REQUIRE((e.getNormal() - expected).length() < T(formulaMargin<T>()));
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EdgeIteratorT tests (index cursor over the mesh's edge array)
+// ─────────────────────────────────────────────────────────────────────────────
 
 TEMPLATE_TEST_CASE("EdgeIteratorT: iterating a face visits exactly its own half-edges and loops back",
                    "[DCEL][Iterator]",
@@ -568,48 +443,56 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: iterating a face visits exactly its own half-
 {
   using T   = TestType;
   auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
 
-  std::vector<std::shared_ptr<TestEdge<T>>> visited;
-  for (TestEdgeIterator<T> it(*face); it.ok(); ++it) {
-    REQUIRE(it()->getFace() == face);
+  const auto&     edges     = mesh->getEdges();
+  const DCELIndex faceIdx   = 0;
+  const DCELIndex startEdge = mesh->getFaces()[faceIdx].getHalfEdge();
+
+  std::vector<DCELIndex> visited;
+  for (TestEdgeIterator<T> it(edges, startEdge); it.ok(); ++it) {
+    REQUIRE(edges[it()].getFace() == faceIdx);
     visited.push_back(it());
   }
 
   REQUIRE(visited.size() == 3); // Every face in a tetrahedron is a triangle.
-  REQUIRE(visited[0] == face->getHalfEdge());
-  REQUIRE(visited[0]->getNextEdge() == visited[1]);
-  REQUIRE(visited[1]->getNextEdge() == visited[2]);
-  REQUIRE(visited[2]->getNextEdge() == visited[0]); // Loops back to the start.
+  REQUIRE(visited[0] == startEdge);
+  REQUIRE(edges[visited[0]].getNextEdge() == visited[1]);
+  REQUIRE(edges[visited[1]].getNextEdge() == visited[2]);
+  REQUIRE(edges[visited[2]].getNextEdge() == visited[0]); // Loops back to the start.
 }
 
-TEMPLATE_TEST_CASE("EdgeIteratorT: constructing from an edge directly matches constructing from its face",
+TEMPLATE_TEST_CASE("EdgeIteratorT: starting from a mid-loop edge still visits all half-edges once",
                    "[DCEL][Iterator]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T   = TestType;
   auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
 
-  std::vector<std::shared_ptr<TestEdge<T>>> fromFace;
-  for (TestEdgeIterator<T> it(*face); it.ok(); ++it) {
-    fromFace.push_back(it());
+  const auto&     edges     = mesh->getEdges();
+  const DCELIndex faceStart = mesh->getFaces()[0].getHalfEdge();
+  const DCELIndex midStart  = edges[faceStart].getNextEdge();
+
+  std::vector<DCELIndex> visited;
+  for (TestEdgeIterator<T> it(edges, midStart); it.ok(); ++it) {
+    visited.push_back(it());
   }
 
-  std::vector<std::shared_ptr<TestEdge<T>>> fromEdge;
-  for (TestEdgeIterator<T> it(face->getHalfEdge()); it.ok(); ++it) {
-    fromEdge.push_back(it());
+  REQUIRE(visited.size() == 3);
+  REQUIRE(visited[0] == midStart);
+  // All three edges of face 0 belong to face 0.
+  for (const auto e : visited) {
+    REQUIRE(edges[e].getFace() == 0);
   }
-
-  REQUIRE(fromFace == fromEdge);
 }
 
-TEMPLATE_TEST_CASE("EdgeIteratorT: ok() is immediately false for a null starting edge",
+TEMPLATE_TEST_CASE("EdgeIteratorT: ok() is immediately false for an invalid starting edge",
                    "[DCEL][Iterator]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T = TestType;
-  TestEdgeIterator<T> it(std::shared_ptr<TestEdge<T>>(nullptr));
+  using T   = TestType;
+  auto mesh = buildTetrahedron<T>();
+
+  TestEdgeIterator<T> it(mesh->getEdges(), InvalidIndex);
   REQUIRE_FALSE(it.ok());
 }
 
@@ -619,10 +502,12 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: reset returns the iterator to its starting ed
 {
   using T   = TestType;
   auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
 
-  TestEdgeIterator<T> it(*face);
-  const auto          start = it();
+  const auto&     edges = mesh->getEdges();
+  const DCELIndex start = mesh->getFaces()[0].getHalfEdge();
+
+  TestEdgeIterator<T> it(edges, start);
+  REQUIRE(it() == start);
 
   ++it;
   ++it;
@@ -639,25 +524,27 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: copy and move both preserve iteration state",
 {
   using T   = TestType;
   auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
 
-  TestEdgeIterator<T> src(*face);
+  const auto&     edges = mesh->getEdges();
+  const DCELIndex start = mesh->getFaces()[0].getHalfEdge();
+
+  TestEdgeIterator<T> src(edges, start);
   ++src;
-  const auto afterOneStep = src();
+  const DCELIndex afterOneStep = src();
 
   TestEdgeIterator<T> copied(src);
   REQUIRE(copied() == afterOneStep);
   ++copied;
   REQUIRE(copied() != src()); // Independent copies: advancing one must not advance the other.
 
-  TestEdgeIterator<T> copyAssigned(*face);
+  TestEdgeIterator<T> copyAssigned(edges, start);
   copyAssigned = src;
   REQUIRE(copyAssigned() == afterOneStep);
 
   TestEdgeIterator<T> moved(std::move(src));
   REQUIRE(moved() == afterOneStep);
 
-  TestEdgeIterator<T> moveAssigned(*face);
+  TestEdgeIterator<T> moveAssigned(edges, start);
   moveAssigned = std::move(copied);
   REQUIRE(moveAssigned.ok());
 }
@@ -686,19 +573,24 @@ TEMPLATE_TEST_CASE("MeshT: full constructor assigns vertices, edges, and faces",
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T                                           = TestType;
-  std::vector<std::shared_ptr<TestVertex<T>>> verts = {std::make_shared<TestVertex<T>>()};
-  std::vector<std::shared_ptr<TestEdge<T>>>   edges = {std::make_shared<TestEdge<T>>()};
-  std::vector<std::shared_ptr<TestFace<T>>>   faces = {std::make_shared<TestFace<T>>()};
+  using T = TestType;
+
+  std::vector<TestVertex<T>> verts = {TestVertex<T>(Vec3T<T>(1, 2, 3))};
+
+  std::vector<TestEdge<T>> edges(1);
+  edges[0].setVertex(0);
+
+  std::vector<TestFace<T>> faces(1);
+  faces[0].setHalfEdge(0);
 
   TestMesh<T> mesh(faces, edges, verts);
 
   REQUIRE(mesh.getVertices().size() == 1);
   REQUIRE(mesh.getEdges().size() == 1);
   REQUIRE(mesh.getFaces().size() == 1);
-  REQUIRE(mesh.getVertices()[0] == verts[0]);
-  REQUIRE(mesh.getEdges()[0] == edges[0]);
-  REQUIRE(mesh.getFaces()[0] == faces[0]);
+  REQUIRE(mesh.getVertices()[0].getPosition() == Vec3T<T>(1, 2, 3));
+  REQUIRE(mesh.getEdges()[0].getVertex() == 0);
+  REQUIRE(mesh.getFaces()[0].getHalfEdge() == 0);
 }
 
 TEMPLATE_TEST_CASE("MeshT: copy is disallowed, move is allowed", "[DCEL][Mesh]", EBGEOMETRY_TEST_PRECISIONS)
@@ -714,21 +606,21 @@ TEMPLATE_TEST_CASE("MeshT: move construction and move assignment transfer owners
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T          = TestType;
-  auto moveCtorSrc = buildTetrahedron<T>();
-  auto v0          = moveCtorSrc->getVertices()[0];
+  using T                    = TestType;
+  auto           moveCtorSrc = buildTetrahedron<T>();
+  const Vec3T<T> v0pos       = moveCtorSrc->getVertices()[0].getPosition();
 
   TestMesh<T> moved(std::move(*moveCtorSrc));
   REQUIRE(moved.getVertices().size() == 4);
   REQUIRE(moved.getFaces().size() == 4);
-  REQUIRE(moved.getVertices()[0] == v0);
+  REQUIRE(moved.getVertices()[0].getPosition() == v0pos);
 
-  auto        moveAssignSrc = buildTetrahedron<T>();
-  auto        v0b           = moveAssignSrc->getVertices()[0];
-  TestMesh<T> moveAssignDst;
+  auto           moveAssignSrc = buildTetrahedron<T>();
+  const Vec3T<T> v0bpos        = moveAssignSrc->getVertices()[0].getPosition();
+  TestMesh<T>    moveAssignDst;
   moveAssignDst = std::move(*moveAssignSrc);
   REQUIRE(moveAssignDst.getVertices().size() == 4);
-  REQUIRE(moveAssignDst.getVertices()[0] == v0b);
+  REQUIRE(moveAssignDst.getVertices()[0].getPosition() == v0bpos);
 }
 
 TEMPLATE_TEST_CASE("MeshT: reconcile computes positive face areas and unit-length normals",
@@ -739,8 +631,8 @@ TEMPLATE_TEST_CASE("MeshT: reconcile computes positive face areas and unit-lengt
   auto mesh = buildTetrahedron<T>();
 
   for (const auto& f : mesh->getFaces()) {
-    REQUIRE(f->getArea() > T(0.0));
-    REQUIRE_THAT(f->getNormal().length(), withinAbsT(T(1.0), exactMargin<T>()));
+    REQUIRE(f.getArea() > T(0.0));
+    REQUIRE_THAT(f.getNormal().length(), withinAbsT(T(1.0), exactMargin<T>()));
   }
 }
 
@@ -751,25 +643,25 @@ TEMPLATE_TEST_CASE("MeshT: flip negates all vertex, edge, and face normals", "[D
 
   std::vector<Vec3T<T>> vertexNormals, edgeNormals, faceNormals;
   for (const auto& v : mesh->getVertices()) {
-    vertexNormals.push_back(v->getNormal());
+    vertexNormals.push_back(v.getNormal());
   }
   for (const auto& e : mesh->getEdges()) {
-    edgeNormals.push_back(e->getNormal());
+    edgeNormals.push_back(e.getNormal());
   }
   for (const auto& f : mesh->getFaces()) {
-    faceNormals.push_back(f->getNormal());
+    faceNormals.push_back(f.getNormal());
   }
 
   mesh->flip();
 
   for (size_t i = 0; i < mesh->getVertices().size(); i++) {
-    REQUIRE((mesh->getVertices()[i]->getNormal() - (-vertexNormals[i])).length() < T(exactMargin<T>()));
+    REQUIRE((mesh->getVertices()[i].getNormal() - (-vertexNormals[i])).length() < T(exactMargin<T>()));
   }
   for (size_t i = 0; i < mesh->getEdges().size(); i++) {
-    REQUIRE((mesh->getEdges()[i]->getNormal() - (-edgeNormals[i])).length() < T(exactMargin<T>()));
+    REQUIRE((mesh->getEdges()[i].getNormal() - (-edgeNormals[i])).length() < T(exactMargin<T>()));
   }
   for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE((mesh->getFaces()[i]->getNormal() - (-faceNormals[i])).length() < T(exactMargin<T>()));
+    REQUIRE((mesh->getFaces()[i].getNormal() - (-faceNormals[i])).length() < T(exactMargin<T>()));
   }
 }
 
@@ -819,7 +711,28 @@ TEMPLATE_TEST_CASE("MeshT: getAllVertexCoordinates matches the vertex positions"
   REQUIRE(coords.size() == mesh->getVertices().size());
 
   for (size_t i = 0; i < coords.size(); i++) {
-    REQUIRE(coords[i] == mesh->getVertices()[i]->getPosition());
+    REQUIRE(coords[i] == mesh->getVertices()[i].getPosition());
+  }
+}
+
+TEMPLATE_TEST_CASE("MeshT: getFaceVertexCoordinates returns a face's vertices in half-edge order",
+                   "[DCEL][Mesh]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T   = TestType;
+  auto mesh = buildTetrahedron<T>();
+
+  const auto&     edges     = mesh->getEdges();
+  const DCELIndex faceIdx   = 0;
+  const auto      coords    = mesh->getFaceVertexCoordinates(faceIdx);
+  const DCELIndex startEdge = mesh->getFaces()[faceIdx].getHalfEdge();
+
+  REQUIRE(coords.size() == 3);
+
+  size_t i = 0;
+  for (TestEdgeIterator<T> it(edges, startEdge); it.ok(); ++it) {
+    REQUIRE(coords[i] == mesh->getVertices()[edges[it()].getVertex()].getPosition());
+    i++;
   }
 }
 
@@ -836,22 +749,17 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy produces an independent mesh with the same g
   REQUIRE(copy->getEdges().size() == mesh->getEdges().size());
   REQUIRE(copy->getFaces().size() == mesh->getFaces().size());
 
-  // Topology must be fully decoupled: no shared vertex/edge/face pointers.
-  for (size_t i = 0; i < mesh->getVertices().size(); i++) {
-    REQUIRE(copy->getVertices()[i] != mesh->getVertices()[i]);
-  }
   for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE(copy->getFaces()[i] != mesh->getFaces()[i]);
-    REQUIRE((copy->getFaces()[i]->getNormal() - mesh->getFaces()[i]->getNormal()).length() < T(exactMargin<T>()));
-    REQUIRE_THAT(copy->getFaces()[i]->getArea(), withinAbsT(mesh->getFaces()[i]->getArea(), exactMargin<T>()));
+    REQUIRE((copy->getFaces()[i].getNormal() - mesh->getFaces()[i].getNormal()).length() < T(exactMargin<T>()));
+    REQUIRE_THAT(copy->getFaces()[i].getArea(), withinAbsT(mesh->getFaces()[i].getArea(), exactMargin<T>()));
   }
 
   // Mutating the copy must not affect the original.
-  copy->getVertices()[0]->setPosition(Vec3T<T>(999, 999, 999));
-  REQUIRE(mesh->getVertices()[0]->getPosition() != Vec3T<T>(999, 999, 999));
+  copy->getVertices()[0].setPosition(Vec3T<T>(999, 999, 999));
+  REQUIRE(mesh->getVertices()[0].getPosition() != Vec3T<T>(999, 999, 999));
 
   // The copy must still be usable for signed-distance queries (validates that the 2D embedding
-  // was correctly rebuilt for every face).
+  // was carried over for every face).
   const Vec3T<T> p(0.1, 0.1, 0.1);
   REQUIRE_THAT(copy->signedDistance(p), withinAbsT(mesh->signedDistance(p), formulaMargin<T>()));
 }
@@ -867,7 +775,7 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy preserves a prior flip() instead of silently
   auto copy = mesh->deepCopy();
 
   for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE((copy->getFaces()[i]->getNormal() - mesh->getFaces()[i]->getNormal()).length() < T(exactMargin<T>()));
+    REQUIRE((copy->getFaces()[i].getNormal() - mesh->getFaces()[i].getNormal()).length() < T(exactMargin<T>()));
   }
 }
 
@@ -966,9 +874,12 @@ TEMPLATE_TEST_CASE("Soup::soupToDCEL reconciles every half-edge's pair edge on a
   using T   = TestType;
   auto mesh = buildTetrahedron<T>();
 
-  for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr);
-    REQUIRE(e->getPairEdge()->getPairEdge() == e); // Pairing must be symmetric.
+  const auto& edges = mesh->getEdges();
+  for (size_t i = 0; i < edges.size(); i++) {
+    const DCELIndex pair = edges[i].getPairEdge();
+
+    REQUIRE(pair != InvalidIndex);
+    REQUIRE(edges[pair].getPairEdge() == static_cast<DCELIndex>(i)); // Pairing must be symmetric.
   }
 }
 
@@ -1004,8 +915,7 @@ TEMPLATE_TEST_CASE("DCEL: all faces have a half-edge", "[DCEL]", EBGEOMETRY_TEST
   REQUIRE(mesh != nullptr);
 
   for (const auto& face : mesh->getFaces()) {
-    REQUIRE(face != nullptr);
-    REQUIRE(face->getHalfEdge() != nullptr);
+    REQUIRE(face.getHalfEdge() != InvalidIndex);
   }
 }
 
@@ -1016,9 +926,8 @@ TEMPLATE_TEST_CASE("DCEL: all half-edges have a pair and a face", "[DCEL]", EBGE
   REQUIRE(mesh != nullptr);
 
   for (const auto& edge : mesh->getEdges()) {
-    REQUIRE(edge != nullptr);
-    REQUIRE(edge->getPairEdge() != nullptr);
-    REQUIRE(edge->getFace() != nullptr);
+    REQUIRE(edge.getPairEdge() != InvalidIndex);
+    REQUIRE(edge.getFace() != InvalidIndex);
   }
 }
 
@@ -1029,7 +938,7 @@ TEMPLATE_TEST_CASE("DCEL: all face normals are unit-length", "[DCEL]", EBGEOMETR
   REQUIRE(mesh != nullptr);
 
   for (const auto& face : mesh->getFaces()) {
-    REQUIRE_THAT(face->getNormal().length(), withinAbsT(T(1.0), formulaMargin<T>()));
+    REQUIRE_THAT(face.getNormal().length(), withinAbsT(T(1.0), formulaMargin<T>()));
   }
 }
 
@@ -1045,7 +954,7 @@ TEMPLATE_TEST_CASE("DCEL: sanityCheck completes without crashing", "[DCEL]", EBG
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Signed-distance tests using MeshSDF (brute-force O(N) evaluator)
+// Signed-distance tests using MeshSDF (BVH-accelerated evaluator)
 // ─────────────────────────────────────────────────────────────────────────────
 
 TEMPLATE_TEST_CASE("MeshSDF: tetrahedron signed distances", "[DCEL][MeshSDF]", EBGEOMETRY_TEST_PRECISIONS)
@@ -1079,9 +988,37 @@ TEMPLATE_TEST_CASE("MeshSDF: tetrahedron signed distances", "[DCEL][MeshSDF]", E
   }
 }
 
+TEMPLATE_TEST_CASE("MeshSDF::getClosestFaces returns face indices sorted by ascending distance",
+                   "[DCEL][MeshSDF]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T   = TestType;
+  auto mesh = buildTetrahedron<T>();
+
+  TestMeshSDF<T> sdf(mesh, BVH::Build::SAH);
+
+  const Vec3T<T> p(0.25, 0.25, 0.25);
+
+  const auto sorted = sdf.getClosestFaces(p, true);
+  REQUIRE(!sorted.empty());
+
+  for (const auto& faceAndDist : sorted) {
+    // The returned first element is a valid face index into the mesh.
+    REQUIRE(faceAndDist.first >= 0);
+    REQUIRE(faceAndDist.first < static_cast<DCELIndex>(mesh->getFaces().size()));
+  }
+  for (size_t i = 1; i < sorted.size(); i++) {
+    REQUIRE(sorted[i - 1].second <= sorted[i].second);
+  }
+
+  // The closest face reported must be consistent with the scalar signed-distance query.
+  const T closestUnsignedDist = sorted.front().second;
+  REQUIRE_THAT(closestUnsignedDist, withinAbsT(std::abs(sdf.signedDistance(p)), formulaMargin<T>()));
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Sign-convention regression: hard-coded DCEL, no file I/O.
-// If the cross-product in computeNormal is ever accidentally inverted this
+// If the cross-product in reconcileFace is ever accidentally inverted this
 // test will immediately flip from pass to fail.
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/Tests/TestOBJ.cpp
+++ b/Tests/TestOBJ.cpp
@@ -134,6 +134,6 @@ TEMPLATE_TEST_CASE("OBJ: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdge() != DCEL::InvalidIndex); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestPLY.cpp
+++ b/Tests/TestPLY.cpp
@@ -164,6 +164,6 @@ TEMPLATE_TEST_CASE("PLY: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdge() != DCEL::InvalidIndex); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestSTL.cpp
+++ b/Tests/TestSTL.cpp
@@ -172,6 +172,6 @@ TEMPLATE_TEST_CASE("Parser::readSTL + convertToDCEL round-trips into a valid, wa
   REQUIRE(mesh->getEdges().size() == 12);
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdge() != DCEL::InvalidIndex); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestVTK.cpp
+++ b/Tests/TestVTK.cpp
@@ -164,6 +164,6 @@ TEMPLATE_TEST_CASE("VTK: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdge() != DCEL::InvalidIndex); // Watertight: every half-edge has a pair.
   }
 }


### PR DESCRIPTION
# Summary

### Background

Tier 1 of the GPU port (see #115). The DCEL half-edge mesh was the last pointer-heavy core data
structure: `DCEL::MeshT` owned its vertices/half-edges/faces via `std::shared_ptr` and every
topological link was a `std::weak_ptr` back-reference (`.lock()`-ed on every access). That
representation cannot be copied to a device. Per the port's "one representation, no host/device data
duality" agreement, this converts the DCEL to a single flat, index-based form used on host (and,
after later annotation, on device) rather than maintaining a pointer host DCEL plus a separate flat
device copy. Host-only and behavior-preserving; a clean break to the DCEL public API (no deprecation
aliases).

### Solution

- **Elements are pure-data value types.** `MeshT` owns `std::vector<VertexT>`/`<EdgeT>`/`<FaceT>` by
  value. Every topological link is a `DCEL::DCELIndex` (`int`) into those arrays, with
  `DCEL::InvalidIndex` (`-1`) denoting "no link" (e.g. a boundary half-edge's absent pair). No
  `shared_ptr`/`weak_ptr`, so no reference-cycle hazard.
- **Traversal and geometric queries move onto `MeshT`** (an element can no longer chase pointers):
  `signedDistanceToFace/Edge/Vertex`, the `unsignedDistance2*` variants, `isPointInsideFace`,
  `reconcile`, and the normal computations. `EdgeIteratorT` becomes an edge-index cursor. The exact
  math (edge projection/vertex fallback, face inside/outside branches, Newell normal, shoelace area,
  angle-weighted vertex pseudonormal, Direct vs Direct2) is preserved.
- **`FaceT` stores its `Polygon2D` by value** instead of `shared_ptr<Polygon2D>`, removing the old
  "copy silently drops the 2D embedding" hazard; `deepCopy()` is now a trivial independent by-value
  array copy that preserves a prior `flip()`.
- **`Soup::soupToDCEL` builds index arrays directly**; `reconcilePairEdgesDCEL` matches anti-parallel
  half-edges via a directed `(origin, other)` key + reverse lookup (orientation-aware, same result
  and same "not watertight" diagnostic as before).
- **`MeshSDF`'s BVH primitive is now the face index** (`PackedBVH<T, DCELIndex, K, ValueStorage>`);
  the leaf evaluator resolves each index against the retained mesh. New `MeshSDF::getMesh()` (mirrors
  `FlatMeshSDF`) exposes the mesh so callers can resolve the `(face index, distance)` pairs now
  returned by `getClosestFaces()`. `FlatMeshSDF` is unchanged; `TriMeshSDF` and
  `Parser::readIntoTriangles` were updated to the index API.

### Side-effects

- Behavior-preserving: full suite passes in both precisions — 525/525 unit tests (Debug and AVX
  Release) and all 11 examples; Doxygen and clang-format 21 clean. `TestDCEL.cpp` was rewritten to
  the index API but keeps every invariant (tetra 4/4/12, dodeca 20/36/108, symmetric watertight
  pairing, unit normals, positive areas, outward sign convention, Direct==Direct2, deepCopy
  independence + flip preservation, iterator ring); an open-mesh test was added for the boundary
  half-edge pseudonormal branch.
- Clean break to the DCEL public API: accessors return indices, `getFaces()/getEdges()/getVertices()`
  hand out value elements, and `MeshSDF::getClosestFaces()` returns `(index, distance)` pairs. The
  AMReX `PaintEB` integration (not CI-tested) was updated to the new API in the same change.
- Net −774 lines; the index-based representation is leaner than the pointer graph.
- Docs updated (`ImplemDCEL`/`Implementation`/`ImplemBVH` and `CLAUDE.md`) to describe the
  index-based DCEL.

### Alternative solutions

- Keeping the pointer-based DCEL for the host and adding a *separate* flat index-based structure for
  the device was considered and rejected: it would double the representation and the maintenance
  surface, against the port's single-representation agreement.
- A per-element back-pointer to the owning mesh would have preserved the method-chaining API with
  less churn, but reintroduces a pointer per element (needing device fix-up), so queries were
  relocated to `MeshT` instead.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation.
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS

---
_Generated by [Claude Code](https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS)_