### PR TITLE
GPU port (Tier 5): explicit compile() + tape.value(p) / view.value(p, scratch)

### DIFF
--- a/Source/EBGeometry_Tape.hpp
+++ b/Source/EBGeometry_Tape.hpp
@@ -7,7 +7,7 @@
  * @brief  Flat linear-SSA "tape" plus single-pass interpreter for implicit-function DAGs.
  * @details The tape is a depth-first flattening of an implicit-function tree into a linear array of
  * trivially-copyable @ref EBGeometry::TapeClause "clauses" that a single forward pass
- * (@ref EBGeometry::evaluate) can execute identically on host and (later) device. Every clause
+ * (@ref EBGeometry::TapeView::value) can execute identically on host and (later) device. Every clause
  * dispatches to the SAME trait static functions used by the recursive @c value() path -- @c SphereOp::eval,
  * @c TranslateOp::mapPoint, @c ScaleOp::mapValue, @c UnionOp::combine, @c SmoothMinOp::eval, ... --
  * so the tape is never a second copy of any distance or blend formula; it is a different traversal
@@ -316,11 +316,24 @@ struct TapeView
    * @brief Whether the tape is free of host callbacks (and thus, in a later tier, device-evaluable).
    */
   bool deviceEligible = true;
+
+  /**
+   * @brief Evaluate the tape at a point via a single forward pass (host and device).
+   * @details Runs each clause in order, dispatching to the shared trait static functions. The
+   * caller supplies scratch buffers sized to the tape's slot counts (@ref numCoordSlots coordinate
+   * slots and @ref numValueSlots value slots). A HOST_CALLBACK clause is only valid on the host.
+   * @param[in]  a_point        Query point.
+   * @param[out] a_coordScratch Coordinate scratch buffer (at least @ref numCoordSlots entries).
+   * @param[out] a_valueScratch Value scratch buffer (at least @ref numValueSlots entries).
+   * @return The value at @p a_point (the tape's root value slot after the pass).
+   */
+  [[nodiscard]] EBGEOMETRY_HOST_DEVICE T
+  value(const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_valueScratch) const noexcept;
 };
 
 /**
  * @brief Host-owned flat tape: the clause array plus every per-op parameter array.
- * @details Built by @ref TapeBuilder (via the free @ref flatten function) and consumed through a
+ * @details Built by @ref TapeBuilder (via the free @ref compile function) and consumed through a
  * trivially-copyable @ref view. The distance/blend math itself lives entirely in the shared trait
  * static functions; a Tape stores only clauses and parameters, never a formula.
  * @tparam T Floating-point precision.
@@ -344,6 +357,17 @@ public:
    */
   [[nodiscard]] EBGEOMETRY_HOST TapeView<T>
                                 view() const noexcept;
+
+  /**
+   * @brief Evaluate the tape at a point, managing scratch internally (host convenience).
+   * @details Delegates to @ref TapeView::value with two thread-local scratch buffers grown to this
+   * tape's slot counts, so each thread's queries are allocation-free after its first call and
+   * concurrent readers never share scratch. Host only.
+   * @param[in] a_point Query point.
+   * @return The value at @p a_point.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST T
+  value(const Vec3T<T>& a_point) const noexcept;
 
   /**
    * @brief Get the number of coordinate slots the interpreter's coordinate scratch must hold.
@@ -565,45 +589,17 @@ private:
 };
 
 /**
- * @brief Lower an implicit-function tree into a flat @ref Tape.
+ * @brief Compile an implicit-function tree into a flat @ref Tape.
  * @details Seeds coordinate slot 0 with the query point's frame and drives the tree's @c flatten
- * overrides. Host only.
+ * lowering overrides. Host only. Evaluate the result with @ref Tape::value (host convenience) or
+ * @ref TapeView::value (caller-provided scratch).
  * @tparam T Floating-point precision.
  * @param[in] a_tree Source implicit-function tree (must outlive any host-callback tape produced).
- * @return The flattened tape.
+ * @return The compiled tape.
  */
 template <class T>
 [[nodiscard]] EBGEOMETRY_HOST Tape<T>
-                              flatten(const ImplicitFunction<T>& a_tree);
-
-/**
- * @brief Evaluate a flattened tape at a point via a single forward pass (host and device).
- * @details Runs each clause in order, dispatching to the shared trait static functions. The caller supplies
- * scratch buffers sized to the tape's slot counts (@c a_view.numCoordSlots coordinate slots and
- * @c a_view.numValueSlots value slots). A HOST_CALLBACK clause is only valid on the host.
- * @tparam T Floating-point precision.
- * @param[in]  a_view         Non-owning view of the tape.
- * @param[in]  a_point        Query point.
- * @param[out] a_coordScratch Coordinate scratch buffer (at least @c a_view.numCoordSlots entries).
- * @param[out] a_valueScratch Value scratch buffer (at least @c a_view.numValueSlots entries).
- * @return The value at @p a_point (the tape's root value slot after the pass).
- */
-template <class T>
-[[nodiscard]] EBGEOMETRY_HOST_DEVICE T
-evaluate(const TapeView<T>& a_view, const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_valueScratch) noexcept;
-
-/**
- * @brief Host convenience overload: evaluate a tape at a point, sizing scratch internally.
- * @details Allocates two @c std::vector scratch buffers sized to the tape's slot counts and calls
- * the pointer-based @ref evaluate with @c a_tape.view(). Host only.
- * @tparam T Floating-point precision.
- * @param[in] a_tape  The tape.
- * @param[in] a_point Query point.
- * @return The value at @p a_point.
- */
-template <class T>
-[[nodiscard]] EBGEOMETRY_HOST T
-evaluate(const Tape<T>& a_tape, const Vec3T<T>& a_point);
+                              compile(const ImplicitFunction<T>& a_tree);
 
 } // namespace EBGeometry
 

--- a/Source/EBGeometry_TapeImplem.hpp
+++ b/Source/EBGeometry_TapeImplem.hpp
@@ -6,9 +6,10 @@
  * @file   EBGeometry_TapeImplem.hpp
  * @brief  Implementation of EBGeometry_Tape.hpp.
  * @details Holds every out-of-line definition: the TapeBuilder methods, Tape::view, the free
- * flatten/evaluate functions, and every flatten() override body (the base opaque-host default, the
- * leaf template, and all transform/combiner nodes). Included last from EBGeometry_Tape.hpp so that
- * Tape, TapeView, TapeBuilder, and every implicit-function class are complete here.
+ * compile function, the TapeView::value/Tape::value evaluators, and every flatten() override body
+ * (the base opaque-host default, the leaf template, and all transform/combiner nodes). Included
+ * last from EBGeometry_Tape.hpp so that Tape, TapeView, TapeBuilder, and every implicit-function
+ * class are complete here.
  * @author Robert Marskar
  */
 
@@ -214,10 +215,10 @@ TapeBuilder<T>::finish(int a_rootValueSlot)
   return std::move(m_tape);
 }
 
-// ── Free functions: flatten / evaluate ────────────────────────────────────────
+// ── Free function: compile ────────────────────────────────────────────────────
 template <class T>
 Tape<T>
-flatten(const ImplicitFunction<T>& a_tree)
+compile(const ImplicitFunction<T>& a_tree)
 {
   TapeBuilder<T> builder;
 
@@ -227,33 +228,37 @@ flatten(const ImplicitFunction<T>& a_tree)
   return builder.finish(rootValueSlot);
 }
 
+// ── Interpreter: TapeView::value / Tape::value ────────────────────────────────
 template <class T>
 EBGEOMETRY_HOST_DEVICE T
-evaluate(const TapeView<T>& a_view, const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_valueScratch) noexcept
+TapeView<T>::value(const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_valueScratch) const noexcept
 {
+  EBGEOMETRY_EXPECT(numCoordSlots > 0);
+  EBGEOMETRY_EXPECT(numValueSlots > 0);
+
   a_coordScratch[0] = a_point;
 
-  for (uint32_t i = 0; i < a_view.numClauses; i++) {
-    const TapeClause& c = a_view.clauses[i];
+  for (uint32_t i = 0; i < numClauses; i++) {
+    const TapeClause& c = clauses[i];
 
     switch (c.opcode) {
-#define EBGEOMETRY_TAPE_EVAL_LEAF(TAG, OP, MEMBER)                                           \
-  case Opcode::TAG:                                                                          \
-    a_valueScratch[c.out] = OP<T>::eval(a_view.MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
+#define EBGEOMETRY_TAPE_EVAL_LEAF(TAG, OP, MEMBER)                                    \
+  case Opcode::TAG:                                                                   \
+    a_valueScratch[c.out] = OP<T>::eval(MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
     break;
       EBGEOMETRY_TAPE_LEAF_OPS(EBGEOMETRY_TAPE_EVAL_LEAF)
 #undef EBGEOMETRY_TAPE_EVAL_LEAF
 
-#define EBGEOMETRY_TAPE_EVAL_MAPPOINT(TAG, OP, MEMBER)                                           \
-  case Opcode::TAG:                                                                              \
-    a_coordScratch[c.out] = OP<T>::mapPoint(a_view.MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
+#define EBGEOMETRY_TAPE_EVAL_MAPPOINT(TAG, OP, MEMBER)                                    \
+  case Opcode::TAG:                                                                       \
+    a_coordScratch[c.out] = OP<T>::mapPoint(MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
     break;
       EBGEOMETRY_TAPE_MAPPOINT_OPS(EBGEOMETRY_TAPE_EVAL_MAPPOINT)
 #undef EBGEOMETRY_TAPE_EVAL_MAPPOINT
 
-#define EBGEOMETRY_TAPE_EVAL_MAPVALUE(TAG, OP, MEMBER)                                           \
-  case Opcode::TAG:                                                                              \
-    a_valueScratch[c.out] = OP<T>::mapValue(a_view.MEMBER[c.paramIndex], a_valueScratch[c.in0]); \
+#define EBGEOMETRY_TAPE_EVAL_MAPVALUE(TAG, OP, MEMBER)                                    \
+  case Opcode::TAG:                                                                       \
+    a_valueScratch[c.out] = OP<T>::mapValue(MEMBER[c.paramIndex], a_valueScratch[c.in0]); \
     break;
       EBGEOMETRY_TAPE_MAPVALUE_OPS(EBGEOMETRY_TAPE_EVAL_MAPVALUE)
 #undef EBGEOMETRY_TAPE_EVAL_MAPVALUE
@@ -265,17 +270,16 @@ evaluate(const TapeView<T>& a_view, const Vec3T<T>& a_point, Vec3T<T>* a_coordSc
       EBGEOMETRY_TAPE_COMBINE_OPS(EBGEOMETRY_TAPE_EVAL_COMBINE)
 #undef EBGEOMETRY_TAPE_EVAL_COMBINE
 
-#define EBGEOMETRY_TAPE_EVAL_SMOOTH(TAG, OP)                                                        \
-  case Opcode::TAG:                                                                                 \
-    a_valueScratch[c.out] =                                                                         \
-      OP<T>::eval(a_valueScratch[c.in0], a_valueScratch[c.in1], a_view.scalarParams[c.paramIndex]); \
+#define EBGEOMETRY_TAPE_EVAL_SMOOTH(TAG, OP)                                                                       \
+  case Opcode::TAG:                                                                                                \
+    a_valueScratch[c.out] = OP<T>::eval(a_valueScratch[c.in0], a_valueScratch[c.in1], scalarParams[c.paramIndex]); \
     break;
       EBGEOMETRY_TAPE_SMOOTH_OPS(EBGEOMETRY_TAPE_EVAL_SMOOTH)
 #undef EBGEOMETRY_TAPE_EVAL_SMOOTH
 
     case Opcode::HOST_CALLBACK: {
 #ifndef EBGEOMETRY_DEVICE_COMPILE
-      a_valueScratch[c.out] = a_view.hostNodes[c.paramIndex]->value(a_coordScratch[c.in0]);
+      a_valueScratch[c.out] = hostNodes[c.paramIndex]->value(a_coordScratch[c.in0]);
 #else
       EBGEOMETRY_EXPECT(false && "HOST_CALLBACK clause is not evaluable on device");
 #endif
@@ -284,17 +288,44 @@ evaluate(const TapeView<T>& a_view, const Vec3T<T>& a_point, Vec3T<T>* a_coordSc
     }
   }
 
-  return a_valueScratch[a_view.rootValueSlot];
+  return a_valueScratch[rootValueSlot];
 }
 
 template <class T>
 T
-evaluate(const Tape<T>& a_tape, const Vec3T<T>& a_point)
+Tape<T>::value(const Vec3T<T>& a_point) const noexcept
 {
-  std::vector<Vec3T<T>> coordScratch(a_tape.getNumCoordSlots());
-  std::vector<T>        valueScratch(a_tape.getNumValueSlots());
+  // Per-thread scratch, only ever grown: queries are allocation-free after each thread's first
+  // call, and concurrent readers never share a buffer. The inUse flag guards re-entrancy: a
+  // HOST_CALLBACK clause calls back into arbitrary user code, and if that code evaluates a tape on
+  // this same thread the shared scratch would be resized/clobbered mid-pass -- so a nested call
+  // detects the live outer pass and falls back to fresh local buffers instead.
+  thread_local std::vector<Vec3T<T>> coordScratch;
+  thread_local std::vector<T>        valueScratch;
+  thread_local bool                  inUse = false;
 
-  return evaluate(a_tape.view(), a_point, coordScratch.data(), valueScratch.data());
+  if (inUse) {
+    std::vector<Vec3T<T>> localCoordScratch(m_numCoordSlots);
+    std::vector<T>        localValueScratch(m_numValueSlots);
+
+    return this->view().value(a_point, localCoordScratch.data(), localValueScratch.data());
+  }
+
+  if (coordScratch.size() < m_numCoordSlots) {
+    coordScratch.resize(m_numCoordSlots);
+  }
+
+  if (valueScratch.size() < m_numValueSlots) {
+    valueScratch.resize(m_numValueSlots);
+  }
+
+  inUse = true;
+
+  const T ret = this->view().value(a_point, coordScratch.data(), valueScratch.data());
+
+  inUse = false;
+
+  return ret;
 }
 
 // ── flatten() overrides ───────────────────────────────────────────────────────
@@ -443,8 +474,8 @@ DifferenceIF<T>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
 // SmoothIntersectionIF's m_smoothMax) that defaults to SmoothMin/SmoothMax but may be any callable --
 // including the enumerated ExpMin or an arbitrary user lambda. A std::function cannot be introspected
 // to recover which enumerated ISA op it is, so, per the project rule that user-supplied std::function
-// blends stay host-only, every smooth combiner lowers to an opaque host callback (keeping
-// evaluate == value exact for any operator, at the cost of device-eligibility). The SMOOTH_MIN/
+// blends stay host-only, every smooth combiner lowers to an opaque host callback (keeping tape
+// evaluation == value() exact for any operator, at the cost of device-eligibility). The SMOOTH_MIN/
 // SMOOTH_MAX/EXP_MIN opcodes remain the device ISA for blends emitted with a known operator (e.g. the
 // builder API directly, and the BVH smooth union of a later tier); they are not reachable from a
 // std::function-carrying node here.

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -98,6 +98,7 @@ using Meta = short;
                                                                                \
   /* -- Flat tape + interpreter -------------------------------------------*/ \
   template class Tape<PREC>;                                                 \
+  template struct TapeView<PREC>;                                            \
   template class TapeBuilder<PREC>;                                          \
                                                                                \
   /* -- Transformation implicit functions ----------------------------------*/\
@@ -186,11 +187,12 @@ instantiateFunctionTemplates()
   (void)VTK<T>().template convertToDCEL<Meta>();
   (void)OBJ<T>().template convertToDCEL<Meta>();
 
-  // Free tape functions (flatten/evaluate) are not reached by explicit class instantiation, so
-  // odr-use them here over a small sphere so both precisions are analysed.
+  // The free tape compiler is not reached by explicit class instantiation, so odr-use it here
+  // over a small sphere so both precisions are analysed (Tape::value / TapeView::value are covered
+  // by the explicit Tape/TapeView instantiations above).
   const SphereSDF<T> sphere;
-  const Tape<T>      tape = EBGeometry::flatten<T>(sphere);
-  (void)EBGeometry::evaluate<T>(tape, Vec3T<T>::zeros());
+  const Tape<T>      tape = EBGeometry::compile<T>(sphere);
+  (void)tape.value(Vec3T<T>::zeros());
 }
 
 template void

--- a/Tests/TestTape.cpp
+++ b/Tests/TestTape.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // Test suite for EBGeometry_Tape.hpp: the flat linear-SSA tape and its single-pass interpreter.
-// Tier 4 validates the tape against the recursive value() oracle -- for every covered tree,
-// evaluate(flatten(tree), p) must reproduce tree.value(p). It also checks device-eligibility
+// Validates the tape against the recursive value() oracle -- for every covered tree,
+// compile(tree).value(p) must reproduce tree.value(p). It also checks device-eligibility
 // bookkeeping: pure-primitive trees are device-eligible, while opaque-host fallbacks (Perlin, Blur,
-// smooth combiners over more than two children) are not.
+// smooth combiners over more than two children, BVH unions) are not.
 
 #include "EBGeometry.hpp"
 #include "TestFloatingPointUtils.hpp"
@@ -64,10 +64,10 @@ template <class T>
 void
 requireTapeMatchesOracle(const ImplicitFunction<T>& a_tree, const double a_margin)
 {
-  const Tape<T> tape = flatten(a_tree);
+  const Tape<T> tape = compile(a_tree);
 
   for (const auto& p : queryPoints<T>()) {
-    REQUIRE_THAT(evaluate(tape, p), withinAbsT(a_tree.value(p), a_margin));
+    REQUIRE_THAT(tape.value(p), withinAbsT(a_tree.value(p), a_margin));
   }
 }
 
@@ -209,9 +209,9 @@ TEMPLATE_TEST_CASE("Tape: smooth combiners match value() via an opaque host node
   requireTapeMatchesOracle<T>(*smoothDiff, formulaMargin<T>());
 
   // A std::function blend operator keeps every smooth combiner host-only.
-  REQUIRE_FALSE(flatten<T>(*smoothUnion).isDeviceEligible());
-  REQUIRE_FALSE(flatten<T>(*smoothInter).isDeviceEligible());
-  REQUIRE_FALSE(flatten<T>(*smoothDiff).isDeviceEligible());
+  REQUIRE_FALSE(compile<T>(*smoothUnion).isDeviceEligible());
+  REQUIRE_FALSE(compile<T>(*smoothInter).isDeviceEligible());
+  REQUIRE_FALSE(compile<T>(*smoothDiff).isDeviceEligible());
 }
 
 // The SMOOTH_MIN/SMOOTH_MAX/EXP_MIN opcodes are the device ISA for blends emitted with a known
@@ -247,7 +247,7 @@ TEMPLATE_TEST_CASE("Tape: smooth ISA opcodes match their trait eval via the buil
                          : (op == Opcode::SMOOTH_MAX) ? SmoothMaxOp<T>::eval(va, vb, s)
                                                       : ExpMinOp<T>::eval(va, vb, s);
 
-      REQUIRE_THAT(evaluate<T>(tape, p), withinAbsT(expected, formulaMargin<T>()));
+      REQUIRE_THAT(tape.value(p), withinAbsT(expected, formulaMargin<T>()));
     }
   }
 }
@@ -289,17 +289,17 @@ TEMPLATE_TEST_CASE("Tape: pure-primitive trees are device-eligible; opaque nodes
 
   // A pure primitive + transforms + sharp combiners tree stays device-eligible.
   const auto pureTree = Difference<T>(Union<T>(a, b), Scale<T>(d, T(1.5)));
-  REQUIRE(flatten<T>(*pureTree).isDeviceEligible());
+  REQUIRE(compile<T>(*pureTree).isDeviceEligible());
 
   // Perlin noise is a direct-value node with no leaf trait -> opaque host callback.
   const PerlinSDF<T> perlin(T(1), Vec3T<T>(1, 1, 1), T(0.5), 2);
-  const Tape<T>      perlinTape = flatten<T>(perlin);
+  const Tape<T>      perlinTape = compile<T>(perlin);
   REQUIRE_FALSE(perlinTape.isDeviceEligible());
   requireTapeMatchesOracle<T>(perlin, exactMargin<T>());
 
   // Blur wraps a child but overrides value() (no trait) -> opaque host callback.
   const auto    blurred  = Blur<T>(a, T(0.1));
-  const Tape<T> blurTape = flatten<T>(*blurred);
+  const Tape<T> blurTape = compile<T>(*blurred);
   REQUIRE_FALSE(blurTape.isDeviceEligible());
   requireTapeMatchesOracle<T>(*blurred, exactMargin<T>());
 }
@@ -321,8 +321,156 @@ TEMPLATE_TEST_CASE("Tape: smooth union over three children falls back to an opaq
   const std::vector<std::shared_ptr<SphereSDF<T>>> three{a, b, c};
 
   const auto    smoothN    = SmoothUnion<T, SphereSDF<T>>(three, T(0.5));
-  const Tape<T> smoothTape = flatten<T>(*smoothN);
+  const Tape<T> smoothTape = compile<T>(*smoothN);
 
   REQUIRE_FALSE(smoothTape.isDeviceEligible());
   requireTapeMatchesOracle<T>(*smoothN, formulaMargin<T>());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (10) Tape::value host convenience query (thread-local scratch)
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEMPLATE_TEST_CASE("Tape: Tape::value matches the recursive value() oracle over mixed trees",
+                   "[Tape][Value]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  const auto sphere = std::make_shared<SphereSDF<T>>(Vec3T<T>(0.3, 0, 0), T(0.8));
+  const auto box    = std::make_shared<BoxSDF<T>>(Vec3T<T>(-1, -1, -1), Vec3T<T>(1, 1, 1));
+
+  // Union(Translate(Sphere), Box) and a nested-transform chain Offset(Rotate(Scale(Sphere))).
+  const auto mixed  = Union<T>(Translate<T>(sphere, Vec3T<T>(0.4, -0.1, 0.2)), box);
+  const auto nested = Offset<T>(Rotate<T>(Scale<T>(sphere, T(1.5)), T(30), 1), T(0.1));
+
+  const Tape<T> mixedTape  = compile<T>(*mixed);
+  const Tape<T> nestedTape = compile<T>(*nested);
+
+  // Repeated queries on the same thread exercise the thread-local scratch reuse path.
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(mixedTape.value(p), withinAbsT(mixed->value(p), exactMargin<T>()));
+    REQUIRE_THAT(nestedTape.value(p), withinAbsT(nested->value(p), exactMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: TapeView::value with caller-provided scratch matches Tape::value",
+                   "[Tape][Value]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  const auto a = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+  const auto b = std::make_shared<SphereSDF<T>>(Vec3T<T>(3, 0, 0), T(1));
+  const auto d = std::make_shared<SphereSDF<T>>(Vec3T<T>(0.8, 0, 0), T(1));
+
+  const auto tree = Difference<T>(Union<T>(a, b), Scale<T>(d, T(1.5)));
+
+  const Tape<T>     tape = compile<T>(*tree);
+  const TapeView<T> view = tape.view();
+
+  std::vector<Vec3T<T>> coordScratch(tape.getNumCoordSlots());
+  std::vector<T>        valueScratch(tape.getNumValueSlots());
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(view.value(p, coordScratch.data(), valueScratch.data()), withinAbsT(tape.value(p), exactMargin<T>()));
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (11) BVH-accelerated union -> opaque host fallback (Tier 6 gives it a native BVH opcode)
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEMPLATE_TEST_CASE("Tape: BVH-accelerated union compiles via the opaque-host fallback",
+                   "[Tape][DeviceEligible][BVH]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  constexpr size_t K          = 4;
+  constexpr int    numSpheres = 4;
+
+  // A row of disjoint unit spheres, centers 3 apart (mirrors TestCSG's sphereRow fixture).
+  std::vector<std::shared_ptr<SphereSDF<T>>> spheres;
+  std::vector<BV>                            bvs;
+
+  for (int i = 0; i < numSpheres; i++) {
+    const Vec3T<T> center(T(3 * i), 0, 0);
+
+    spheres.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
+    bvs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
+  }
+
+  const BVHUnionIF<T, SphereSDF<T>, BV, K> bvhUnion(spheres, bvs);
+
+  // BVHUnionIF has no flatten() lowering override, so the whole node lowers to a single opaque
+  // host-callback clause -- correct but host-only. Tier 6 gives it a native BVH opcode.
+  const Tape<T> tape = compile<T>(bvhUnion);
+
+  REQUIRE_FALSE(tape.isDeviceEligible());
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(bvhUnion.value(p), exactMargin<T>()));
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (12) Re-entrancy: a host-callback node whose value() itself evaluates a tape
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// An implicit function backed by its own compiled tape -- the natural adapter a user writes once
+// tapes exist. It has no flatten() override, so an enclosing compile() lowers it to an opaque host
+// callback, and evaluating the enclosing tape re-enters Tape::value on the same thread mid-pass.
+// Tape::value must detect this and give the nested pass its own scratch instead of resizing or
+// clobbering the outer pass's thread-local buffers.
+template <class T>
+class TapeBackedIF : public ImplicitFunction<T>
+{
+public:
+  explicit TapeBackedIF(const std::shared_ptr<ImplicitFunction<T>>& a_tree) : m_tree(a_tree), m_tape(compile(*a_tree))
+  {}
+
+  [[nodiscard]] T
+  value(const Vec3T<T>& a_point) const noexcept override
+  {
+    return m_tape.value(a_point);
+  }
+
+private:
+  std::shared_ptr<ImplicitFunction<T>> m_tree;
+  Tape<T>                              m_tape;
+};
+
+} // namespace
+
+TEMPLATE_TEST_CASE("Tape: nested tape evaluation through a host callback is safe",
+                   "[Tape][HostCallback][Reentrancy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // The inner tree is deliberately deeper (more slots) than the outer tape, so a naively shared
+  // scratch buffer would be regrown and overwritten by the nested pass.
+  const auto box   = std::make_shared<BoxSDF<T>>(Vec3T<T>(-1, -1, -1), Vec3T<T>(1, 1, 1));
+  const auto inner = Offset<T>(
+    Annular<T>(Translate<T>(Rotate<T>(Scale<T>(box, T(1.5)), T(20), 1), Vec3T<T>(0.5, 0, 0)), T(0.1)), T(0.2));
+
+  const auto adapter = std::make_shared<TapeBackedIF<T>>(inner);
+  const auto sphere  = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+
+  // Union(sphere, adapter): the outer tape computes the sphere's value slot first, then runs the
+  // adapter's host callback (which evaluates the inner tape on this same thread), then combines --
+  // so a clobbered sphere slot or a reallocated scratch buffer would corrupt the result.
+  const auto outer = Union<T>(sphere, adapter);
+
+  const Tape<T> tape = compile<T>(*outer);
+
+  REQUIRE_FALSE(tape.isDeviceEligible());
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(outer->value(p), exactMargin<T>()));
+  }
 }


### PR DESCRIPTION
# Summary

### Background

Tier 5 of the GPU port (issue #115). Tier 4 validated the tape against the recursive `value()` oracle, but its evaluation API was provisional: a free `flatten()` returning a `Tape` and free `evaluate()` functions — including a host convenience overload that heap-allocated two `std::vector` scratch buffers on *every* query, unusable for per-cell EB loops. The issue's working agreement fixes the spelling: evaluation is `.value(p)` everywhere — `if->value(p)`, `tape.value(p)`, `view.value(p)`. After discussion, the design decision (vs. flipping `value()` itself onto the interpreter) is an explicit compile step with no new class: build the tree, `compile()` once, then query the tape — while the recursive `value()` overrides remain the authoring-side convenience path and test oracle, since both paths call the identical trait static functions and a benchmark showed the interpreter within ~8 % of the recursive path even on small trees.

### Solution

- The free `flatten(tree)` is renamed **`compile(tree)`** (the virtual per-node lowering hook keeps the name `flatten`).
- The free `evaluate()` overloads are deleted in favor of members: **`Tape<T>::value(p)`** — host convenience query with per-thread, grow-only `thread_local` scratch (allocation-free after each thread's first call, safe for concurrent readers) — and **`TapeView<T>::value(p, coordScratch, valueScratch)`** — the `EBGEOMETRY_HOST_DEVICE` single forward pass a device kernel calls with its own scratch. Interpreter body unchanged.
- `Tape::value` guards **re-entrancy**: a `HOST_CALLBACK` clause runs arbitrary user code, and a node whose `value()` itself evaluates a tape on the same thread (e.g. a tape-backed `ImplicitFunction` adapter) would otherwise resize or clobber the live thread-local scratch mid-pass — an adversarial review reproduced both a heap-use-after-free and a silent wrong answer. A nested call now detects the in-use outer pass and falls back to fresh local buffers; a regression test (tape-backed adapter under a union, mutation-checked to fail without the guard) covers it, and the full tape suite runs clean under ASan/UBSan.
- `TapeView::value` asserts non-empty slot counts, catching evaluation of a default-constructed `Tape`.
- Tests updated to the new spelling plus three new cases: `tape.value` vs. the oracle, `view.value` with caller-allocated scratch, and a **BVH-accelerated union** compiling via the opaque-host fallback (exact, `isDeviceEligible() == false` — Tier 6 gives it a native BVH opcode).

### Side-effects

Clean break, no aliases: any external code using the Tier 4 free `flatten`/`evaluate` spelling must switch to `compile(tree)` / `tape.value(p)` / `view.value(p, ...)` (the Tier 4 API existed only briefly on `main`). `Tape::value` is `noexcept` yet allocates on a thread's first call (terminate-on-OOM), matching existing codebase practice. Recursive `value()` behavior is untouched.

### Alternative solutions

Two rejected designs: (a) lazily compiling and interpreting inside `value()` itself (hides a throwing, mutating build in a `noexcept` read path, adds `mutable`/`call_once` machinery, and slows every plain-leaf query for no CPU gain); (b) a mutating `node->compile()` that rewires `value()` and deletes the recursive bodies (breaks every `const` implicit-function usage and silently evaluates an empty tape if `compile()` is forgotten in a release build). A separate `CompiledSDF` wrapper class was also discarded — "SDF" would misname non-metric functions, and the plan already specifies `tape.value(p)`.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation. 
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS

---
_Generated by [Claude Code](https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS)_