### PR TITLE
GPU port (Tier 3): transforms + combiners to HOST_DEVICE traits; propagate m_sdf

### DIFF
--- a/Source/EBGeometry_CSG.hpp
+++ b/Source/EBGeometry_CSG.hpp
@@ -224,9 +224,169 @@ FiniteRepetition(const std::shared_ptr<P>& a_implicitFunction,
                  const Vec3T<T>&           a_repeatHi);
 
 /**
+ * @brief Reduction trait for the sharp CSG union.
+ * @details Single source of truth for the sharp-union reduction: the union of two signed-distance
+ * values is their minimum. Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct UnionOp
+{
+  static_assert(std::is_floating_point_v<T>, "UnionOp requires a floating-point type T");
+
+  /**
+   * @brief Combine two signed-distance values by taking their minimum.
+   * @param[in] a First value.
+   * @param[in] b Second value.
+   * @return min(a, b).
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  combine(T a, T b) noexcept
+  {
+    return std::min(a, b);
+  }
+};
+
+/**
+ * @brief Reduction trait for the sharp CSG intersection.
+ * @details Single source of truth for the sharp-intersection reduction: the intersection of two
+ * signed-distance values is their maximum. Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct IntersectionOp
+{
+  static_assert(std::is_floating_point_v<T>, "IntersectionOp requires a floating-point type T");
+
+  /**
+   * @brief Combine two signed-distance values by taking their maximum.
+   * @param[in] a First value.
+   * @param[in] b Second value.
+   * @return max(a, b).
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  combine(T a, T b) noexcept
+  {
+    return std::max(a, b);
+  }
+};
+
+/**
+ * @brief Reduction trait for the sharp CSG difference A \ B.
+ * @details Single source of truth for the sharp-difference reduction: A \ B evaluates to max(A, -B).
+ * Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct DifferenceOp
+{
+  static_assert(std::is_floating_point_v<T>, "DifferenceOp requires a floating-point type T");
+
+  /**
+   * @brief Combine two signed-distance values into the set difference A \ B.
+   * @param[in] a Value of the minuend A.
+   * @param[in] b Value of the subtrahend B.
+   * @return max(a, -b).
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  combine(T a, T b) noexcept
+  {
+    return std::max(a, -b);
+  }
+};
+
+/**
+ * @brief Reduction trait for the exponential smooth minimum.
+ * @details Single source of truth for the exponential smooth-minimum blend formula, reused verbatim by
+ * the tape interpreter and by the ExpMin std::function wrapper.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct ExpMinOp
+{
+  static_assert(std::is_floating_point_v<T>, "ExpMinOp requires a floating-point type T");
+
+  /**
+   * @brief Exponentially blended minimum of two signed-distance values.
+   * @param[in] a First value.
+   * @param[in] b Second value.
+   * @param[in] s Smoothing length (must be > 0).
+   * @return Exponentially blended approximation of min(a, b).
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  eval(T a, T b, T s) noexcept
+  {
+    EBGEOMETRY_EXPECT(s > T(0));
+
+    const T ret = std::exp(-a / s) + std::exp(-b / s);
+
+    return -std::log(ret) * s;
+  }
+};
+
+/**
+ * @brief Reduction trait for the quadratic polynomial smooth minimum.
+ * @details Single source of truth for the polynomial smooth-minimum blend formula, reused verbatim by
+ * the tape interpreter and by the SmoothMin std::function wrapper.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct SmoothMinOp
+{
+  static_assert(std::is_floating_point_v<T>, "SmoothMinOp requires a floating-point type T");
+
+  /**
+   * @brief Polynomially blended minimum of two signed-distance values.
+   * @param[in] a First value.
+   * @param[in] b Second value.
+   * @param[in] s Smoothing length (must be > 0). Controls the blend region width.
+   * @return Polynomial-blended approximation of min(a, b).
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  eval(T a, T b, T s) noexcept
+  {
+    EBGEOMETRY_EXPECT(s > T(0));
+
+    const T h = std::max(s - std::abs(a - b), T(0)) / s;
+
+    return std::min(a, b) - T(0.25) * h * h * s;
+  }
+};
+
+/**
+ * @brief Reduction trait for the quadratic polynomial smooth maximum.
+ * @details Single source of truth for the polynomial smooth-maximum blend formula, reused verbatim by
+ * the tape interpreter and by the SmoothMax std::function wrapper.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct SmoothMaxOp
+{
+  static_assert(std::is_floating_point_v<T>, "SmoothMaxOp requires a floating-point type T");
+
+  /**
+   * @brief Polynomially blended maximum of two signed-distance values.
+   * @param[in] a First value.
+   * @param[in] b Second value.
+   * @param[in] s Smoothing length (must be > 0). Controls the blend region width.
+   * @return Polynomial-blended approximation of max(a, b).
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  eval(T a, T b, T s) noexcept
+  {
+    EBGEOMETRY_EXPECT(s > T(0));
+
+    const T h = std::max(s - std::abs(a - b), T(0)) / s;
+
+    return std::max(a, b) + T(0.25) * h * h * s;
+  }
+};
+
+/**
  * @brief Exponential smooth minimum for blending two signed-distance values.
  * @details Approximates min(a, b) with exponential weighting; the blend region width scales with s.
- * Useful when a differentiable interface is required. Approaches min(a, b) as s → 0.
+ * Useful when a differentiable interface is required. Approaches min(a, b) as s → 0. Thin std::function
+ * wrapper around ExpMinOp, which is the single source of truth for the formula.
  * @tparam T Floating-point precision.
  * @param[in] a First value.
  * @param[in] b Second value.
@@ -234,19 +394,14 @@ FiniteRepetition(const std::shared_ptr<P>& a_implicitFunction,
  * @return Exponentially blended approximation of min(a, b).
  */
 template <class T>
-std::function<T(const T& a, const T& b, const T& s)> ExpMin = [](const T& a, const T& b, const T& s) -> T {
-  static_assert(std::is_floating_point_v<T>, "ExpMin requires a floating-point type T");
-
-  EBGEOMETRY_EXPECT(s > T(0));
-  T ret = std::exp(-a / s) + std::exp(-b / s);
-
-  return -std::log(ret) * s;
-};
+std::function<T(const T& a, const T& b, const T& s)> ExpMin =
+  [](const T& a, const T& b, const T& s) -> T { return ExpMinOp<T>::eval(a, b, s); };
 
 /**
  * @brief Quadratic polynomial smooth minimum for blending two signed-distance values.
  * @details Approximates min(a, b) within the overlap region |a - b| < s; coincides exactly with
  * min(a, b) outside that region. Cheaper to evaluate than ExpMin and the default choice for CSG unions.
+ * Thin std::function wrapper around SmoothMinOp, which is the single source of truth for the formula.
  * @tparam T Floating-point precision.
  * @param[in] a First value.
  * @param[in] b Second value.
@@ -254,19 +409,15 @@ std::function<T(const T& a, const T& b, const T& s)> ExpMin = [](const T& a, con
  * @return Polynomial-blended approximation of min(a, b).
  */
 template <class T>
-std::function<T(const T& a, const T& b, const T& s)> SmoothMin = [](const T& a, const T& b, const T& s) -> T {
-  static_assert(std::is_floating_point_v<T>, "SmoothMin requires a floating-point type T");
-
-  EBGEOMETRY_EXPECT(s > T(0));
-  const T h = std::max(s - std::abs(a - b), T(0)) / s;
-
-  return std::min(a, b) - T(0.25) * h * h * s;
-};
+std::function<T(const T& a, const T& b, const T& s)> SmoothMin =
+  [](const T& a, const T& b, const T& s) -> T { return SmoothMinOp<T>::eval(a, b, s); };
 
 /**
  * @brief Quadratic polynomial smooth maximum for blending two signed-distance values.
  * @details Approximates max(a, b) within the overlap region |a - b| < s; coincides exactly with
- * max(a, b) outside that region. Symmetric counterpart to SmoothMin; used for CSG intersections and differences.
+ * max(a, b) outside that region. Symmetric counterpart to SmoothMin; used for CSG intersections and
+ * differences. Thin std::function wrapper around SmoothMaxOp, which is the single source of truth for
+ * the formula.
  * @tparam T Floating-point precision.
  * @param[in] a First value.
  * @param[in] b Second value.
@@ -274,14 +425,8 @@ std::function<T(const T& a, const T& b, const T& s)> SmoothMin = [](const T& a, 
  * @return Polynomial-blended approximation of max(a, b).
  */
 template <class T>
-std::function<T(const T& a, const T& b, const T& s)> SmoothMax = [](const T& a, const T& b, const T& s) -> T {
-  static_assert(std::is_floating_point_v<T>, "SmoothMax requires a floating-point type T");
-
-  EBGEOMETRY_EXPECT(s > T(0));
-  const T h = std::max(s - std::abs(a - b), T(0)) / s;
-
-  return std::max(a, b) + T(0.25) * h * h * s;
-};
+std::function<T(const T& a, const T& b, const T& s)> SmoothMax =
+  [](const T& a, const T& b, const T& s) -> T { return SmoothMaxOp<T>::eval(a, b, s); };
 
 /**
  * @brief Implicit function whose interior is the union of all input function interiors.

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -343,11 +343,17 @@ UnionIF<T>::UnionIF(const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_i
 {
   EBGEOMETRY_EXPECT(!a_implicitFunctions.empty());
 
+  bool allSignedDistance = true;
+
   for (const auto& prim : a_implicitFunctions) {
     EBGEOMETRY_EXPECT(prim != nullptr);
 
+    allSignedDistance = allSignedDistance && prim->isSignedDistance();
+
     m_implicitFunctions.emplace_back(prim);
   }
+
+  this->m_sdf = allSignedDistance;
 }
 
 template <class T>
@@ -361,7 +367,7 @@ UnionIF<T>::value(const Vec3T<T>& a_point) const noexcept
 
     EBGEOMETRY_EXPECT(!std::isnan(v));
 
-    ret = std::min(ret, v);
+    ret = UnionOp<T>::combine(ret, v);
   }
 
   return ret;
@@ -383,6 +389,8 @@ SmoothUnionIF<T>::SmoothUnionIF(const std::vector<std::shared_ptr<ImplicitFuncti
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
   m_smoothMin = a_smoothMin;
+
+  this->m_sdf = false;
 }
 
 template <class T>
@@ -425,9 +433,15 @@ BVHUnionIF<T, P, BV, K>::BVHUnionIF(const std::vector<std::pair<std::shared_ptr<
 {
   EBGEOMETRY_EXPECT(!a_primsAndBVs.empty());
 
+  bool allSignedDistance = true;
+
   for (const auto& [prim, bv] : a_primsAndBVs) {
     EBGEOMETRY_EXPECT(prim != nullptr);
+
+    allSignedDistance = allSignedDistance && prim->isSignedDistance();
   }
+
+  this->m_sdf = allSignedDistance;
 
   this->buildTree(a_primsAndBVs);
 }
@@ -439,9 +453,15 @@ BVHUnionIF<T, P, BV, K>::BVHUnionIF(const std::vector<std::shared_ptr<P>>& a_pri
   EBGEOMETRY_EXPECT(!a_primitives.empty());
   EBGEOMETRY_EXPECT(a_primitives.size() == a_boundingVolumes.size());
 
+  bool allSignedDistance = true;
+
   for (const auto& p : a_primitives) {
     EBGEOMETRY_EXPECT(p != nullptr);
+
+    allSignedDistance = allSignedDistance && p->isSignedDistance();
   }
+
+  this->m_sdf = allSignedDistance;
 
   std::vector<std::pair<std::shared_ptr<const P>, BV>> primsAndBVs;
 
@@ -535,6 +555,8 @@ BVHSmoothUnionIF<T, P, BV, K>::BVHSmoothUnionIF(
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
   m_smoothMin = a_smoothMin;
+
+  this->m_sdf = false;
 }
 
 template <class T, class P, class BV, size_t K>
@@ -612,11 +634,17 @@ IntersectionIF<T>::IntersectionIF(const std::vector<std::shared_ptr<ImplicitFunc
 {
   EBGEOMETRY_EXPECT(!a_implicitFunctions.empty());
 
+  bool allSignedDistance = true;
+
   for (const auto& prim : a_implicitFunctions) {
     EBGEOMETRY_EXPECT(prim != nullptr);
 
+    allSignedDistance = allSignedDistance && prim->isSignedDistance();
+
     m_implicitFunctions.emplace_back(prim);
   }
+
+  this->m_sdf = allSignedDistance;
 }
 
 template <class T>
@@ -630,7 +658,7 @@ IntersectionIF<T>::value(const Vec3T<T>& a_point) const noexcept
 
     EBGEOMETRY_EXPECT(!std::isnan(v));
 
-    ret = std::max(ret, v);
+    ret = IntersectionOp<T>::combine(ret, v);
   }
 
   return ret;
@@ -652,6 +680,8 @@ SmoothIntersectionIF<T>::SmoothIntersectionIF(
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
   m_smoothMax = a_smoothMax;
+
+  this->m_sdf = false;
 }
 
 template <class T>
@@ -671,6 +701,8 @@ SmoothIntersectionIF<T>::SmoothIntersectionIF(
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
   m_smoothMax = a_smoothMax;
+
+  this->m_sdf = false;
 }
 
 template <class T>
@@ -717,6 +749,8 @@ DifferenceIF<T>::DifferenceIF(const std::shared_ptr<ImplicitFunction<T>>& a_impl
 
   m_implicitFunctionA = a_implicitFunctionA;
   m_implicitFunctionB = a_implicitFunctionB;
+
+  this->m_sdf = a_implicitFunctionA->isSignedDistance() && a_implicitFunctionB->isSignedDistance();
 }
 
 template <class T>
@@ -728,6 +762,8 @@ DifferenceIF<T>::DifferenceIF(const std::shared_ptr<ImplicitFunction<T>>&       
 
   m_implicitFunctionA = a_implicitFunctionA;
   m_implicitFunctionB = EBGeometry::Union<T>(a_implicitFunctionsB);
+
+  this->m_sdf = m_implicitFunctionA->isSignedDistance() && m_implicitFunctionB->isSignedDistance();
 }
 
 template <class T>
@@ -740,7 +776,7 @@ DifferenceIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(!std::isnan(a));
   EBGEOMETRY_EXPECT(!std::isnan(b));
 
-  return std::max(a, -b);
+  return DifferenceOp<T>::combine(a, b);
 }
 
 template <class T>
@@ -756,6 +792,8 @@ SmoothDifferenceIF<T>::SmoothDifferenceIF(
 
   m_smoothIntersectionIF = std::make_shared<SmoothIntersectionIF<T>>(
     a_implicitFunctionA, EBGeometry::Complement<T>(a_implicitFunctionB), a_smoothLen, a_smoothMax);
+
+  this->m_sdf = false;
 }
 
 template <class T>
@@ -781,6 +819,8 @@ SmoothDifferenceIF<T>::SmoothDifferenceIF(
   }
 
   m_smoothIntersectionIF = std::make_shared<SmoothIntersectionIF<T>>(implicitFunctions, a_smoothLen, a_smoothMax);
+
+  this->m_sdf = false;
 }
 
 template <class T>
@@ -808,6 +848,8 @@ FiniteRepetitionIF<T>::FiniteRepetitionIF(const std::shared_ptr<ImplicitFunction
   m_period           = a_period;
   m_repeatLo         = a_repeatLo;
   m_repeatHi         = a_repeatHi;
+
+  this->m_sdf = false;
 }
 
 template <class T>

--- a/Source/EBGeometry_Transform.hpp
+++ b/Source/EBGeometry_Transform.hpp
@@ -12,6 +12,7 @@
 #define EBGEOMETRY_TRANSFORM_HPP
 
 // Std includes
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <type_traits>
@@ -20,6 +21,7 @@
 
 // Our includes
 #include "EBGeometry_ImplicitFunction.hpp"
+#include "EBGeometry_Macros.hpp"
 #include "EBGeometry_Vec.hpp"
 
 namespace EBGeometry {
@@ -138,6 +140,43 @@ template <class T>
 Reflect(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunction, const size_t& a_reflectPlane);
 
 /**
+ * @brief Distance-formula trait for the complement transform.
+ * @details Single source of truth for the complement's value remapping: the complement negates the
+ * wrapped function value. This math is reused verbatim by the tape interpreter, so it must live in the
+ * HOST_DEVICE trait static rather than inline in ComplementIF::value.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct ComplementOp
+{
+  /**
+   * @brief Stored parameters for the complement transform (none).
+   */
+  struct Params
+  {
+  };
+
+  /**
+   * @brief The complement of a signed distance function is again a signed distance function.
+   */
+  static constexpr bool preservesSignedDistance = true;
+
+  /**
+   * @brief Remap the child value to its complement.
+   * @param[in] a_params     Complement parameters (unused).
+   * @param[in] a_childValue Value of the wrapped implicit function.
+   * @return The negated child value.
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  mapValue(const Params& a_params, T a_childValue) noexcept
+  {
+    (void)a_params;
+
+    return -a_childValue;
+  }
+};
+
+/**
  * @brief Complemented implicit function
  * @tparam T Floating-point precision
  */
@@ -204,6 +243,46 @@ protected:
    * @brief Implicit function
    */
   std::shared_ptr<ImplicitFunction<T>> m_implicitFunction = nullptr;
+
+  /**
+   * @brief Transform parameters (empty for the complement).
+   */
+  typename ComplementOp<T>::Params m_params;
+};
+
+/**
+ * @brief Distance-formula trait for the translation transform.
+ * @details Single source of truth for the translation's coordinate remapping: the query point is
+ * shifted by -shift before evaluating the wrapped function. Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct TranslateOp
+{
+  /**
+   * @brief Stored parameters for the translation transform.
+   */
+  struct Params
+  {
+    Vec3T<T> shift = Vec3T<T>::zeros(); ///< Translation amount.
+  };
+
+  /**
+   * @brief A rigid translation of a signed distance function is again a signed distance function.
+   */
+  static constexpr bool preservesSignedDistance = true;
+
+  /**
+   * @brief Remap the query point by the inverse translation.
+   * @param[in] a_params Translation parameters.
+   * @param[in] a_point  Query point.
+   * @return The query point shifted by -shift.
+   */
+  EBGEOMETRY_HOST_DEVICE static Vec3T<T>
+  mapPoint(const Params& a_params, const Vec3T<T>& a_point) noexcept
+  {
+    return a_point - a_params.shift;
+  }
 };
 
 /**
@@ -264,7 +343,7 @@ public:
   /**
    * @brief Value function
    * @param[in] a_point Query point
-   * @return Value of the wrapped implicit function evaluated at a_point shifted by -m_shift
+   * @return Value of the wrapped implicit function evaluated at a_point shifted by -m_params.shift
    */
   [[nodiscard]] T
   value(const Vec3T<T>& a_point) const noexcept override;
@@ -276,9 +355,79 @@ protected:
   std::shared_ptr<ImplicitFunction<T>> m_implicitFunction = nullptr;
 
   /**
-   * @brief Input point translate.
+   * @brief Transform parameters (translation shift).
    */
-  Vec3T<T> m_shift;
+  typename TranslateOp<T>::Params m_params;
+};
+
+/**
+ * @brief Distance-formula trait for the rotation transform.
+ * @details Single source of truth for the rotation's coordinate remapping: the query point is rotated
+ * about a Cartesian axis by the pre-computed cos/sin of the rotation angle before evaluating the
+ * wrapped function. Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct RotateOp
+{
+  /**
+   * @brief Stored parameters for the rotation transform.
+   */
+  struct Params
+  {
+    size_t axis     = 0;    ///< Axis to rotate about (0=x, 1=y, 2=z).
+    T      cosAngle = T(1); ///< Cosine of the rotation angle.
+    T      sinAngle = T(0); ///< Sine of the rotation angle.
+  };
+
+  /**
+   * @brief A rigid rotation of a signed distance function is again a signed distance function.
+   */
+  static constexpr bool preservesSignedDistance = true;
+
+  /**
+   * @brief Remap the query point by the rotation.
+   * @param[in] a_params Rotation parameters.
+   * @param[in] a_point  Query point.
+   * @return The rotated query point.
+   */
+  EBGEOMETRY_HOST_DEVICE static Vec3T<T>
+  mapPoint(const Params& a_params, const Vec3T<T>& a_point) noexcept
+  {
+    const T& x = a_point[0];
+    const T& y = a_point[1];
+    const T& z = a_point[2];
+
+    Vec3T<T> rotatedPoint = a_point;
+
+    switch (a_params.axis) {
+    case 0: {
+      rotatedPoint[1] = y * a_params.cosAngle + z * a_params.sinAngle;
+      rotatedPoint[2] = -y * a_params.sinAngle + z * a_params.cosAngle;
+
+      break;
+    }
+    case 1: {
+      rotatedPoint[0] = x * a_params.cosAngle - z * a_params.sinAngle;
+      rotatedPoint[2] = x * a_params.sinAngle + z * a_params.cosAngle;
+
+      break;
+    }
+    case 2: {
+      rotatedPoint[0] = x * a_params.cosAngle + y * a_params.sinAngle;
+      rotatedPoint[1] = -x * a_params.sinAngle + y * a_params.cosAngle;
+
+      break;
+    }
+    default: {
+      EBGEOMETRY_EXPECT(false && "RotateOp: axis must be 0, 1, or 2");
+
+      break;
+    }
+    }
+
+    return rotatedPoint;
+  }
 };
 
 /**
@@ -354,24 +503,44 @@ protected:
   std::shared_ptr<ImplicitFunction<T>> m_implicitFunction = nullptr;
 
   /**
-   * @brief Axis to rotate about
+   * @brief Transform parameters (rotation axis and pre-computed cos/sin of the angle).
    */
-  size_t m_axis;
+  typename RotateOp<T>::Params m_params;
+};
+
+/**
+ * @brief Distance-formula trait for the offset transform.
+ * @details Single source of truth for the offset's value remapping: a constant offset is subtracted
+ * from the wrapped function value. Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct OffsetOp
+{
+  /**
+   * @brief Stored parameters for the offset transform.
+   */
+  struct Params
+  {
+    T offset = T(0); ///< Offset subtracted from the wrapped value.
+  };
 
   /**
-   * @brief Angle to rotate.
+   * @brief Offsetting a signed distance function by a constant preserves the signed distance property.
    */
-  T m_angle;
+  static constexpr bool preservesSignedDistance = true;
 
   /**
-   * @brief Parameter in rotation matrix. Stored for efficiency.
+   * @brief Remap the child value by subtracting the offset.
+   * @param[in] a_params     Offset parameters.
+   * @param[in] a_childValue Value of the wrapped implicit function.
+   * @return The child value minus the offset.
    */
-  T m_cosAngle;
-
-  /**
-   * @brief Parameter in rotation matrix. Stored for efficiency.
-   */
-  T m_sinAngle;
+  EBGEOMETRY_HOST_DEVICE static T
+  mapValue(const Params& a_params, T a_childValue) noexcept
+  {
+    return a_childValue - a_params.offset;
+  }
 };
 
 /**
@@ -444,9 +613,57 @@ protected:
   std::shared_ptr<ImplicitFunction<T>> m_implicitFunction = nullptr;
 
   /**
-   * @brief Offset value.
+   * @brief Transform parameters (offset value).
    */
-  T m_offset;
+  typename OffsetOp<T>::Params m_params;
+};
+
+/**
+ * @brief Distance-formula trait for the uniform-scaling transform.
+ * @details Single source of truth for the scale's remapping: the query point is divided by the scale
+ * factor before evaluating the wrapped function and the result is multiplied back by the scale factor.
+ * Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct ScaleOp
+{
+  /**
+   * @brief Stored parameters for the scaling transform.
+   */
+  struct Params
+  {
+    T scale = T(1); ///< Uniform scaling factor (non-zero).
+  };
+
+  /**
+   * @brief A uniform scaling of a signed distance function is again a signed distance function.
+   */
+  static constexpr bool preservesSignedDistance = true;
+
+  /**
+   * @brief Remap the query point by the inverse scaling.
+   * @param[in] a_params Scaling parameters.
+   * @param[in] a_point  Query point.
+   * @return The query point divided by the scale factor.
+   */
+  EBGEOMETRY_HOST_DEVICE static Vec3T<T>
+  mapPoint(const Params& a_params, const Vec3T<T>& a_point) noexcept
+  {
+    return a_point / a_params.scale;
+  }
+
+  /**
+   * @brief Post-scale the child value.
+   * @param[in] a_params     Scaling parameters.
+   * @param[in] a_childValue Value of the wrapped implicit function.
+   * @return The child value multiplied by the scale factor.
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  mapValue(const Params& a_params, T a_childValue) noexcept
+  {
+    return a_childValue * a_params.scale;
+  }
 };
 
 /**
@@ -507,7 +724,7 @@ public:
   /**
    * @brief Value function.
    * @param[in] a_point Query point
-   * @return Signed distance of the wrapped function evaluated at a_point/m_scale, multiplied by m_scale
+   * @return Signed distance of the wrapped function evaluated at a_point/m_params.scale, multiplied by m_params.scale
    */
   [[nodiscard]] T
   value(const Vec3T<T>& a_point) const noexcept override;
@@ -519,9 +736,45 @@ protected:
   std::shared_ptr<ImplicitFunction<T>> m_implicitFunction = nullptr;
 
   /**
-   * @brief Scaling factor.
+   * @brief Transform parameters (scaling factor).
    */
-  T m_scale;
+  typename ScaleOp<T>::Params m_params;
+};
+
+/**
+ * @brief Distance-formula trait for the annular (shell) transform.
+ * @details Single source of truth for the annular value remapping: the absolute value of the wrapped
+ * function is taken and the shell thickness is subtracted, hollowing the shape into a shell. Reused
+ * verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct AnnularOp
+{
+  /**
+   * @brief Stored parameters for the annular transform.
+   */
+  struct Params
+  {
+    T delta = T(0); ///< Shell thickness.
+  };
+
+  /**
+   * @brief The annular map of a signed distance function is again a signed distance function.
+   */
+  static constexpr bool preservesSignedDistance = true;
+
+  /**
+   * @brief Remap the child value into a shell.
+   * @param[in] a_params     Annular parameters.
+   * @param[in] a_childValue Value of the wrapped implicit function.
+   * @return std::abs(a_childValue) - delta.
+   */
+  EBGEOMETRY_HOST_DEVICE static T
+  mapValue(const Params& a_params, T a_childValue) noexcept
+  {
+    return std::abs(a_childValue) - a_params.delta;
+  }
 };
 
 /**
@@ -582,7 +835,7 @@ public:
   /**
    * @brief Value function.
    * @param[in] a_point Query point
-   * @return std::abs(f(a_point)) - m_delta, hollowing out the shape at distance m_delta from the surface
+   * @return std::abs(f(a_point)) - m_params.delta, hollowing out the shape at distance m_params.delta from the surface
    */
   [[nodiscard]] T
   value(const Vec3T<T>& a_point) const noexcept override;
@@ -594,9 +847,9 @@ protected:
   std::shared_ptr<const ImplicitFunction<T>> m_implicitFunction = nullptr;
 
   /**
-   * @brief Shell thickness.
+   * @brief Transform parameters (shell thickness).
    */
-  T m_delta;
+  typename AnnularOp<T>::Params m_params;
 };
 
 /**
@@ -775,6 +1028,42 @@ protected:
 };
 
 /**
+ * @brief Distance-formula trait for the elongation transform.
+ * @details Single source of truth for the elongation's coordinate remapping: the query point is
+ * clamped component-wise to [-elongation, +elongation] and the clamped value is subtracted before
+ * evaluating the wrapped function. Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct ElongateOp
+{
+  /**
+   * @brief Stored parameters for the elongation transform.
+   */
+  struct Params
+  {
+    Vec3T<T> elongation = Vec3T<T>::zeros(); ///< Per-axis elongation amounts.
+  };
+
+  /**
+   * @brief Elongation does not preserve the signed distance property (the swept region is not metric).
+   */
+  static constexpr bool preservesSignedDistance = false;
+
+  /**
+   * @brief Remap the query point by the elongation.
+   * @param[in] a_params Elongation parameters.
+   * @param[in] a_point  Query point.
+   * @return a_point minus its component-wise clamp to [-elongation, +elongation].
+   */
+  EBGEOMETRY_HOST_DEVICE static Vec3T<T>
+  mapPoint(const Params& a_params, const Vec3T<T>& a_point) noexcept
+  {
+    return a_point - clamp(a_point, -a_params.elongation, a_params.elongation);
+  }
+};
+
+/**
  * @brief Implicit function which is an elongation of another implicit function along each axis.
  * @details Elongation clamps the query point component-wise to [-elongation, +elongation] and
  * subtracts the clamped value before evaluating the wrapped function — effectively stretching
@@ -835,7 +1124,7 @@ public:
   /**
    * @brief Value function
    * @param[in] a_point Query point
-   * @return Value of the wrapped function evaluated at a_point clamped by m_elongation
+   * @return Value of the wrapped function evaluated at a_point clamped by m_params.elongation
    */
   [[nodiscard]] T
   value(const Vec3T<T>& a_point) const noexcept override;
@@ -847,9 +1136,45 @@ protected:
   std::shared_ptr<const ImplicitFunction<T>> m_implicitFunction = nullptr;
 
   /**
-   * @brief Elongation
+   * @brief Transform parameters (per-axis elongation).
    */
-  Vec3T<T> m_elongation;
+  typename ElongateOp<T>::Params m_params;
+};
+
+/**
+ * @brief Distance-formula trait for the reflection transform.
+ * @details Single source of truth for the reflection's coordinate remapping: the query point is
+ * multiplied component-wise by the reflection parameters (ones, with -1 in the reflected axis) before
+ * evaluating the wrapped function. Reused verbatim by the tape interpreter.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct ReflectOp
+{
+  /**
+   * @brief Stored parameters for the reflection transform.
+   */
+  struct Params
+  {
+    Vec3T<T> reflectParams = Vec3T<T>::ones(); ///< Per-axis reflection multipliers (-1 in reflected axis).
+  };
+
+  /**
+   * @brief A reflection of a signed distance function is again a signed distance function.
+   */
+  static constexpr bool preservesSignedDistance = true;
+
+  /**
+   * @brief Remap the query point by the reflection.
+   * @param[in] a_params Reflection parameters.
+   * @param[in] a_point  Query point.
+   * @return The query point multiplied component-wise by the reflection parameters.
+   */
+  EBGEOMETRY_HOST_DEVICE static Vec3T<T>
+  mapPoint(const Params& a_params, const Vec3T<T>& a_point) noexcept
+  {
+    return a_point * a_params.reflectParams;
+  }
 };
 
 /**
@@ -922,9 +1247,9 @@ protected:
   std::shared_ptr<const ImplicitFunction<T>> m_implicitFunction = nullptr;
 
   /**
-   * @brief Reflection parameters
+   * @brief Transform parameters (per-axis reflection multipliers).
    */
-  Vec3T<T> m_reflectParams;
+  typename ReflectOp<T>::Params m_params;
 };
 
 } // namespace EBGeometry

--- a/Source/EBGeometry_TransformImplem.hpp
+++ b/Source/EBGeometry_TransformImplem.hpp
@@ -122,6 +122,8 @@ ComplementIF<T>::ComplementIF(const std::shared_ptr<ImplicitFunction<T>>& a_impl
   EBGEOMETRY_EXPECT(a_implicitFunction != nullptr);
 
   m_implicitFunction = a_implicitFunction;
+
+  this->m_sdf = a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -133,7 +135,7 @@ ComplementIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  return -m_implicitFunction->value(a_point);
+  return ComplementOp<T>::mapValue(m_params, m_implicitFunction->value(a_point));
 }
 
 template <class T>
@@ -146,7 +148,9 @@ TranslateIF<T>::TranslateIF(const std::shared_ptr<ImplicitFunction<T>>& a_implic
   EBGEOMETRY_EXPECT(std::isfinite(a_translation[2]));
 
   m_implicitFunction = a_implicitFunction;
-  m_shift            = a_translation;
+  m_params.shift     = a_translation;
+
+  this->m_sdf = a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -158,7 +162,7 @@ TranslateIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  return m_implicitFunction->value(a_point - m_shift);
+  return m_implicitFunction->value(TranslateOp<T>::mapPoint(m_params, a_point));
 }
 
 template <class T>
@@ -171,13 +175,14 @@ RotateIF<T>::RotateIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunc
   EBGEOMETRY_EXPECT(a_axis <= 2U);
 
   m_implicitFunction = a_implicitFunction;
-  m_angle            = a_angle;
-  m_axis             = a_axis;
 
-  const T theta = m_angle * pi<T> / T(180);
+  const T theta = a_angle * pi<T> / T(180);
 
-  m_cosAngle = std::cos(theta);
-  m_sinAngle = std::sin(theta);
+  m_params.axis     = a_axis;
+  m_params.cosAngle = std::cos(theta);
+  m_params.sinAngle = std::sin(theta);
+
+  this->m_sdf = a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -189,39 +194,7 @@ RotateIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  const T& x = a_point[0];
-  const T& y = a_point[1];
-  const T& z = a_point[2];
-
-  Vec3T<T> rotatedPoint = a_point;
-
-  switch (m_axis) {
-  case 0: {
-    rotatedPoint[1] = y * m_cosAngle + z * m_sinAngle;
-    rotatedPoint[2] = -y * m_sinAngle + z * m_cosAngle;
-
-    break;
-  }
-  case 1: {
-    rotatedPoint[0] = x * m_cosAngle - z * m_sinAngle;
-    rotatedPoint[2] = x * m_sinAngle + z * m_cosAngle;
-
-    break;
-  }
-  case 2: {
-    rotatedPoint[0] = x * m_cosAngle + y * m_sinAngle;
-    rotatedPoint[1] = -x * m_sinAngle + y * m_cosAngle;
-
-    break;
-  }
-  default: {
-    EBGEOMETRY_EXPECT(false && "RotateIF: m_axis must be 0, 1, or 2");
-
-    break;
-  }
-  }
-
-  return m_implicitFunction->value(rotatedPoint);
+  return m_implicitFunction->value(RotateOp<T>::mapPoint(m_params, a_point));
 }
 
 template <class T>
@@ -231,7 +204,9 @@ OffsetIF<T>::OffsetIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunc
   EBGEOMETRY_EXPECT(std::isfinite(a_offset));
 
   m_implicitFunction = a_implicitFunction;
-  m_offset           = a_offset;
+  m_params.offset    = a_offset;
+
+  this->m_sdf = a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -243,7 +218,7 @@ OffsetIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  return m_implicitFunction->value(a_point) - m_offset;
+  return OffsetOp<T>::mapValue(m_params, m_implicitFunction->value(a_point));
 }
 
 template <class T>
@@ -254,7 +229,9 @@ ScaleIF<T>::ScaleIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFuncti
   EBGEOMETRY_EXPECT(a_scale != T(0));
 
   m_implicitFunction = a_implicitFunction;
-  m_scale            = a_scale;
+  m_params.scale     = a_scale;
+
+  this->m_sdf = a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -266,7 +243,7 @@ ScaleIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  return (m_implicitFunction->value(a_point / m_scale)) * m_scale;
+  return ScaleOp<T>::mapValue(m_params, m_implicitFunction->value(ScaleOp<T>::mapPoint(m_params, a_point)));
 }
 
 template <class T>
@@ -276,7 +253,9 @@ AnnularIF<T>::AnnularIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFu
   EBGEOMETRY_EXPECT(std::isfinite(a_delta));
 
   m_implicitFunction = a_implicitFunction;
-  m_delta            = a_delta;
+  m_params.delta     = a_delta;
+
+  this->m_sdf = a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -288,7 +267,7 @@ AnnularIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  return std::abs(m_implicitFunction->value(a_point)) - m_delta;
+  return AnnularOp<T>::mapValue(m_params, m_implicitFunction->value(a_point));
 }
 
 template <class T>
@@ -305,6 +284,8 @@ BlurIF<T>::BlurIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunction
   m_implicitFunction = a_implicitFunction;
   m_blurDistance     = a_blurDistance;
   m_alpha            = a_alpha;
+
+  this->m_sdf = false;
 }
 
 template <class T>
@@ -353,6 +334,8 @@ MollifyIF<T>::MollifyIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFu
 
   m_implicitFunction = a_implicitFunction;
   m_mollifier        = a_mollifier;
+
+  this->m_sdf = false;
 
   const T maxVal = std::abs(a_maxValue);
 
@@ -418,8 +401,10 @@ ElongateIF<T>::ElongateIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicit
   EBGEOMETRY_EXPECT(a_elongation[1] >= T(0));
   EBGEOMETRY_EXPECT(a_elongation[2] >= T(0));
 
-  m_implicitFunction = a_implicitFunction;
-  m_elongation       = a_elongation;
+  m_implicitFunction  = a_implicitFunction;
+  m_params.elongation = a_elongation;
+
+  this->m_sdf = false;
 }
 
 template <class T>
@@ -431,7 +416,7 @@ ElongateIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  return m_implicitFunction->value(a_point - clamp(a_point, -m_elongation, m_elongation));
+  return m_implicitFunction->value(ElongateOp<T>::mapPoint(m_params, a_point));
 }
 
 template <class T>
@@ -441,12 +426,14 @@ ReflectIF<T>::ReflectIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFu
   EBGEOMETRY_EXPECT(a_implicitFunction != nullptr);
   EBGEOMETRY_EXPECT(a_reflectPlane <= 2U);
 
-  m_implicitFunction = a_implicitFunction;
-  m_reflectParams    = Vec3T<T>::ones();
+  m_implicitFunction     = a_implicitFunction;
+  m_params.reflectParams = Vec3T<T>::ones();
 
   if (a_reflectPlane <= 2) {
-    m_reflectParams[a_reflectPlane] = -1;
+    m_params.reflectParams[a_reflectPlane] = -1;
   }
+
+  this->m_sdf = a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -458,7 +445,7 @@ ReflectIF<T>::value(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  return m_implicitFunction->value(a_point * m_reflectParams);
+  return m_implicitFunction->value(ReflectOp<T>::mapPoint(m_params, a_point));
 }
 
 } // namespace EBGeometry

--- a/Source/EBGeometry_TransformImplem.hpp
+++ b/Source/EBGeometry_TransformImplem.hpp
@@ -123,7 +123,7 @@ ComplementIF<T>::ComplementIF(const std::shared_ptr<ImplicitFunction<T>>& a_impl
 
   m_implicitFunction = a_implicitFunction;
 
-  this->m_sdf = a_implicitFunction->isSignedDistance();
+  this->m_sdf = ComplementOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -150,7 +150,7 @@ TranslateIF<T>::TranslateIF(const std::shared_ptr<ImplicitFunction<T>>& a_implic
   m_implicitFunction = a_implicitFunction;
   m_params.shift     = a_translation;
 
-  this->m_sdf = a_implicitFunction->isSignedDistance();
+  this->m_sdf = TranslateOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -182,7 +182,7 @@ RotateIF<T>::RotateIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunc
   m_params.cosAngle = std::cos(theta);
   m_params.sinAngle = std::sin(theta);
 
-  this->m_sdf = a_implicitFunction->isSignedDistance();
+  this->m_sdf = RotateOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -206,7 +206,7 @@ OffsetIF<T>::OffsetIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunc
   m_implicitFunction = a_implicitFunction;
   m_params.offset    = a_offset;
 
-  this->m_sdf = a_implicitFunction->isSignedDistance();
+  this->m_sdf = OffsetOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -231,7 +231,7 @@ ScaleIF<T>::ScaleIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFuncti
   m_implicitFunction = a_implicitFunction;
   m_params.scale     = a_scale;
 
-  this->m_sdf = a_implicitFunction->isSignedDistance();
+  this->m_sdf = ScaleOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -255,7 +255,7 @@ AnnularIF<T>::AnnularIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFu
   m_implicitFunction = a_implicitFunction;
   m_params.delta     = a_delta;
 
-  this->m_sdf = a_implicitFunction->isSignedDistance();
+  this->m_sdf = AnnularOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -404,7 +404,7 @@ ElongateIF<T>::ElongateIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicit
   m_implicitFunction  = a_implicitFunction;
   m_params.elongation = a_elongation;
 
-  this->m_sdf = false;
+  this->m_sdf = ElongateOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>
@@ -433,7 +433,7 @@ ReflectIF<T>::ReflectIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFu
     m_params.reflectParams[a_reflectPlane] = -1;
   }
 
-  this->m_sdf = a_implicitFunction->isSignedDistance();
+  this->m_sdf = ReflectOp<T>::preservesSignedDistance && a_implicitFunction->isSignedDistance();
 }
 
 template <class T>

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -69,6 +69,14 @@ using Meta = short;
   template class RoundedCylinderSDF<PREC>;                                   \
   template class PerlinSDF<PREC>;                                            \
                                                                                \
+  /* -- CSG reduction traits ----------------------------------------------*/ \
+  template struct UnionOp<PREC>;                                             \
+  template struct IntersectionOp<PREC>;                                     \
+  template struct DifferenceOp<PREC>;                                       \
+  template struct SmoothMinOp<PREC>;                                        \
+  template struct SmoothMaxOp<PREC>;                                        \
+  template struct ExpMinOp<PREC>;                                           \
+                                                                               \
   /* -- CSG implicit functions --------------------------------------------*/ \
   template class UnionIF<PREC>;                                              \
   template class SmoothUnionIF<PREC>;                                        \
@@ -77,6 +85,16 @@ using Meta = short;
   template class DifferenceIF<PREC>;                                         \
   template class SmoothDifferenceIF<PREC>;                                   \
   template class FiniteRepetitionIF<PREC>;                                   \
+                                                                               \
+  /* -- Transformation distance-formula traits ----------------------------*/ \
+  template struct ComplementOp<PREC>;                                       \
+  template struct TranslateOp<PREC>;                                        \
+  template struct RotateOp<PREC>;                                           \
+  template struct OffsetOp<PREC>;                                           \
+  template struct ScaleOp<PREC>;                                            \
+  template struct AnnularOp<PREC>;                                          \
+  template struct ElongateOp<PREC>;                                         \
+  template struct ReflectOp<PREC>;                                          \
                                                                                \
   /* -- Transformation implicit functions ----------------------------------*/\
   template class ComplementIF<PREC>;                                         \

--- a/Tests/TestCSG.cpp
+++ b/Tests/TestCSG.cpp
@@ -884,3 +884,80 @@ TEMPLATE_TEST_CASE("FiniteRepetition: free function matches FiniteRepetitionIF",
     REQUIRE_THAT(freeFunc->value(p), withinAbsT(direct.value(p), formulaMargin<T>()));
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isSignedDistance() propagation
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEMPLATE_TEST_CASE("CSG: sharp combiners are metric iff all operands are metric",
+                   "[CSG][isSignedDistance]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+
+  // A sphere is a true signed distance function; a Perlin noise field is a general (non-metric)
+  // implicit function.
+  const std::shared_ptr<IF<T>> metricA   = std::make_shared<Sphere<T>>(Vec3::zeros(), T(1));
+  const std::shared_ptr<IF<T>> metricB   = std::make_shared<Sphere<T>>(Vec3(3, 0, 0), T(1));
+  const std::shared_ptr<IF<T>> nonMetric = std::make_shared<PerlinSDF<T>>();
+
+  REQUIRE(metricA->isSignedDistance());
+  REQUIRE_FALSE(nonMetric->isSignedDistance());
+
+  const std::vector<std::shared_ptr<IF<T>>> bothMetric{metricA, metricB};
+  const std::vector<std::shared_ptr<IF<T>>> mixed{metricA, nonMetric};
+
+  // Sharp union / intersection: metric iff every operand is metric.
+  REQUIRE(UnionIF<T>(bothMetric).isSignedDistance());
+  REQUIRE_FALSE(UnionIF<T>(mixed).isSignedDistance());
+
+  REQUIRE(IntersectionIF<T>(bothMetric).isSignedDistance());
+  REQUIRE_FALSE(IntersectionIF<T>(mixed).isSignedDistance());
+
+  // Sharp difference A \ B: metric iff both stored children are metric.
+  REQUIRE(DifferenceIF<T>(metricA, metricB).isSignedDistance());
+  REQUIRE_FALSE(DifferenceIF<T>(metricA, nonMetric).isSignedDistance());
+  REQUIRE_FALSE(DifferenceIF<T>(nonMetric, metricA).isSignedDistance());
+}
+
+TEMPLATE_TEST_CASE("CSG: smooth combiners always clear the metric flag",
+                   "[CSG][isSignedDistance]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+
+  const std::shared_ptr<IF<T>> metricA = std::make_shared<Sphere<T>>(Vec3::zeros(), T(1));
+  const std::shared_ptr<IF<T>> metricB = std::make_shared<Sphere<T>>(Vec3(3, 0, 0), T(1));
+
+  const std::vector<std::shared_ptr<IF<T>>> bothMetric{metricA, metricB};
+
+  const T smoothLen = T(0.5);
+
+  // Even with two metric operands, every smooth combiner is non-metric.
+  REQUIRE_FALSE(SmoothUnionIF<T>(bothMetric, smoothLen).isSignedDistance());
+  REQUIRE_FALSE(SmoothIntersectionIF<T>(metricA, metricB, smoothLen).isSignedDistance());
+  REQUIRE_FALSE(SmoothDifferenceIF<T>(metricA, metricB, smoothLen).isSignedDistance());
+}
+
+TEMPLATE_TEST_CASE("CSG: BVH-accelerated combiners propagate metric-ness like their sharp/smooth kin",
+                   "[CSG][isSignedDistance]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  constexpr size_t K = 4;
+
+  const auto               spheres = sphereRow<T>();
+  const std::vector<BV<T>> bvs     = sphereRowBVs<T>();
+
+  const T smoothLen = T(0.5);
+
+  // Sharp BVH union of metric spheres is metric; its smooth counterpart is not.
+  const BVHUnionIF<T, Sphere<T>, BV<T>, K> bvhUnion(spheres, bvs);
+  REQUIRE(bvhUnion.isSignedDistance());
+
+  const BVHSmoothUnionIF<T, Sphere<T>, BV<T>, K> bvhSmooth(spheres, bvs, smoothLen);
+  REQUIRE_FALSE(bvhSmooth.isSignedDistance());
+}

--- a/Tests/TestTransform.cpp
+++ b/Tests/TestTransform.cpp
@@ -597,3 +597,63 @@ TEMPLATE_TEST_CASE("Reflect: free function matches ReflectIF", "[Transform][Refl
     REQUIRE_THAT(freeFunc->value(p), withinAbsT(direct.value(p), exactMargin<T>()));
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isSignedDistance() propagation
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEMPLATE_TEST_CASE("Transform: preserving transforms propagate the child's metric-ness",
+                   "[Transform][isSignedDistance]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+
+  // A sphere is a true signed distance function; a Perlin noise field is a general (non-metric)
+  // implicit function.
+  const std::shared_ptr<IF<T>> metric    = std::make_shared<Sphere<T>>(Vec3::zeros(), T(1));
+  const std::shared_ptr<IF<T>> nonMetric = std::make_shared<PerlinSDF<T>>();
+
+  REQUIRE(metric->isSignedDistance());
+  REQUIRE_FALSE(nonMetric->isSignedDistance());
+
+  // Each preserving transform is metric iff its child is metric.
+  REQUIRE(ComplementIF<T>(metric).isSignedDistance());
+  REQUIRE_FALSE(ComplementIF<T>(nonMetric).isSignedDistance());
+
+  REQUIRE(TranslateIF<T>(metric, Vec3(1, 2, 3)).isSignedDistance());
+  REQUIRE_FALSE(TranslateIF<T>(nonMetric, Vec3(1, 2, 3)).isSignedDistance());
+
+  REQUIRE(RotateIF<T>(metric, T(30), size_t(2)).isSignedDistance());
+  REQUIRE_FALSE(RotateIF<T>(nonMetric, T(30), size_t(2)).isSignedDistance());
+
+  REQUIRE(ReflectIF<T>(metric, size_t(1)).isSignedDistance());
+  REQUIRE_FALSE(ReflectIF<T>(nonMetric, size_t(1)).isSignedDistance());
+
+  REQUIRE(ScaleIF<T>(metric, T(2)).isSignedDistance());
+  REQUIRE_FALSE(ScaleIF<T>(nonMetric, T(2)).isSignedDistance());
+
+  REQUIRE(OffsetIF<T>(metric, T(0.3)).isSignedDistance());
+  REQUIRE_FALSE(OffsetIF<T>(nonMetric, T(0.3)).isSignedDistance());
+
+  REQUIRE(AnnularIF<T>(metric, T(0.2)).isSignedDistance());
+  REQUIRE_FALSE(AnnularIF<T>(nonMetric, T(0.2)).isSignedDistance());
+}
+
+TEMPLATE_TEST_CASE("Transform: clearing transforms are never metric, even over a metric child",
+                   "[Transform][isSignedDistance]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+
+  const std::shared_ptr<IF<T>> metric = std::make_shared<Sphere<T>>(Vec3::zeros(), T(1));
+
+  REQUIRE(metric->isSignedDistance());
+
+  REQUIRE_FALSE(ElongateIF<T>(metric, Vec3(1, 0, 0)).isSignedDistance());
+  REQUIRE_FALSE(BlurIF<T>(metric, T(0.3)).isSignedDistance());
+
+  const auto mollifier = std::make_shared<Sphere<T>>(Vec3::zeros(), T(0.5));
+  REQUIRE_FALSE(MollifyIF<T>(metric, mollifier, T(0.4), 3).isSignedDistance());
+}


### PR DESCRIPTION
# Summary

### Background

Tier 3 of the GPU port (issue #115). The transforms (`Source/EBGeometry_Transform.hpp`) and CSG combiners (`Source/EBGeometry_CSG.hpp`) still held their distance math inline in each node's virtual `value()` body, and none of them set the `m_sdf` (metric-ness) datum introduced in Tier 2 — so every transform/combiner silently inherited the base default `m_sdf = true`, even when the operation does not preserve a true signed distance. Both are prerequisites for the tape interpreter: the evaluation math must live in `EBGEOMETRY_HOST_DEVICE` trait statics so the (later) device tape can reuse it verbatim, and the interpreter needs a correct per-node metric-ness flag to decide whether a node's value keys a branch-and-bound bound directly or must be gradient-normalized.

### Solution

- Extracted each transform/combiner's math into a single-source-of-truth `EBGEOMETRY_HOST_DEVICE` trait op:
  - 8 transform ops (`ComplementOp`/`TranslateOp`/`RotateOp`/`OffsetOp`/`ScaleOp`/`AnnularOp`/`ElongateOp`/`ReflectOp`) with a POD `Params` bundle plus `mapPoint`/`mapValue`; each `XxxIF` now stores `typename XxxOp<T>::Params m_params` and delegates `value()` to the op.
  - 6 combiner ops: `UnionOp`/`IntersectionOp`/`DifferenceOp` (`combine(a,b)` = `min`/`max`/`max(a,-b)`) and `SmoothMinOp`/`SmoothMaxOp`/`ExpMinOp` (`eval(a,b,s)`); the existing `SmoothMin`/`SmoothMax`/`ExpMin` `std::function` globals now just delegate to their op, so the blend formulas live in exactly one place.
- Set and propagate `m_sdf` on every node. Unary transforms derive it from the trait flag `Op::preservesSignedDistance` (`m_sdf = Op::preservesSignedDistance && child->isSignedDistance()`): rigid transforms (translate/rotate/reflect), uniform scale, offset, annular, and complement preserve; elongate clears. Blur/Mollify/FiniteRepetition (no trait yet — device-ported in a later tier) clear directly. Combiners: sharp union/intersection/BVH-union are metric iff every operand is; difference iff both operands are; all smooth variants and BVH-smooth-union clear.
- Added `isSignedDistance()` propagation tests to `Tests/TestTransform.cpp` and `Tests/TestCSG.cpp` (metric `SphereSDF` vs. non-metric `PerlinSDF` operands), and instantiated all 14 new ops for both precisions in `Tests/InstantiateAll.cpp`.

### Side-effects

Clean break, no behavior change to `value()`: every numeric result is bit-for-bit identical to before (verified by the retained value-equivalence tests and an independent review). The only new observable is that `isSignedDistance()` now returns `false` on transform/combiner nodes that do not preserve a true metric, where it previously (incorrectly) returned `true`. `RotateIF`'s transient `m_angle` member was dropped (unused after cos/sin are precomputed into `RotateOp::Params`). No public constructor signatures changed.

### Alternative solutions

Keeping the math inline in each `value()` and only adding the `m_sdf` assignments would have satisfied the metric-ness requirement but not the GPU one — the device tape interpreter (later tier) needs the formulas as `HOST_DEVICE` trait statics it can call directly, so the trait extraction is done now rather than duplicated later.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation. 
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS

---
_Generated by [Claude Code](https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS)_