### PR TITLE
GPU port (Tier 6): BVH unions into the tape + template Blend parameter

### DIFF
--- a/Docs/Sphinx/source/ImplemBVH.rst
+++ b/Docs/Sphinx/source/ImplemBVH.rst
@@ -505,8 +505,9 @@ One such union is known as the *smooth union*, in which the transition between t
 ``b`` (``a`` the closest, ``b`` the second-closest): the leaf-evaluator updates both as leaves are
 scanned, and the pruning rule returns ``max(0, b)`` squared -- pruning against the *second*-smallest
 value rather than the nearest, so a primitive that is not the single closest but still contributes to
-the blend is never pruned away. Once traversal completes, the two values are blended with the stored
-smooth-minimum operator. ``BVHUnionIF::value()`` is the same pattern with a single running minimum
+the blend is never pruned away. Once traversal completes, the two values are blended with the
+class's smooth-minimum blend operator (its ``Blend`` template parameter, ``SmoothMinOp`` by
+default). ``BVHUnionIF::value()`` is the same pattern with a single running minimum
 and a ``max(0, minDist)``-squared pruning bound. See :ref:`Chap:ImplemCSG` for the CSG combinators
 themselves, and the Doxygen reference for
 `BVHSmoothUnionIF <doxygen/html/classEBGeometry_1_1BVHSmoothUnionIF.html>`__ /

--- a/Docs/Sphinx/source/ImplemCSG.rst
+++ b/Docs/Sphinx/source/ImplemCSG.rst
@@ -251,15 +251,20 @@ in the Doxygen listing above -- one taking a ``std::vector`` of any number of im
 and one taking exactly two -- both constructing the same underlying wrapper class.
 
 The "smooth" combinators blend the transition between objects instead of leaving a sharp crease,
-using a caller-replaceable blending functor rather than a plain ``min``/``max``. Two are provided
-as ``std::function`` template variables in :file:`Source/EBGeometry_CSG.hpp`: ``SmoothMin<T>``
-(a cheap polynomial smooth-minimum, the default for ``SmoothUnion``) and ``SmoothMax<T>`` (its
-symmetric counterpart, the default for both ``SmoothIntersection`` and ``SmoothDifference`` --
-difference is implemented internally as the intersection of ``A`` with the complement of ``B``,
-which is why it defaults to the same operator as intersection rather than to ``SmoothMin<T>``),
-plus a more expensive exponential alternative, ``ExpMin<T>``. Any of the three -- or a
-user-supplied functor of the same signature, ``T(const T&, const T&, const T&)`` -- can be passed
-as the smoothing operator to the smooth combinators' constructors/free functions.
+using a compile-time blend operator rather than a plain ``min``/``max``. The blend is a template
+parameter (``Blend``) on the smooth wrapper classes and free functions, with sensible defaults.
+Three operators are provided as trait structs in :file:`Source/EBGeometry_CSG.hpp`:
+``SmoothMinOp<T>`` (a cheap polynomial smooth-minimum, the default for ``SmoothUnion`` and
+``BVHSmoothUnion``) and ``SmoothMaxOp<T>`` (its symmetric counterpart, the default for both
+``SmoothIntersection`` and ``SmoothDifference`` -- difference is implemented internally as the
+intersection of ``A`` with the complement of ``B``, which is why it defaults to the same operator
+as intersection rather than to ``SmoothMinOp<T>``), plus a more expensive exponential alternative,
+``ExpMinOp<T>``. A non-default blend is chosen by naming it explicitly, e.g.
+``SmoothUnion<T, ExpMinOp<T>>(...)``, and a user-supplied operator with the same trait shape -- a
+struct exposing ``static T eval(T a, T b, T s) noexcept`` -- works the same way. See the Doxygen
+pages for `SmoothMinOp <doxygen/html/structEBGeometry_1_1SmoothMinOp.html>`__ /
+`SmoothMaxOp <doxygen/html/structEBGeometry_1_1SmoothMaxOp.html>`__ /
+`ExpMinOp <doxygen/html/structEBGeometry_1_1ExpMinOp.html>`__ for the exact formulas.
 
 Because a plain CSG union is evaluated as :math:`\min(I_1, \ldots, I_N)`, querying it costs
 :math:`\mathcal{O}(N)` per point for :math:`N` objects. ``BVHUnionIF``/``BVHUnion`` and

--- a/Docs/Sphinx/source/TestingLocally.rst
+++ b/Docs/Sphinx/source/TestingLocally.rst
@@ -222,7 +222,8 @@ Test coverage
        correct after a moving geometry (idempotent on an unchanged cloud, queries still matching a
        brute-force scan after displacement).
    * - ``TestCSG``
-     - :cpp:func:`SmoothMin`/:cpp:func:`SmoothMax`/:cpp:func:`ExpMin` blending primitives;
+     - :cpp:class:`SmoothMinOp`/:cpp:class:`SmoothMaxOp`/:cpp:class:`ExpMinOp` blend operator
+       traits;
        sharp and smooth :cpp:class:`UnionIF`/:cpp:class:`IntersectionIF`/:cpp:class:`DifferenceIF`
        (and their BVH-accelerated counterparts); :cpp:class:`FiniteRepetitionIF` tiling and
        boundary clamping.

--- a/Integrations/AMReX/PackedSpheres/main.cpp
+++ b/Integrations/AMReX/PackedSpheres/main.cpp
@@ -61,7 +61,7 @@ public:
     }
 
     // Create the standard and fast CSG unions.
-    m_slowUnion = EBGeometry::SmoothUnion<T, Prim>(spheres, smoothLen);
+    m_slowUnion = EBGeometry::SmoothUnion<T>(spheres, smoothLen);
     m_fastUnion = EBGeometry::BVHSmoothUnion<T, Prim, BV, K>(spheres, boundingVolumes, smoothLen);
 
     // AMReX uses the opposite sign than EBGeometry.

--- a/Integrations/Chombo/PackedSpheres/main.cpp
+++ b/Integrations/Chombo/PackedSpheres/main.cpp
@@ -65,7 +65,7 @@ public:
     }
 
     // Create the standard and fast CSG unions.
-    m_slowUnion = EBGeometry::SmoothUnion<T, Prim>(spheres, smoothLen);
+    m_slowUnion = EBGeometry::SmoothUnion<T>(spheres, smoothLen);
     m_fastUnion = EBGeometry::BVHSmoothUnion<T, Prim, BV, K>(spheres, boundingVolumes, smoothLen);
 
     // AMReX uses the opposite to EBGeometry.

--- a/Source/EBGeometry_BVH.hpp
+++ b/Source/EBGeometry_BVH.hpp
@@ -1605,6 +1605,17 @@ public:
   getPrimitives() const noexcept;
 
   /**
+   * @brief Get the flat node array (depth-first pre-order; root at index 0).
+   * @details Read-only access to the packed node topology: each node exposes its bounding volume,
+   * its primitive range (leaves), and its child index table (interior nodes). Leaf primitive
+   * offsets index the list returned by getPrimitives(). Used by e.g. the tape lowering of the
+   * BVH-accelerated CSG unions to mirror this BVH's topology.
+   * @return Reference to m_linearNodes.
+   */
+  [[nodiscard]] inline const std::vector<Node>&
+  getNodes() const noexcept;
+
+  /**
    * @brief Get the bounding volume of the root node.
    * @return Reference to the root node's bounding volume.
    */

--- a/Source/EBGeometry_BVHImplem.hpp
+++ b/Source/EBGeometry_BVHImplem.hpp
@@ -1038,6 +1038,13 @@ PackedBVH<T, P, K, StoragePolicy>::getPrimitives() const noexcept
 }
 
 template <class T, class P, size_t K, class StoragePolicy>
+inline const std::vector<typename PackedBVH<T, P, K, StoragePolicy>::Node>&
+PackedBVH<T, P, K, StoragePolicy>::getNodes() const noexcept
+{
+  return m_linearNodes;
+}
+
+template <class T, class P, size_t K, class StoragePolicy>
 inline const EBGeometry::BoundingVolumes::AABBT<T>&
 PackedBVH<T, P, K, StoragePolicy>::getBoundingVolume() const noexcept
 {

--- a/Source/EBGeometry_CSG.hpp
+++ b/Source/EBGeometry_CSG.hpp
@@ -423,7 +423,7 @@ struct HasBlendEval<
   Blend,
   T,
   std::void_t<decltype(static_cast<T>(Blend::eval(std::declval<T>(), std::declval<T>(), std::declval<T>())))>>
-  : std::true_type
+  : std::bool_constant<noexcept(Blend::eval(std::declval<T>(), std::declval<T>(), std::declval<T>()))>
 {
 };
 

--- a/Source/EBGeometry_CSG.hpp
+++ b/Source/EBGeometry_CSG.hpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -35,6 +34,14 @@ namespace EBGeometry {
  */
 template <class T>
 class TapeBuilder;
+
+// Forward declarations of the smooth-blend operator traits (defined further below), needed as
+// default arguments for the smooth combiners' Blend template parameter.
+template <class T>
+struct SmoothMinOp;
+
+template <class T>
+struct SmoothMaxOp;
 
 /**
  * @brief Constructs an implicit function whose interior is the union of the interiors of all input functions.
@@ -63,28 +70,31 @@ Union(const std::shared_ptr<P1>& a_implicitFunctionA, const std::shared_ptr<P2>&
 
 /**
  * @brief Constructs an implicit function whose interior is a smoothly blended union of all input function interiors.
- * @details Uses SmoothMin to blend the two closest values; the blend region width is a_smooth.
- * @tparam T Floating-point precision.
- * @tparam P Primitive type; must derive from ImplicitFunction<T>.
+ * @details Uses the Blend operator (SmoothMinOp by default) to blend the two closest values; the
+ * blend region width is a_smooth. Choose another blend as e.g. SmoothUnion<T, ExpMinOp<T>>(...).
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-minimum blend operator; must provide static T eval(T a, T b, T s) noexcept.
+ * @tparam P     Primitive type; must derive from ImplicitFunction<T>.
  * @param[in] a_implicitFunctions Input implicit functions.
  * @param[in] a_smooth Smoothing length (must be > 0).
- * @return Shared pointer to a SmoothUnionIF<T> wrapping all input functions.
+ * @return Shared pointer to a SmoothUnionIF<T, Blend> wrapping all input functions.
  */
-template <class T, class P = ImplicitFunction<T>>
+template <class T, class Blend = SmoothMinOp<T>, class P = ImplicitFunction<T>>
 [[nodiscard]] std::shared_ptr<ImplicitFunction<T>>
 SmoothUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, const T a_smooth);
 
 /**
  * @brief Constructs an implicit function whose interior is a smoothly blended union of the interiors of A and B.
- * @tparam T  Floating-point precision.
- * @tparam P1 Type of A; must derive from ImplicitFunction<T>.
- * @tparam P2 Type of B; must derive from ImplicitFunction<T>.
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-minimum blend operator; must provide static T eval(T a, T b, T s) noexcept.
+ * @tparam P1    Type of A; must derive from ImplicitFunction<T>.
+ * @tparam P2    Type of B; must derive from ImplicitFunction<T>.
  * @param[in] a_implicitFunctionA First implicit function.
  * @param[in] a_implicitFunctionB Second implicit function.
  * @param[in] a_smooth Smoothing length (must be > 0).
- * @return Shared pointer to a SmoothUnionIF<T> containing both functions.
+ * @return Shared pointer to a SmoothUnionIF<T, Blend> containing both functions.
  */
-template <class T, class P1, class P2>
+template <class T, class Blend = SmoothMinOp<T>, class P1, class P2>
 [[nodiscard]] std::shared_ptr<ImplicitFunction<T>>
 SmoothUnion(const std::shared_ptr<P1>& a_implicitFunctionA,
             const std::shared_ptr<P2>& a_implicitFunctionB,
@@ -111,16 +121,17 @@ BVHUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, const std::
  * @brief Constructs a BVH-accelerated smooth union of implicit functions.
  * @details Uses the BVH to locate the two nearest primitives and applies a smooth-minimum to their
  * values, yielding C1 (or better) blending across nearby surfaces. Sub-linear query cost.
- * @tparam T  Floating-point precision.
- * @tparam P  Primitive type; must derive from ImplicitFunction<T>.
- * @tparam BV Bounding volume type (e.g. AABBT<T>).
- * @tparam K  BVH branching factor.
+ * @tparam T     Floating-point precision.
+ * @tparam P     Primitive type; must derive from ImplicitFunction<T>.
+ * @tparam BV    Bounding volume type (e.g. AABBT<T>).
+ * @tparam K     BVH branching factor.
+ * @tparam Blend Smooth-minimum blend operator; must provide static T eval(T a, T b, T s) noexcept.
  * @param[in] a_implicitFunctions Input implicit functions.
  * @param[in] a_boundingVolumes   Bounding volumes for each implicit function.
  * @param[in] a_smoothLen         Smoothing length (must be > 0).
- * @return Shared pointer to a BVHSmoothUnionIF<T,P,BV,K> with an internal BVH.
+ * @return Shared pointer to a BVHSmoothUnionIF<T,P,BV,K,Blend> with an internal BVH.
  */
-template <class T, class P, class BV, size_t K>
+template <class T, class P, class BV, size_t K, class Blend = SmoothMinOp<T>>
 [[nodiscard]] std::shared_ptr<ImplicitFunction<T>>
 BVHSmoothUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions,
                const std::vector<BV>&                 a_boundingVolumes,
@@ -153,27 +164,30 @@ Intersection(const std::shared_ptr<P1>& a_implicitFunctionA, const std::shared_p
 
 /**
  * @brief Constructs an implicit function whose interior is a smoothly blended intersection of all input function interiors.
- * @tparam T Floating-point precision.
- * @tparam P Primitive type; must derive from ImplicitFunction<T>.
+ * @details Uses the Blend operator (SmoothMaxOp by default) to blend the two largest values.
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-maximum blend operator; must provide static T eval(T a, T b, T s) noexcept.
+ * @tparam P     Primitive type; must derive from ImplicitFunction<T>.
  * @param[in] a_implicitFunctions Input implicit functions.
  * @param[in] a_smooth Smoothing length (must be > 0).
- * @return Shared pointer to a SmoothIntersectionIF<T> wrapping all input functions.
+ * @return Shared pointer to a SmoothIntersectionIF<T, Blend> wrapping all input functions.
  */
-template <class T, class P>
+template <class T, class Blend = SmoothMaxOp<T>, class P = ImplicitFunction<T>>
 [[nodiscard]] std::shared_ptr<ImplicitFunction<T>>
 SmoothIntersection(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, const T a_smooth);
 
 /**
  * @brief Constructs an implicit function whose interior is a smoothly blended intersection of the interiors of A and B.
- * @tparam T  Floating-point precision.
- * @tparam P1 Type of A; must derive from ImplicitFunction<T>.
- * @tparam P2 Type of B; must derive from ImplicitFunction<T>.
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-maximum blend operator; must provide static T eval(T a, T b, T s) noexcept.
+ * @tparam P1    Type of A; must derive from ImplicitFunction<T>.
+ * @tparam P2    Type of B; must derive from ImplicitFunction<T>.
  * @param[in] a_implicitFunctionA First implicit function.
  * @param[in] a_implicitFunctionB Second implicit function.
  * @param[in] a_smooth Smoothing length (must be > 0).
- * @return Shared pointer to a SmoothIntersectionIF<T> containing both functions.
+ * @return Shared pointer to a SmoothIntersectionIF<T, Blend> containing both functions.
  */
-template <class T, class P1, class P2>
+template <class T, class Blend = SmoothMaxOp<T>, class P1, class P2>
 [[nodiscard]] std::shared_ptr<ImplicitFunction<T>>
 SmoothIntersection(const std::shared_ptr<P1>& a_implicitFunctionA,
                    const std::shared_ptr<P2>& a_implicitFunctionB,
@@ -195,16 +209,18 @@ Difference(const std::shared_ptr<P1>& a_implicitFunctionA, const std::shared_ptr
 
 /**
  * @brief Constructs an implicit function representing a smoothly blended set difference A \ B.
- * @details Implemented as a smooth intersection of A with the complement of B.
- * @tparam T  Floating-point precision.
- * @tparam P1 Type of the minuend A; must derive from ImplicitFunction<T>.
- * @tparam P2 Type of the subtrahend B; must derive from ImplicitFunction<T>.
+ * @details Implemented as a smooth intersection of A with the complement of B, which is why the
+ * default Blend is SmoothMaxOp (the smooth-intersection default) rather than SmoothMinOp.
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-maximum blend operator; must provide static T eval(T a, T b, T s) noexcept.
+ * @tparam P1    Type of the minuend A; must derive from ImplicitFunction<T>.
+ * @tparam P2    Type of the subtrahend B; must derive from ImplicitFunction<T>.
  * @param[in] a_implicitFunctionA Minuend implicit function.
  * @param[in] a_implicitFunctionB Subtrahend implicit function.
  * @param[in] a_smoothLen         Smoothing length (must be > 0).
- * @return Shared pointer to a SmoothDifferenceIF<T> representing the smooth A \ B.
+ * @return Shared pointer to a SmoothDifferenceIF<T, Blend> representing the smooth A \ B.
  */
-template <class T, class P1 = ImplicitFunction<T>, class P2 = ImplicitFunction<T>>
+template <class T, class Blend = SmoothMaxOp<T>, class P1 = ImplicitFunction<T>, class P2 = ImplicitFunction<T>>
 [[nodiscard]] std::shared_ptr<ImplicitFunction<T>>
 SmoothDifference(const std::shared_ptr<P1>& a_implicitFunctionA,
                  const std::shared_ptr<P2>& a_implicitFunctionB,
@@ -304,8 +320,9 @@ struct DifferenceOp
 
 /**
  * @brief Reduction trait for the exponential smooth minimum.
- * @details Single source of truth for the exponential smooth-minimum blend formula, reused verbatim by
- * the tape interpreter and by the ExpMin std::function wrapper.
+ * @details Single source of truth for the exponential smooth-minimum blend formula, reused verbatim
+ * by the tape interpreter. A more expensive alternative to SmoothMinOp; select it as e.g.
+ * SmoothUnion<T, ExpMinOp<T>>(...).
  * @tparam T Floating-point precision.
  */
 template <class T>
@@ -333,8 +350,9 @@ struct ExpMinOp
 
 /**
  * @brief Reduction trait for the quadratic polynomial smooth minimum.
- * @details Single source of truth for the polynomial smooth-minimum blend formula, reused verbatim by
- * the tape interpreter and by the SmoothMin std::function wrapper.
+ * @details Single source of truth for the polynomial smooth-minimum blend formula, reused verbatim
+ * by the tape interpreter. Coincides exactly with min(a, b) outside the overlap region
+ * |a - b| < s; cheaper to evaluate than ExpMinOp and the default Blend for the smooth CSG unions.
  * @tparam T Floating-point precision.
  */
 template <class T>
@@ -362,8 +380,9 @@ struct SmoothMinOp
 
 /**
  * @brief Reduction trait for the quadratic polynomial smooth maximum.
- * @details Single source of truth for the polynomial smooth-maximum blend formula, reused verbatim by
- * the tape interpreter and by the SmoothMax std::function wrapper.
+ * @details Single source of truth for the polynomial smooth-maximum blend formula, reused verbatim
+ * by the tape interpreter. Symmetric counterpart to SmoothMinOp; the default Blend for the smooth
+ * CSG intersection and difference.
  * @tparam T Floating-point precision.
  */
 template <class T>
@@ -389,51 +408,42 @@ struct SmoothMaxOp
   }
 };
 
-/**
- * @brief Exponential smooth minimum for blending two signed-distance values.
- * @details Approximates min(a, b) with exponential weighting; the blend region width scales with s.
- * Useful when a differentiable interface is required. Approaches min(a, b) as s → 0. Thin std::function
- * wrapper around ExpMinOp, which is the single source of truth for the formula.
- * @tparam T Floating-point precision.
- * @param[in] a First value.
- * @param[in] b Second value.
- * @param[in] s Smoothing length (must be > 0).
- * @return Exponentially blended approximation of min(a, b).
- */
-template <class T>
-std::function<T(const T& a, const T& b, const T& s)> ExpMin =
-  [](const T& a, const T& b, const T& s) -> T { return ExpMinOp<T>::eval(a, b, s); };
+/// @cond EBGEOMETRY_INTERNAL
+namespace CSGDetail {
+
+// Detection helper behind isValidBlend: true iff Blend::eval(a, b, s) is callable with three T
+// values and its result converts to T.
+template <class Blend, class T, class = void>
+struct HasBlendEval : std::false_type
+{
+};
+
+template <class Blend, class T>
+struct HasBlendEval<
+  Blend,
+  T,
+  std::void_t<decltype(static_cast<T>(Blend::eval(std::declval<T>(), std::declval<T>(), std::declval<T>())))>>
+  : std::true_type
+{
+};
+
+} // namespace CSGDetail
+/// @endcond
 
 /**
- * @brief Quadratic polynomial smooth minimum for blending two signed-distance values.
- * @details Approximates min(a, b) within the overlap region |a - b| < s; coincides exactly with
- * min(a, b) outside that region. Cheaper to evaluate than ExpMin and the default choice for CSG unions.
- * Thin std::function wrapper around SmoothMinOp, which is the single source of truth for the formula.
- * @tparam T Floating-point precision.
- * @param[in] a First value.
- * @param[in] b Second value.
- * @param[in] s Smoothing length (must be > 0). Controls the blend region width.
- * @return Polynomial-blended approximation of min(a, b).
+ * @brief Detection trait: true iff Blend is a valid smooth-blend operator for precision T.
+ * @details A valid blend operator exposes the trait shape shared by SmoothMinOp, SmoothMaxOp, and
+ * ExpMinOp -- a static eval taking two signed-distance values and the smoothing length:
+ * @code
+ * static T eval(T a, T b, T s) noexcept;
+ * @endcode
+ * The smooth combiners static_assert on this so that an ill-shaped Blend produces a readable error
+ * message instead of a template-instantiation avalanche.
+ * @tparam Blend Candidate blend operator.
+ * @tparam T     Floating-point precision.
  */
-template <class T>
-std::function<T(const T& a, const T& b, const T& s)> SmoothMin =
-  [](const T& a, const T& b, const T& s) -> T { return SmoothMinOp<T>::eval(a, b, s); };
-
-/**
- * @brief Quadratic polynomial smooth maximum for blending two signed-distance values.
- * @details Approximates max(a, b) within the overlap region |a - b| < s; coincides exactly with
- * max(a, b) outside that region. Symmetric counterpart to SmoothMin; used for CSG intersections and
- * differences. Thin std::function wrapper around SmoothMaxOp, which is the single source of truth for
- * the formula.
- * @tparam T Floating-point precision.
- * @param[in] a First value.
- * @param[in] b Second value.
- * @param[in] s Smoothing length (must be > 0). Controls the blend region width.
- * @return Polynomial-blended approximation of max(a, b).
- */
-template <class T>
-std::function<T(const T& a, const T& b, const T& s)> SmoothMax =
-  [](const T& a, const T& b, const T& s) -> T { return SmoothMaxOp<T>::eval(a, b, s); };
+template <class Blend, class T>
+inline constexpr bool isValidBlend = CSGDetail::HasBlendEval<Blend, T>::value;
 
 /**
  * @brief Implicit function whose interior is the union of all input function interiors.
@@ -492,16 +502,21 @@ protected:
 
 /**
  * @brief Implicit function whose interior is a smoothly blended union of all input function interiors.
- * @details Replaces the sharp min of UnionIF with a smooth-minimum operator, yielding a C1 (or better)
- * interface where interiors overlap. Only the two closest values are blended; the blend region width
- * is controlled by m_smoothLen.
- * @tparam T Floating-point precision.
+ * @details Replaces the sharp min of UnionIF with a smooth-minimum blend operator, yielding a C1 (or
+ * better) interface where interiors overlap. Only the two closest values are blended; the blend
+ * region width is controlled by m_smoothLen.
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-minimum blend operator; must provide static T eval(T a, T b, T s) noexcept
+ * (see SmoothMinOp, the default, or ExpMinOp).
  */
-template <class T>
+template <class T, class Blend = SmoothMinOp<T>>
 class SmoothUnionIF : public ImplicitFunction<T>
 {
 public:
   static_assert(std::is_floating_point_v<T>, "SmoothUnionIF requires a floating-point type T");
+  static_assert(isValidBlend<Blend, T>,
+                "SmoothUnionIF requires Blend to provide 'static T eval(T a, T b, T s) noexcept' "
+                "(see SmoothMinOp/SmoothMaxOp/ExpMinOp)");
 
   /**
    * @brief Disallowed, use the full constructor.
@@ -512,11 +527,8 @@ public:
    * @brief Constructs the smooth union of the given implicit functions.
    * @param[in] a_implicitFunctions List of implicit functions (must be non-empty; no null entries).
    * @param[in] a_smoothLen         Smoothing length (must be > 0).
-   * @param[in] a_smoothMin         Smooth-minimum operator; defaults to SmoothMin<T>.
    */
-  SmoothUnionIF(const std::vector<std::shared_ptr<ImplicitFunction<T>>>&   a_implicitFunctions,
-                const T                                                    a_smoothLen,
-                const std::function<T(const T& a, const T& b, const T& s)> a_smoothMin = SmoothMin<T>);
+  SmoothUnionIF(const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_implicitFunctions, const T a_smoothLen);
 
   /**
    * @brief Destructor.
@@ -525,8 +537,8 @@ public:
 
   /**
    * @brief Evaluates the smoothly blended signed distance at a_point.
-   * @details Finds the two closest function values and applies the stored smooth-minimum operator.
-   * Negative when inside the smooth union.
+   * @details Finds the two closest function values and applies the Blend operator. Negative when
+   * inside the smooth union.
    * @param[in] a_point 3D query point.
    * @return Smooth minimum signed distance value.
    */
@@ -535,8 +547,10 @@ public:
 
   /**
    * @brief Lower this smooth union into the tape (see EBGeometry_Tape.hpp).
-   * @details Exactly two children lower to a single smooth-minimum clause; any other count falls
-   * back to an opaque host callback (keeping the two-closest-of-N blend exact).
+   * @details A single child lowers to the child itself; exactly two children lower to a single
+   * native smooth clause when Blend has a registered ISA opcode. Any other case (more than two
+   * children, whose two-closest-of-N blend is not expressible as a fold of binary clauses, or an
+   * unregistered custom Blend) falls back to an opaque host callback.
    * @param[in,out] a_builder   Tape builder accumulating the flattened clauses.
    * @param[in]     a_coordSlot Coordinate slot holding this subtree's input frame.
    * @return Value slot holding this subtree's result.
@@ -554,11 +568,6 @@ protected:
    * @brief Smoothing length.
    */
   T m_smoothLen;
-
-  /**
-   * @brief Smooth-minimum operator.
-   */
-  std::function<T(const T&, const T&, const T&)> m_smoothMin;
 };
 
 /**
@@ -642,15 +651,17 @@ protected:
 
 /**
  * @brief BVH-accelerated smooth union of implicit functions.
- * @details Uses the BVH to locate the two nearest primitives and applies a smooth-minimum operator
- * to their values, yielding C1 (or better) blending across nearby surfaces. Query cost is sub-linear
- * in the number of primitives.
- * @tparam T  Floating-point precision.
- * @tparam P  Primitive type; must derive from ImplicitFunction<T>.
- * @tparam BV Bounding volume type (e.g. AABBT<T>).
- * @tparam K  BVH branching factor.
+ * @details Uses the BVH to locate the two nearest primitives and applies a smooth-minimum blend
+ * operator to their values, yielding C1 (or better) blending across nearby surfaces. Query cost is
+ * sub-linear in the number of primitives.
+ * @tparam T     Floating-point precision.
+ * @tparam P     Primitive type; must derive from ImplicitFunction<T>.
+ * @tparam BV    Bounding volume type (e.g. AABBT<T>).
+ * @tparam K     BVH branching factor.
+ * @tparam Blend Smooth-minimum blend operator; must provide static T eval(T a, T b, T s) noexcept
+ * (see SmoothMinOp, the default, or ExpMinOp).
  */
-template <class T, class P, class BV, size_t K>
+template <class T, class P, class BV, size_t K, class Blend = SmoothMinOp<T>>
 class BVHSmoothUnionIF : public ImplicitFunction<T>
 {
 public:
@@ -658,6 +669,9 @@ public:
   static_assert(std::is_base_of_v<EBGeometry::ImplicitFunction<T>, P>,
                 "BVHSmoothUnionIF requires an implicit function");
   static_assert(K > 0, "BVHSmoothUnionIF BVH branching factor K must be positive");
+  static_assert(isValidBlend<Blend, T>,
+                "BVHSmoothUnionIF requires Blend to provide 'static T eval(T a, T b, T s) noexcept' "
+                "(see SmoothMinOp/SmoothMaxOp/ExpMinOp)");
 
   /**
    * @brief Alias for the flat BVH type.
@@ -674,12 +688,10 @@ public:
    * @param[in] a_distanceFunctions Input implicit functions (must be non-empty; no null entries).
    * @param[in] a_boundingVolumes   Bounding volumes for each function (same length as a_distanceFunctions).
    * @param[in] a_smoothLen         Smoothing length (must be > 0).
-   * @param[in] a_smoothMin         Smooth-minimum operator; defaults to SmoothMin<T>.
    */
-  BVHSmoothUnionIF(const std::vector<std::shared_ptr<P>>&               a_distanceFunctions,
-                   const std::vector<BV>&                               a_boundingVolumes,
-                   const T                                              a_smoothLen,
-                   const std::function<T(const T&, const T&, const T&)> a_smoothMin = SmoothMin<T>) noexcept;
+  BVHSmoothUnionIF(const std::vector<std::shared_ptr<P>>& a_distanceFunctions,
+                   const std::vector<BV>&                 a_boundingVolumes,
+                   const T                                a_smoothLen) noexcept;
 
   /**
    * @brief Destructor.
@@ -688,8 +700,8 @@ public:
 
   /**
    * @brief Evaluates the smoothly blended signed distance at a_point using BVH traversal.
-   * @details Finds the two nearest primitives via BVH and applies the stored smooth-minimum. Negative
-   * when inside the smooth union.
+   * @details Finds the two nearest primitives via BVH and applies the Blend operator. Negative when
+   * inside the smooth union.
    * @param[in] a_point 3D query point.
    * @return Smooth minimum signed distance blended from the two closest primitives.
    */
@@ -713,11 +725,6 @@ protected:
    * @brief Smoothing length.
    */
   T m_smoothLen;
-
-  /**
-   * @brief Smooth-minimum operator.
-   */
-  std::function<T(const T&, const T&, const T&)> m_smoothMin;
 
   /**
    * @brief Builds the internal BVH from primitive/BV pairs.
@@ -786,16 +793,21 @@ protected:
 
 /**
  * @brief Implicit function whose interior is a smoothly blended intersection of all input function interiors.
- * @details Replaces the sharp max of IntersectionIF with a smooth-maximum operator, yielding a C1 (or better)
- * interface at intersection boundaries. Only the two largest values are blended; the blend region width
- * is controlled by m_smoothLen.
- * @tparam T Floating-point precision.
+ * @details Replaces the sharp max of IntersectionIF with a smooth-maximum blend operator, yielding a
+ * C1 (or better) interface at intersection boundaries. Only the two largest values are blended; the
+ * blend region width is controlled by m_smoothLen.
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-maximum blend operator; must provide static T eval(T a, T b, T s) noexcept
+ * (see SmoothMaxOp, the default).
  */
-template <class T>
+template <class T, class Blend = SmoothMaxOp<T>>
 class SmoothIntersectionIF : public ImplicitFunction<T>
 {
 public:
   static_assert(std::is_floating_point_v<T>, "SmoothIntersectionIF requires a floating-point type T");
+  static_assert(isValidBlend<Blend, T>,
+                "SmoothIntersectionIF requires Blend to provide 'static T eval(T a, T b, T s) noexcept' "
+                "(see SmoothMinOp/SmoothMaxOp/ExpMinOp)");
 
   /**
    * @brief Disallowed, use the full constructor.
@@ -807,22 +819,18 @@ public:
    * @param[in] a_implicitFunctionA First implicit function (must not be null).
    * @param[in] a_implicitFunctionB Second implicit function (must not be null).
    * @param[in] a_smoothLen         Smoothing length (must be > 0).
-   * @param[in] a_smoothMax         Smooth-maximum operator; defaults to SmoothMax<T>.
    */
-  SmoothIntersectionIF(const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionA,
-                       const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionB,
-                       const T                                                     a_smoothLen,
-                       const std::function<T(const T& a, const T& b, const T& s)>& a_smoothMax = SmoothMax<T>) noexcept;
+  SmoothIntersectionIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionA,
+                       const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionB,
+                       const T                                     a_smoothLen) noexcept;
 
   /**
    * @brief Constructs the smooth intersection of a list of implicit functions.
    * @param[in] a_implicitFunctions List of implicit functions (must be non-empty; no null entries).
    * @param[in] a_smoothLen         Smoothing length (must be > 0).
-   * @param[in] a_smoothMax         Smooth-maximum operator; defaults to SmoothMax<T>.
    */
-  SmoothIntersectionIF(const std::vector<std::shared_ptr<ImplicitFunction<T>>>&    a_implicitFunctions,
-                       const T                                                     a_smoothLen,
-                       const std::function<T(const T& a, const T& b, const T& s)>& a_smoothMax = SmoothMax<T>) noexcept;
+  SmoothIntersectionIF(const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_implicitFunctions,
+                       const T                                                  a_smoothLen) noexcept;
 
   /**
    * @brief Destructor.
@@ -831,8 +839,8 @@ public:
 
   /**
    * @brief Evaluates the smoothly blended signed distance at a_point.
-   * @details Finds the two largest function values and applies the stored smooth-maximum operator.
-   * Negative when inside the smooth intersection.
+   * @details Finds the two largest function values and applies the Blend operator. Negative when
+   * inside the smooth intersection.
    * @param[in] a_point 3D query point.
    * @return Smooth maximum signed distance value.
    */
@@ -841,8 +849,10 @@ public:
 
   /**
    * @brief Lower this smooth intersection into the tape (see EBGeometry_Tape.hpp).
-   * @details Exactly two children lower to a single smooth-maximum clause; any other count falls
-   * back to an opaque host callback (keeping the two-closest-of-N blend exact).
+   * @details A single child lowers to the child itself; exactly two children lower to a single
+   * native smooth clause when Blend has a registered ISA opcode. Any other case (more than two
+   * children, whose two-largest-of-N blend is not expressible as a fold of binary clauses, or an
+   * unregistered custom Blend) falls back to an opaque host callback.
    * @param[in,out] a_builder   Tape builder accumulating the flattened clauses.
    * @param[in]     a_coordSlot Coordinate slot holding this subtree's input frame.
    * @return Value slot holding this subtree's result.
@@ -860,11 +870,6 @@ protected:
    * @brief Smoothing length.
    */
   T m_smoothLen;
-
-  /**
-   * @brief Smooth-maximum operator.
-   */
-  std::function<T(const T& a, const T& b, const T& s)> m_smoothMax;
 };
 
 /**
@@ -938,16 +943,22 @@ protected:
 
 /**
  * @brief Implicit function representing a smoothly blended set difference A \ B.
- * @details Implemented as a smooth intersection of A with the complement of B. A point is
- * near-inside if it is inside A and outside (or near-outside) B; the interface is smoothed
- * over a region of width m_smoothLen.
- * @tparam T Floating-point precision.
+ * @details Implemented as a smooth intersection of A with the complement of B (which is why the
+ * default Blend is SmoothMaxOp, the smooth-intersection default). A point is near-inside if it is
+ * inside A and outside (or near-outside) B; the interface is smoothed over a region of width
+ * m_smoothLen.
+ * @tparam T     Floating-point precision.
+ * @tparam Blend Smooth-maximum blend operator; must provide static T eval(T a, T b, T s) noexcept
+ * (see SmoothMaxOp, the default).
  */
-template <class T>
+template <class T, class Blend = SmoothMaxOp<T>>
 class SmoothDifferenceIF : public ImplicitFunction<T>
 {
 public:
   static_assert(std::is_floating_point_v<T>, "SmoothDifferenceIF requires a floating-point type T");
+  static_assert(isValidBlend<Blend, T>,
+                "SmoothDifferenceIF requires Blend to provide 'static T eval(T a, T b, T s) noexcept' "
+                "(see SmoothMinOp/SmoothMaxOp/ExpMinOp)");
 
   /**
    * @brief Disallowed, use the full constructor.
@@ -959,24 +970,20 @@ public:
    * @param[in] a_implicitFunctionA Minuend (must not be null).
    * @param[in] a_implicitFunctionB Subtrahend (must not be null).
    * @param[in] a_smoothLen         Smoothing length (must be > 0).
-   * @param[in] a_smoothMax         Smooth-maximum operator; defaults to SmoothMax<T>.
    */
-  SmoothDifferenceIF(const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionA,
-                     const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionB,
-                     const T                                                     a_smoothLen,
-                     const std::function<T(const T& a, const T& b, const T& s)>& a_smoothMax = SmoothMax<T>) noexcept;
+  SmoothDifferenceIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionA,
+                     const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionB,
+                     const T                                     a_smoothLen) noexcept;
 
   /**
    * @brief Constructs the smooth difference A \ union(Bs) from A and a list of subtrahends.
    * @param[in] a_implicitFunctionA  Minuend (must not be null).
    * @param[in] a_implicitFunctionsB Subtrahends (must be non-empty; no null entries).
    * @param[in] a_smoothLen          Smoothing length (must be > 0).
-   * @param[in] a_smoothMax          Smooth-maximum operator; defaults to SmoothMax<T>.
    */
-  SmoothDifferenceIF(const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionA,
-                     const std::vector<std::shared_ptr<ImplicitFunction<T>>>&    a_implicitFunctionsB,
-                     const T                                                     a_smoothLen,
-                     const std::function<T(const T& a, const T& b, const T& s)>& a_smoothMax = SmoothMax<T>) noexcept;
+  SmoothDifferenceIF(const std::shared_ptr<ImplicitFunction<T>>&              a_implicitFunctionA,
+                     const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_implicitFunctionsB,
+                     const T                                                  a_smoothLen) noexcept;
 
   /**
    * @brief Destructor.
@@ -1006,7 +1013,7 @@ protected:
   /**
    * @brief Internal smooth intersection implementing smooth(A ∩ complement(B)).
    */
-  std::shared_ptr<SmoothIntersectionIF<T>> m_smoothIntersectionIF;
+  std::shared_ptr<SmoothIntersectionIF<T, Blend>> m_smoothIntersectionIF;
 };
 
 /**

--- a/Source/EBGeometry_CSG.hpp
+++ b/Source/EBGeometry_CSG.hpp
@@ -633,6 +633,20 @@ public:
   [[nodiscard]] const EBGeometry::BoundingVolumes::AABBT<T>&
   getBoundingVolume() const noexcept;
 
+  /**
+   * @brief Lower this BVH union into the tape as a native BVH clause (see EBGeometry_Tape.hpp).
+   * @details Emits a BVH_UNION clause whose block copies the internal PackedBVH's node topology;
+   * every leaf primitive's subtree is flattened into the tape's deferred clause region and
+   * executed on demand by the interpreter's pruned traversal. A BVH union that is itself a leaf
+   * primitive of an enclosing BVH union lowers to an opaque host callback instead (exact, but
+   * host-only).
+   * @param[in,out] a_builder   Tape builder accumulating the flattened clauses.
+   * @param[in]     a_coordSlot Coordinate slot holding this subtree's input frame.
+   * @return Value slot holding this subtree's result.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST int
+  flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const override;
+
 protected:
   /**
    * @brief Flat BVH over all input primitives.
@@ -714,6 +728,20 @@ public:
    */
   [[nodiscard]] const EBGeometry::BoundingVolumes::AABBT<T>&
   getBoundingVolume() const noexcept;
+
+  /**
+   * @brief Lower this BVH smooth union into the tape (see EBGeometry_Tape.hpp).
+   * @details When Blend has a registered smooth ISA opcode (SmoothMinOp, SmoothMaxOp, ExpMinOp),
+   * emits a native BVH_SMOOTH_UNION clause whose pruned traversal tracks the two nearest leaf
+   * values and blends them with Blend's trait -- exactly what value() computes. An unregistered
+   * custom Blend, or a smooth union that is itself a leaf primitive of an enclosing BVH union,
+   * lowers to an opaque host callback instead (exact, but host-only).
+   * @param[in,out] a_builder   Tape builder accumulating the flattened clauses.
+   * @param[in]     a_coordSlot Coordinate slot holding this subtree's input frame.
+   * @return Value slot holding this subtree's result.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST int
+  flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const override;
 
 protected:
   /**

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -16,7 +16,6 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -135,7 +134,7 @@ Union(const std::shared_ptr<P1>& a_implicitFunction1, const std::shared_ptr<P2>&
   return std::make_shared<UnionIF<T>>(implicitFunctions);
 }
 
-template <class T, class P>
+template <class T, class Blend, class P>
 std::shared_ptr<ImplicitFunction<T>>
 SmoothUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, const T a_smooth)
 {
@@ -153,10 +152,10 @@ SmoothUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, const T 
     implicitFunctions.emplace_back(f);
   }
 
-  return std::make_shared<SmoothUnionIF<T>>(implicitFunctions, a_smooth);
+  return std::make_shared<SmoothUnionIF<T, Blend>>(implicitFunctions, a_smooth);
 }
 
-template <class T, class P1, class P2>
+template <class T, class Blend, class P1, class P2>
 std::shared_ptr<ImplicitFunction<T>>
 SmoothUnion(const std::shared_ptr<P1>& a_implicitFunction1,
             const std::shared_ptr<P2>& a_implicitFunction2,
@@ -175,7 +174,7 @@ SmoothUnion(const std::shared_ptr<P1>& a_implicitFunction1,
   implicitFunctions.emplace_back(a_implicitFunction1);
   implicitFunctions.emplace_back(a_implicitFunction2);
 
-  return std::make_shared<SmoothUnionIF<T>>(implicitFunctions, a_smooth);
+  return std::make_shared<SmoothUnionIF<T, Blend>>(implicitFunctions, a_smooth);
 }
 
 template <class T, class P, class BV, size_t K>
@@ -191,7 +190,7 @@ BVHUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, const std::
   return std::make_shared<EBGeometry::BVHUnionIF<T, P, BV, K>>(a_implicitFunctions, a_boundingVolumes);
 }
 
-template <class T, class P, class BV, size_t K>
+template <class T, class P, class BV, size_t K, class Blend>
 std::shared_ptr<ImplicitFunction<T>>
 BVHSmoothUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions,
                const std::vector<BV>&                 a_boundingVolumes,
@@ -204,7 +203,7 @@ BVHSmoothUnion(const std::vector<std::shared_ptr<P>>& a_implicitFunctions,
   EBGEOMETRY_EXPECT(a_implicitFunctions.size() == a_boundingVolumes.size());
   EBGEOMETRY_EXPECT(a_smoothLen > T(0));
 
-  return std::make_shared<EBGeometry::BVHSmoothUnionIF<T, P, BV, K>>(
+  return std::make_shared<EBGeometry::BVHSmoothUnionIF<T, P, BV, K, Blend>>(
     a_implicitFunctions, a_boundingVolumes, a_smoothLen);
 }
 
@@ -247,7 +246,7 @@ Intersection(const std::shared_ptr<P1>& a_implicitFunction1, const std::shared_p
   return std::make_shared<IntersectionIF<T>>(implicitFunctions);
 }
 
-template <class T, class P>
+template <class T, class Blend, class P>
 std::shared_ptr<ImplicitFunction<T>>
 SmoothIntersection(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, const T a_smooth)
 {
@@ -263,10 +262,10 @@ SmoothIntersection(const std::vector<std::shared_ptr<P>>& a_implicitFunctions, c
     implicitFunctions.emplace_back(f);
   }
 
-  return std::make_shared<SmoothIntersectionIF<T>>(implicitFunctions, a_smooth);
+  return std::make_shared<SmoothIntersectionIF<T, Blend>>(implicitFunctions, a_smooth);
 }
 
-template <class T, class P1, class P2>
+template <class T, class Blend, class P1, class P2>
 std::shared_ptr<ImplicitFunction<T>>
 SmoothIntersection(const std::shared_ptr<P1>& a_implicitFunction1,
                    const std::shared_ptr<P2>& a_implicitFunction2,
@@ -285,7 +284,7 @@ SmoothIntersection(const std::shared_ptr<P1>& a_implicitFunction1,
   implicitFunctions.emplace_back(a_implicitFunction1);
   implicitFunctions.emplace_back(a_implicitFunction2);
 
-  return std::make_shared<SmoothIntersectionIF<T>>(implicitFunctions, a_smooth);
+  return std::make_shared<SmoothIntersectionIF<T, Blend>>(implicitFunctions, a_smooth);
 }
 
 template <class T, class P1, class P2>
@@ -302,7 +301,7 @@ Difference(const std::shared_ptr<P1>& a_implicitFunctionA, const std::shared_ptr
   return std::make_shared<DifferenceIF<T>>(a_implicitFunctionA, a_implicitFunctionB);
 }
 
-template <class T, class P1, class P2>
+template <class T, class Blend, class P1, class P2>
 std::shared_ptr<ImplicitFunction<T>>
 SmoothDifference(const std::shared_ptr<P1>& a_implicitFunctionA,
                  const std::shared_ptr<P2>& a_implicitFunctionB,
@@ -316,7 +315,7 @@ SmoothDifference(const std::shared_ptr<P1>& a_implicitFunctionA,
   EBGEOMETRY_EXPECT(a_implicitFunctionB != nullptr);
   EBGEOMETRY_EXPECT(a_smoothLen > T(0));
 
-  return std::make_shared<SmoothDifferenceIF<T>>(a_implicitFunctionA, a_implicitFunctionB, a_smoothLen);
+  return std::make_shared<SmoothDifferenceIF<T, Blend>>(a_implicitFunctionA, a_implicitFunctionB, a_smoothLen);
 }
 
 template <class T, class P>
@@ -373,10 +372,9 @@ UnionIF<T>::value(const Vec3T<T>& a_point) const noexcept
   return ret;
 }
 
-template <class T>
-SmoothUnionIF<T>::SmoothUnionIF(const std::vector<std::shared_ptr<ImplicitFunction<T>>>&    a_implicitFunctions,
-                                const T                                                     a_smoothLen,
-                                const std::function<T(const T& a_, const T& b, const T& s)> a_smoothMin)
+template <class T, class Blend>
+SmoothUnionIF<T, Blend>::SmoothUnionIF(const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_implicitFunctions,
+                                       const T                                                  a_smoothLen)
 {
   EBGEOMETRY_EXPECT(!a_implicitFunctions.empty());
   EBGEOMETRY_EXPECT(a_smoothLen > T(0));
@@ -388,14 +386,13 @@ SmoothUnionIF<T>::SmoothUnionIF(const std::vector<std::shared_ptr<ImplicitFuncti
   }
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
-  m_smoothMin = a_smoothMin;
 
   this->m_sdf = false;
 }
 
-template <class T>
+template <class T, class Blend>
 T
-SmoothUnionIF<T>::value(const Vec3T<T>& a_point) const noexcept
+SmoothUnionIF<T, Blend>::value(const Vec3T<T>& a_point) const noexcept
 {
   T ret = std::numeric_limits<T>::infinity();
 
@@ -422,7 +419,7 @@ SmoothUnionIF<T>::value(const Vec3T<T>& a_point) const noexcept
       }
     }
 
-    ret = m_smoothMin(a, b, m_smoothLen);
+    ret = Blend::eval(a, b, m_smoothLen);
   }
 
   return ret;
@@ -528,12 +525,10 @@ BVHUnionIF<T, P, BV, K>::getBoundingVolume() const noexcept
   return m_bvh->getBoundingVolume();
 }
 
-template <class T, class P, class BV, size_t K>
-BVHSmoothUnionIF<T, P, BV, K>::BVHSmoothUnionIF(
-  const std::vector<std::shared_ptr<P>>&               a_distanceFunctions,
-  const std::vector<BV>&                               a_boundingVolumes,
-  const T                                              a_smoothLen,
-  const std::function<T(const T&, const T&, const T&)> a_smoothMin) noexcept
+template <class T, class P, class BV, size_t K, class Blend>
+BVHSmoothUnionIF<T, P, BV, K, Blend>::BVHSmoothUnionIF(const std::vector<std::shared_ptr<P>>& a_distanceFunctions,
+                                                       const std::vector<BV>&                 a_boundingVolumes,
+                                                       const T                                a_smoothLen) noexcept
 {
   EBGEOMETRY_EXPECT(!a_distanceFunctions.empty());
   EBGEOMETRY_EXPECT(a_distanceFunctions.size() == a_boundingVolumes.size());
@@ -554,22 +549,21 @@ BVHSmoothUnionIF<T, P, BV, K>::BVHSmoothUnionIF(
   this->buildTree(primsAndBVs);
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
-  m_smoothMin = a_smoothMin;
 
   this->m_sdf = false;
 }
 
-template <class T, class P, class BV, size_t K>
+template <class T, class P, class BV, size_t K, class Blend>
 void
-BVHSmoothUnionIF<T, P, BV, K>::buildTree(const std::vector<std::pair<std::shared_ptr<const P>, BV>>& a_primsAndBVs,
-                                         const BVH::Build                                            a_build) noexcept
+BVHSmoothUnionIF<T, P, BV, K, Blend>::buildTree(
+  const std::vector<std::pair<std::shared_ptr<const P>, BV>>& a_primsAndBVs, const BVH::Build a_build) noexcept
 {
   m_bvh = CSGDetail::buildBVH<T, P, BV, K>(a_primsAndBVs, a_build);
 }
 
-template <class T, class P, class BV, size_t K>
+template <class T, class P, class BV, size_t K, class Blend>
 T
-BVHSmoothUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
+BVHSmoothUnionIF<T, P, BV, K, Blend>::value(const Vec3T<T>& a_point) const noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
 
@@ -617,12 +611,12 @@ BVHSmoothUnionIF<T, P, BV, K>::value(const Vec3T<T>& a_point) const noexcept
 
   m_bvh->pruneTraverse(a_point, closest, evalLeaf, pruneDist2);
 
-  return m_smoothMin(closest.a, closest.b, m_smoothLen);
+  return Blend::eval(closest.a, closest.b, m_smoothLen);
 }
 
-template <class T, class P, class BV, size_t K>
+template <class T, class P, class BV, size_t K, class Blend>
 const EBGeometry::BoundingVolumes::AABBT<T>&
-BVHSmoothUnionIF<T, P, BV, K>::getBoundingVolume() const noexcept
+BVHSmoothUnionIF<T, P, BV, K, Blend>::getBoundingVolume() const noexcept
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
 
@@ -664,12 +658,10 @@ IntersectionIF<T>::value(const Vec3T<T>& a_point) const noexcept
   return ret;
 }
 
-template <class T>
-SmoothIntersectionIF<T>::SmoothIntersectionIF(
-  const std::shared_ptr<ImplicitFunction<T>>&           a_implicitFunctionA,
-  const std::shared_ptr<ImplicitFunction<T>>&           a_implicitFunctionB,
-  const T                                               a_smoothLen,
-  const std::function<T(const T&, const T&, const T&)>& a_smoothMax) noexcept
+template <class T, class Blend>
+SmoothIntersectionIF<T, Blend>::SmoothIntersectionIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionA,
+                                                     const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionB,
+                                                     const T                                     a_smoothLen) noexcept
 {
   EBGEOMETRY_EXPECT(a_implicitFunctionA != nullptr);
   EBGEOMETRY_EXPECT(a_implicitFunctionB != nullptr);
@@ -679,16 +671,13 @@ SmoothIntersectionIF<T>::SmoothIntersectionIF(
   m_implicitFunctions.emplace_back(a_implicitFunctionB);
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
-  m_smoothMax = a_smoothMax;
 
   this->m_sdf = false;
 }
 
-template <class T>
-SmoothIntersectionIF<T>::SmoothIntersectionIF(
-  const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_implicitFunctions,
-  const T                                                  a_smoothLen,
-  const std::function<T(const T&, const T&, const T&)>&    a_smoothMax) noexcept
+template <class T, class Blend>
+SmoothIntersectionIF<T, Blend>::SmoothIntersectionIF(
+  const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_implicitFunctions, const T a_smoothLen) noexcept
 {
   EBGEOMETRY_EXPECT(!a_implicitFunctions.empty());
   EBGEOMETRY_EXPECT(a_smoothLen > T(0));
@@ -700,14 +689,13 @@ SmoothIntersectionIF<T>::SmoothIntersectionIF(
   }
 
   m_smoothLen = std::max(a_smoothLen, std::numeric_limits<T>::min());
-  m_smoothMax = a_smoothMax;
 
   this->m_sdf = false;
 }
 
-template <class T>
+template <class T, class Blend>
 T
-SmoothIntersectionIF<T>::value(const Vec3T<T>& a_point) const noexcept
+SmoothIntersectionIF<T, Blend>::value(const Vec3T<T>& a_point) const noexcept
 {
   T ret = std::numeric_limits<T>::infinity();
 
@@ -734,7 +722,7 @@ SmoothIntersectionIF<T>::value(const Vec3T<T>& a_point) const noexcept
       }
     }
 
-    ret = m_smoothMax(a, b, m_smoothLen);
+    ret = Blend::eval(a, b, m_smoothLen);
   }
 
   return ret;
@@ -779,29 +767,26 @@ DifferenceIF<T>::value(const Vec3T<T>& a_point) const noexcept
   return DifferenceOp<T>::combine(a, b);
 }
 
-template <class T>
-SmoothDifferenceIF<T>::SmoothDifferenceIF(
-  const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionA,
-  const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionB,
-  const T                                                     a_smoothLen,
-  const std::function<T(const T& a, const T& b, const T& s)>& a_smoothMax) noexcept
+template <class T, class Blend>
+SmoothDifferenceIF<T, Blend>::SmoothDifferenceIF(const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionA,
+                                                 const std::shared_ptr<ImplicitFunction<T>>& a_implicitFunctionB,
+                                                 const T                                     a_smoothLen) noexcept
 {
   EBGEOMETRY_EXPECT(a_implicitFunctionA != nullptr);
   EBGEOMETRY_EXPECT(a_implicitFunctionB != nullptr);
   EBGEOMETRY_EXPECT(a_smoothLen > T(0));
 
-  m_smoothIntersectionIF = std::make_shared<SmoothIntersectionIF<T>>(
-    a_implicitFunctionA, EBGeometry::Complement<T>(a_implicitFunctionB), a_smoothLen, a_smoothMax);
+  m_smoothIntersectionIF = std::make_shared<SmoothIntersectionIF<T, Blend>>(
+    a_implicitFunctionA, EBGeometry::Complement<T>(a_implicitFunctionB), a_smoothLen);
 
   this->m_sdf = false;
 }
 
-template <class T>
-SmoothDifferenceIF<T>::SmoothDifferenceIF(
-  const std::shared_ptr<ImplicitFunction<T>>&                 a_implicitFunctionA,
-  const std::vector<std::shared_ptr<ImplicitFunction<T>>>&    a_implicitFunctionsB,
-  const T                                                     a_smoothLen,
-  const std::function<T(const T& a, const T& b, const T& s)>& a_smoothMax) noexcept
+template <class T, class Blend>
+SmoothDifferenceIF<T, Blend>::SmoothDifferenceIF(
+  const std::shared_ptr<ImplicitFunction<T>>&              a_implicitFunctionA,
+  const std::vector<std::shared_ptr<ImplicitFunction<T>>>& a_implicitFunctionsB,
+  const T                                                  a_smoothLen) noexcept
 {
   EBGEOMETRY_EXPECT(a_implicitFunctionA != nullptr);
   EBGEOMETRY_EXPECT(!a_implicitFunctionsB.empty());
@@ -818,14 +803,14 @@ SmoothDifferenceIF<T>::SmoothDifferenceIF(
     implicitFunctions.emplace_back(EBGeometry::Complement<T>(subtractedFunction));
   }
 
-  m_smoothIntersectionIF = std::make_shared<SmoothIntersectionIF<T>>(implicitFunctions, a_smoothLen, a_smoothMax);
+  m_smoothIntersectionIF = std::make_shared<SmoothIntersectionIF<T, Blend>>(implicitFunctions, a_smoothLen);
 
   this->m_sdf = false;
 }
 
-template <class T>
+template <class T, class Blend>
 T
-SmoothDifferenceIF<T>::value(const Vec3T<T>& a_point) const noexcept
+SmoothDifferenceIF<T, Blend>::value(const Vec3T<T>& a_point) const noexcept
 {
   EBGEOMETRY_EXPECT(m_smoothIntersectionIF != nullptr);
 

--- a/Source/EBGeometry_ImplicitFunction.hpp
+++ b/Source/EBGeometry_ImplicitFunction.hpp
@@ -136,7 +136,8 @@ public:
    * @details Non-pure virtual: the base default emits a single opaque host-callback clause that, at
    * evaluation, invokes this node's value() on the host. Trait-based leaves and the CSG/transform
    * nodes override this to emit native clauses; any node without an override (Perlin, Blur, Mollify,
-   * FiniteRepetition, the BVH unions, or a user subclass) keeps the opaque-host default. Host only.
+   * FiniteRepetition, or a user subclass) keeps the opaque-host default; the BVH unions emit native
+   * BVH clauses (falling back to this default only when nested inside another BVH leaf). Host only.
    * @param[in,out] a_builder   Tape builder accumulating the flattened clauses.
    * @param[in]     a_coordSlot Coordinate slot holding this subtree's input frame.
    * @return Value slot holding this subtree's result.

--- a/Source/EBGeometry_Tape.hpp
+++ b/Source/EBGeometry_Tape.hpp
@@ -320,6 +320,7 @@ struct TapeBVHNode
 };
 
 static_assert(std::is_trivially_copyable_v<TapeBVHNode<float>>, "TapeBVHNode must be trivially copyable");
+static_assert(std::is_trivially_copyable_v<TapeBVHNode<double>>, "TapeBVHNode must be trivially copyable");
 
 /**
  * @brief One BVH leaf primitive: a clause sub-range of the same tape holding its flattened subtree.
@@ -392,9 +393,10 @@ struct TapeBVHBlock
 };
 
 static_assert(std::is_trivially_copyable_v<TapeBVHBlock<float>>, "TapeBVHBlock must be trivially copyable");
+static_assert(std::is_trivially_copyable_v<TapeBVHBlock<double>>, "TapeBVHBlock must be trivially copyable");
 
 /**
- * @brief A single trivially-copyable clause in the flat tape (16 bytes).
+ * @brief A single trivially-copyable clause in the flat tape (20 bytes).
  * @details One clause performs exactly one operation. The @ref opcode selects which trait static
  * runs and which slot files @ref in0 / @ref in1 / @ref out address (coordinate slots for coordinate
  * transforms, value slots otherwise); the interpreter never branches on anything but @ref opcode.
@@ -408,10 +410,12 @@ struct TapeClause
 
   /**
    * @brief Index into this op's parameter array. For a smooth combiner it indexes the shared scalar
-   * (smoothing length) array; for a HOST_CALLBACK it indexes the host-node array; unused for sharp
-   * combiners.
+   * (smoothing length) array; for a BVH clause it indexes the BVH block array; for a HOST_CALLBACK
+   * it indexes the host-node array; unused for sharp combiners. 32 bits wide so that unions over
+   * hundreds of thousands of primitives -- the BVH_UNION use case -- cannot overflow it (two padding
+   * bytes follow the opcode; the clause is 20 bytes).
    */
-  uint16_t paramIndex;
+  uint32_t paramIndex;
 
   /**
    * @brief First input slot. Coordinate slot for leaves, coordinate transforms, and host callbacks;
@@ -430,7 +434,7 @@ struct TapeClause
   uint32_t out;
 };
 
-static_assert(sizeof(TapeClause) == 16, "TapeClause must be 16 bytes");
+static_assert(sizeof(TapeClause) == 20, "TapeClause must be 20 bytes");
 static_assert(std::is_trivially_copyable_v<TapeClause>, "TapeClause must be trivially copyable");
 
 /**

--- a/Source/EBGeometry_Tape.hpp
+++ b/Source/EBGeometry_Tape.hpp
@@ -34,6 +34,7 @@
 
 // Our includes
 #include "EBGeometry_AnalyticDistanceFunctions.hpp"
+#include "EBGeometry_BoundingVolumes.hpp"
 #include "EBGeometry_CSG.hpp"
 #include "EBGeometry_GPU.hpp"
 #include "EBGeometry_ImplicitFunction.hpp"
@@ -156,6 +157,11 @@ enum class Opcode : uint16_t
   SMOOTH_MIN,       ///< Smooth combiner: polynomial smooth minimum (SmoothMinOp::eval).
   SMOOTH_MAX,       ///< Smooth combiner: polynomial smooth maximum (SmoothMaxOp::eval).
   EXP_MIN,          ///< Smooth combiner: exponential smooth minimum (ExpMinOp::eval).
+  BVH_UNION,        ///< BVH-pruned sharp union: valueSlot[out] = min over all non-culled leaf
+                    ///  subtrees. paramIndex indexes the TapeBVHBlock array; in0 is the input
+                    ///  coordinate slot.
+  BVH_SMOOTH_UNION, ///< BVH-pruned smooth union: the two nearest leaf-subtree values, blended with
+                    ///  the block's registered smooth operator. Same operand layout as BVH_UNION.
   HOST_CALLBACK     ///< Opaque host node: valueSlot[out] = node->value(coordSlot[in0]). Host only.
 };
 #else
@@ -166,7 +172,9 @@ enum class Opcode : uint16_t
     EBGEOMETRY_TAPE_MAPVALUE_OPS(EBGEOMETRY_TAPE_ENUM_ENTRY) EBGEOMETRY_TAPE_COMBINE_OPS(EBGEOMETRY_TAPE_ENUM_ENTRY)
       EBGEOMETRY_TAPE_SMOOTH_OPS(EBGEOMETRY_TAPE_ENUM_ENTRY)
 #undef EBGEOMETRY_TAPE_ENUM_ENTRY
-        HOST_CALLBACK
+        BVH_UNION,
+  BVH_SMOOTH_UNION,
+  HOST_CALLBACK
 };
 #endif
 
@@ -249,6 +257,141 @@ inline constexpr bool isRegisteredBlend = false;
 template <class Blend>
 inline constexpr bool isRegisteredBlend<Blend, std::void_t<decltype(BlendOpcodeOf<Blend>::value)>> = true;
 /// @endcond
+
+/**
+ * @brief Fixed traversal-stack capacity for the tape-internal BVH traversal.
+ * @details Mirrors the fixed 256-entry stacks used by every SIMD path of
+ * @c BVH::PackedBVH::pruneTraverse; guarded by @c EBGEOMETRY_EXPECT at push time.
+ */
+inline constexpr uint32_t TapeBVHStackSize = 256;
+
+/**
+ * @brief Maximum number of children per tape-internal BVH node.
+ * @details Covers every SIMD-supported branching factor K of @c BVH::PackedBVH; enforced by
+ * @c static_assert in the BVH-union @c flatten overrides and by @c EBGEOMETRY_EXPECT in
+ * @ref TapeBuilder::emitBVHUnion.
+ */
+inline constexpr uint32_t TapeBVHMaxChildren = 16;
+
+/**
+ * @brief One flattened BVH node stored in the tape's shared BVH node array.
+ * @details All index fields are global indices into the tape's shared @c bvhNodes / @c bvhChildren
+ * / @c bvhLeaves arrays (blocks are appended back to back, so no per-block base arithmetic is
+ * needed at query time). The bounding box is stored as raw corners rather than an
+ * @c BoundingVolumes::AABBT (whose user-provided copy constructor makes it not trivially
+ * copyable); the interpreter rebuilds an @c AABBT on the fly and evaluates its
+ * @c getDistance2 -- the single source of truth for the point-to-box distance.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct TapeBVHNode
+{
+  /**
+   * @brief Low corner of this node's axis-aligned bounding box.
+   */
+  Vec3T<T> lo;
+
+  /**
+   * @brief High corner of this node's axis-aligned bounding box.
+   */
+  Vec3T<T> hi;
+
+  /**
+   * @brief Interior nodes: index of the first entry in the shared child array (entries are global
+   * node indices). Unused for leaves.
+   */
+  uint32_t childBegin = 0;
+
+  /**
+   * @brief Interior nodes: number of children (the K of the source PackedBVH). Zero for leaves.
+   */
+  uint32_t childCount = 0;
+
+  /**
+   * @brief Leaves: index of the first entry in the shared leaf array. Unused for interior nodes.
+   */
+  uint32_t leafBegin = 0;
+
+  /**
+   * @brief Leaves: number of leaf primitives; a value greater than zero marks this node as a leaf
+   * (mirroring @c PackedBVH::Node::isLeaf).
+   */
+  uint32_t leafCount = 0;
+};
+
+static_assert(std::is_trivially_copyable_v<TapeBVHNode<float>>, "TapeBVHNode must be trivially copyable");
+
+/**
+ * @brief One BVH leaf primitive: a clause sub-range of the same tape holding its flattened subtree.
+ * @details The sub-range lives in the tape's deferred region @c [numMainClauses, numClauses) and is
+ * executed on demand by a BVH clause; after the range has run, @ref valueSlot holds the subtree's
+ * value at the query point.
+ */
+struct TapeBVHLeaf
+{
+  /**
+   * @brief First clause of the subtree, inside the deferred region.
+   */
+  uint32_t clauseBegin = 0;
+
+  /**
+   * @brief Number of clauses in the subtree (always at least one).
+   */
+  uint32_t clauseCount = 0;
+
+  /**
+   * @brief Value slot holding the subtree's result after the sub-range has executed.
+   */
+  uint32_t valueSlot = 0;
+};
+
+static_assert(std::is_trivially_copyable_v<TapeBVHLeaf>, "TapeBVHLeaf must be trivially copyable");
+
+/**
+ * @brief Per-clause header of one BVH-union block, indexed by the clause's @c paramIndex.
+ * @details Ties one BVH_UNION / BVH_SMOOTH_UNION clause to its slice of the tape's shared BVH
+ * arrays. The blend tag is a tape-internal selector (the smooth opcode of the block's registered
+ * blend operator); the public choice of blend is the @c Blend template parameter of
+ * @c BVHSmoothUnionIF.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+struct TapeBVHBlock
+{
+  /**
+   * @brief Smoothing length (BVH_SMOOTH_UNION only; zero for BVH_UNION).
+   */
+  T smoothLen = T(0);
+
+  /**
+   * @brief Global index of this block's root node in the shared BVH node array.
+   */
+  uint32_t rootNode = 0;
+
+  /**
+   * @brief Number of nodes in this block (validation/debugging).
+   */
+  uint32_t numNodes = 0;
+
+  /**
+   * @brief Index of this block's first entry in the shared leaf array.
+   */
+  uint32_t leafBegin = 0;
+
+  /**
+   * @brief Total number of leaf primitives in this block.
+   */
+  uint32_t numLeaves = 0;
+
+  /**
+   * @brief Tape-internal blend tag (BVH_SMOOTH_UNION only): the smooth opcode (SMOOTH_MIN,
+   * SMOOTH_MAX, or EXP_MIN) whose trait the interpreter's epilogue applies to the two nearest
+   * values. Unused for BVH_UNION.
+   */
+  Opcode blend = Opcode::SMOOTH_MIN;
+};
+
+static_assert(std::is_trivially_copyable_v<TapeBVHBlock<float>>, "TapeBVHBlock must be trivially copyable");
 
 /**
  * @brief A single trivially-copyable clause in the flat tape (16 bytes).
@@ -338,6 +481,33 @@ struct TapeView
   const ImplicitFunction<T>* const* hostNodes = nullptr;
 
   /**
+   * @brief Pointer to the shared BVH node array indexed (via TapeBVHBlock) by BVH clauses.
+   */
+  const TapeBVHNode<T>* bvhNodes = nullptr;
+
+  /**
+   * @brief Pointer to the shared BVH child-index array (entries are global node indices).
+   */
+  const uint32_t* bvhChildren = nullptr;
+
+  /**
+   * @brief Pointer to the shared BVH leaf array (clause sub-ranges of this same tape).
+   */
+  const TapeBVHLeaf* bvhLeaves = nullptr;
+
+  /**
+   * @brief Pointer to the per-clause BVH block headers indexed by a BVH clause's paramIndex.
+   */
+  const TapeBVHBlock<T>* bvhBlocks = nullptr;
+
+  /**
+   * @brief Main-pass clause bound: the forward pass executes clauses [0, numMainClauses); the
+   * deferred region [numMainClauses, numClauses) holds BVH leaf subtrees executed on demand by
+   * BVH clauses. Equal to numClauses for a tape without BVH clauses.
+   */
+  uint32_t numMainClauses = 0;
+
+  /**
    * @brief Number of coordinate slots the interpreter's coordinate scratch buffer must hold.
    */
   uint32_t numCoordSlots = 0;
@@ -359,9 +529,12 @@ struct TapeView
 
   /**
    * @brief Evaluate the tape at a point via a single forward pass (host and device).
-   * @details Runs each clause in order, dispatching to the shared trait static functions. The
-   * caller supplies scratch buffers sized to the tape's slot counts (@ref numCoordSlots coordinate
-   * slots and @ref numValueSlots value slots). A HOST_CALLBACK clause is only valid on the host.
+   * @details Runs each main-region clause (indices [0, @ref numMainClauses)) in order, dispatching
+   * to the shared trait static functions; a BVH clause additionally runs a pruned, iterative
+   * traversal that executes non-culled leaf sub-ranges from the deferred clause region on demand.
+   * The caller supplies scratch buffers sized to the tape's slot counts (@ref numCoordSlots
+   * coordinate slots and @ref numValueSlots value slots). A HOST_CALLBACK clause is only valid on
+   * the host.
    * @param[in]  a_point        Query point.
    * @param[out] a_coordScratch Coordinate scratch buffer (at least @ref numCoordSlots entries).
    * @param[out] a_valueScratch Value scratch buffer (at least @ref numValueSlots entries).
@@ -459,6 +632,59 @@ public:
     return m_clauses;
   }
 
+  /**
+   * @brief Get the main-pass clause bound.
+   * @details The forward pass executes clauses [0, numMainClauses); clauses in
+   * [numMainClauses, numClauses) are BVH leaf subtrees executed on demand by BVH clauses. Equal to
+   * the total clause count for a tape without BVH clauses.
+   * @return Number of main-region clauses.
+   */
+  [[nodiscard]] uint32_t
+  getNumMainClauses() const noexcept
+  {
+    return m_numMainClauses;
+  }
+
+  /**
+   * @brief Get the shared BVH node array.
+   * @return Const reference to the BVH node vector.
+   */
+  [[nodiscard]] const std::vector<TapeBVHNode<T>>&
+  getBVHNodes() const noexcept
+  {
+    return m_bvhNodes;
+  }
+
+  /**
+   * @brief Get the shared BVH child-index array (entries are global node indices).
+   * @return Const reference to the BVH child-index vector.
+   */
+  [[nodiscard]] const std::vector<uint32_t>&
+  getBVHChildren() const noexcept
+  {
+    return m_bvhChildren;
+  }
+
+  /**
+   * @brief Get the shared BVH leaf array.
+   * @return Const reference to the BVH leaf vector.
+   */
+  [[nodiscard]] const std::vector<TapeBVHLeaf>&
+  getBVHLeaves() const noexcept
+  {
+    return m_bvhLeaves;
+  }
+
+  /**
+   * @brief Get the per-clause BVH block headers.
+   * @return Const reference to the BVH block vector.
+   */
+  [[nodiscard]] const std::vector<TapeBVHBlock<T>>&
+  getBVHBlocks() const noexcept
+  {
+    return m_bvhBlocks;
+  }
+
 private:
   friend class TapeBuilder<T>;
 
@@ -483,6 +709,32 @@ private:
    * @brief Opaque host nodes indexed by HOST_CALLBACK clauses (raw, non-owning back-pointers).
    */
   std::vector<const ImplicitFunction<T>*> m_hostNodes;
+
+  /**
+   * @brief Shared BVH node array (all blocks appended back to back; global indices).
+   */
+  std::vector<TapeBVHNode<T>> m_bvhNodes;
+
+  /**
+   * @brief Shared BVH child-index array (entries are global node indices; may contain duplicates
+   * when the source PackedBVH padded an interior node by repeating a child).
+   */
+  std::vector<uint32_t> m_bvhChildren;
+
+  /**
+   * @brief Shared BVH leaf array (clause sub-ranges of this same tape).
+   */
+  std::vector<TapeBVHLeaf> m_bvhLeaves;
+
+  /**
+   * @brief Per-clause BVH block headers indexed by a BVH clause's paramIndex.
+   */
+  std::vector<TapeBVHBlock<T>> m_bvhBlocks;
+
+  /**
+   * @brief Main-pass clause bound (see @ref getNumMainClauses).
+   */
+  uint32_t m_numMainClauses = 0;
 
   /**
    * @brief Number of coordinate slots.
@@ -518,6 +770,36 @@ class TapeBuilder
   static_assert(std::is_floating_point_v<T>, "TapeBuilder<T>: T must be a floating-point type");
 
 public:
+  /**
+   * @brief Block-local, K-erased description of one PackedBVH node (host-only build type).
+   * @details Produced by the BVH-union @c flatten overrides from @c PackedBVH::getNodes and
+   * consumed by @ref emitBVHUnion, which globalises the block-local indices into the tape's shared
+   * BVH arrays.
+   */
+  struct BVHNodeInfo
+  {
+    /**
+     * @brief Axis-aligned bounding box of this node's subtree.
+     */
+    BoundingVolumes::AABBT<T> aabb;
+
+    /**
+     * @brief Leaves: block-local index of the first primitive (leaf-traversal order).
+     */
+    uint32_t primOff = 0;
+
+    /**
+     * @brief Leaves: number of primitives; a value greater than zero marks this node as a leaf.
+     */
+    uint32_t numPrims = 0;
+
+    /**
+     * @brief Interior nodes: block-local node indices of the children (size K of the source
+     * PackedBVH; duplicates from PackedBVH's power-of-K padding are kept verbatim).
+     */
+    std::vector<uint32_t> children;
+  };
+
   /**
    * @brief Default constructor. Constructs a builder over an empty tape.
    */
@@ -605,7 +887,48 @@ public:
   emitHostCallback(int a_inCoord, const ImplicitFunction<T>* a_node);
 
   /**
+   * @brief Emit a BVH-pruned union clause (sharp or smooth) and record its leaf primitives for
+   * deferred flattening.
+   * @details Globalises @p a_nodes into the tape's shared BVH arrays, appends the block header and
+   * the BVH clause, and records the primitives on a pending list; @ref finish later flattens every
+   * pending primitive's subtree into the tape's deferred clause region. Every leaf subtree is
+   * flattened against the same input frame @p a_inCoord (matching UnionIF::flatten's convention).
+   * @param[in] a_inCoord    Input coordinate slot.
+   * @param[in] a_nodes      Block-local node descriptions, depth-first with the root first.
+   * @param[in] a_primitives Leaf primitives in leaf-traversal order (non-owning; must stay alive
+   * until @ref finish has run).
+   * @param[in] a_smooth     True for BVH_SMOOTH_UNION, false for BVH_UNION.
+   * @param[in] a_blend      Tape-internal blend tag (SMOOTH_MIN, SMOOTH_MAX, or EXP_MIN); only
+   * read for the smooth variant.
+   * @param[in] a_smoothLen  Smoothing length (must be positive for the smooth variant; pass zero
+   * for the sharp union).
+   * @return Value slot holding the union's result.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST int
+  emitBVHUnion(int                                       a_inCoord,
+               std::vector<BVHNodeInfo>&&                a_nodes,
+               std::vector<const ImplicitFunction<T>*>&& a_primitives,
+               bool                                      a_smooth,
+               Opcode                                    a_blend,
+               T                                         a_smoothLen);
+
+  /**
+   * @brief Whether the builder is currently flattening a BVH leaf subtree (finish's deferred
+   * phase).
+   * @details Used by the BVH-union @c flatten overrides to route a nested BVH union to an opaque
+   * host callback: the tape's interpreter executes leaf sub-ranges through an inner clause loop
+   * that does not itself handle BVH clauses (that would require a per-nesting-level traversal
+   * stack), so a BVH union inside a BVH leaf must stay opaque in this tier.
+   * @return True while @ref finish is flattening pending BVH leaf subtrees.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST bool
+  isFlatteningBVHLeaf() const noexcept;
+
+  /**
    * @brief Finalise and hand back the built tape.
+   * @details Freezes the main clause region, then flattens every pending BVH block's leaf
+   * primitives into the deferred clause region (reusing one shared coordinate/value slot window
+   * across all leaves; see the implementation for why that is safe).
    * @param[in] a_rootValueSlot Value slot holding the whole tree's result.
    * @return The completed tape (moved out of the builder).
    */
@@ -623,9 +946,41 @@ private:
                                 paramArrayFor();
 
   /**
+   * @brief One BVH block recorded by @ref emitBVHUnion whose leaf subtrees still await flattening.
+   */
+  struct PendingBVHBlock
+  {
+    /**
+     * @brief Index of the block in the tape's BVH block array.
+     */
+    uint32_t blockIndex = 0;
+
+    /**
+     * @brief Coordinate slot every leaf subtree of this block is flattened against.
+     */
+    int coordSlot = 0;
+
+    /**
+     * @brief Leaf primitives in leaf-traversal order (non-owning).
+     */
+    std::vector<const ImplicitFunction<T>*> primitives;
+  };
+
+  /**
    * @brief The tape being assembled; moved out by @ref finish.
    */
   Tape<T> m_tape;
+
+  /**
+   * @brief BVH blocks awaiting the deferred leaf-flattening phase of @ref finish.
+   */
+  std::vector<PendingBVHBlock> m_pendingBlocks;
+
+  /**
+   * @brief True while @ref finish is flattening pending BVH leaf subtrees (see
+   * @ref isFlatteningBVHLeaf).
+   */
+  bool m_flatteningBVHLeaf = false;
 };
 
 /**

--- a/Source/EBGeometry_Tape.hpp
+++ b/Source/EBGeometry_Tape.hpp
@@ -211,6 +211,46 @@ template <class Op>
 inline constexpr bool IsRegistered = OpcodeOf<Op>::registered;
 
 /**
+ * @brief Compile-time map from a smooth-blend operator trait to its interpreter @ref Opcode.
+ * @details The primary template is deliberately empty (no nested @c value) so that a smooth
+ * combiner instantiated with an unregistered custom @c Blend falls back to an opaque host callback
+ * in its @c flatten. The X-macro-generated specialisations (one per smooth op in the ISA) expose
+ * the matching opcode as @c value.
+ * @tparam Blend Smooth-blend operator trait (e.g. @c SmoothMinOp<T>).
+ */
+template <class Blend>
+struct BlendOpcodeOf
+{
+};
+
+/// @cond EBGEOMETRY_INTERNAL
+#define EBGEOMETRY_TAPE_BLEND_OPCODEOF(TAG, OP)  \
+  template <class T>                             \
+  struct BlendOpcodeOf<OP<T>>                    \
+  {                                              \
+    static constexpr Opcode value = Opcode::TAG; \
+  };
+EBGEOMETRY_TAPE_SMOOTH_OPS(EBGEOMETRY_TAPE_BLEND_OPCODEOF)
+#undef EBGEOMETRY_TAPE_BLEND_OPCODEOF
+/// @endcond
+
+/**
+ * @brief Detection trait: true iff @c Blend has a registered smooth @ref Opcode (i.e.
+ * @ref BlendOpcodeOf exposes a nested @c value for it).
+ * @details Used by the smooth combiners' @c flatten with @c if @c constexpr so that a registered
+ * blend (SmoothMinOp, SmoothMaxOp, ExpMinOp) lowers to a native smooth clause while an unregistered
+ * custom blend lowers to an opaque host callback.
+ * @tparam Blend Smooth-blend operator trait.
+ */
+template <class Blend, class = void>
+inline constexpr bool isRegisteredBlend = false;
+
+/// @cond EBGEOMETRY_INTERNAL
+template <class Blend>
+inline constexpr bool isRegisteredBlend<Blend, std::void_t<decltype(BlendOpcodeOf<Blend>::value)>> = true;
+/// @endcond
+
+/**
  * @brief A single trivially-copyable clause in the flat tape (16 bytes).
  * @details One clause performs exactly one operation. The @ref opcode selects which trait static
  * runs and which slot files @ref in0 / @ref in1 / @ref out address (coordinate slots for coordinate

--- a/Source/EBGeometry_TapeImplem.hpp
+++ b/Source/EBGeometry_TapeImplem.hpp
@@ -17,12 +17,16 @@
 #define EBGEOMETRY_TAPEIMPLEM_HPP
 
 // Std includes
+#include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 // Our includes
+#include "EBGeometry_BVH.hpp"
+#include "EBGeometry_BoundingVolumes.hpp"
 #include "EBGeometry_CSG.hpp"
 #include "EBGeometry_ImplicitFunction.hpp"
 #include "EBGeometry_Macros.hpp"
@@ -58,6 +62,12 @@ Tape<T>::view() const noexcept
   v.scalarParams = m_scalarParams.data();
   v.hostNodes    = m_hostNodes.data();
 
+  v.bvhNodes    = m_bvhNodes.data();
+  v.bvhChildren = m_bvhChildren.data();
+  v.bvhLeaves   = m_bvhLeaves.data();
+  v.bvhBlocks   = m_bvhBlocks.data();
+
+  v.numMainClauses = m_numMainClauses;
   v.numCoordSlots  = m_numCoordSlots;
   v.numValueSlots  = m_numValueSlots;
   v.rootValueSlot  = m_rootValueSlot;
@@ -207,9 +217,164 @@ TapeBuilder<T>::emitHostCallback(int a_inCoord, const ImplicitFunction<T>* a_nod
 }
 
 template <class T>
+int
+TapeBuilder<T>::emitBVHUnion(int                                       a_inCoord,
+                             std::vector<BVHNodeInfo>&&                a_nodes,
+                             std::vector<const ImplicitFunction<T>*>&& a_primitives,
+                             bool                                      a_smooth,
+                             Opcode                                    a_blend,
+                             T                                         a_smoothLen)
+{
+  // Belt-and-braces nesting guard: the BVH flatten overrides already route a nested BVH union to
+  // emitHostCallback while finish()'s deferred phase runs.
+  EBGEOMETRY_EXPECT(!m_flatteningBVHLeaf);
+  EBGEOMETRY_EXPECT(!a_nodes.empty());
+  EBGEOMETRY_EXPECT(!a_primitives.empty());
+  EBGEOMETRY_EXPECT(a_smooth || a_smoothLen == T(0));
+  EBGEOMETRY_EXPECT(!a_smooth || a_smoothLen > T(0));
+
+  const int out = this->newValueSlot();
+
+  const size_t blockIndex = m_tape.m_bvhBlocks.size();
+
+  EBGEOMETRY_EXPECT(blockIndex <= size_t(std::numeric_limits<uint16_t>::max()));
+
+  // Globalise the block-local node/child/leaf indices into the tape's shared arrays (blocks are
+  // appended back to back, so a block-local index maps to base + local).
+  const uint32_t nodeBase = static_cast<uint32_t>(m_tape.m_bvhNodes.size());
+  const uint32_t leafBase = static_cast<uint32_t>(m_tape.m_bvhLeaves.size());
+
+  for (const auto& info : a_nodes) {
+    TapeBVHNode<T> node;
+
+    node.lo = info.aabb.getLowCorner();
+    node.hi = info.aabb.getHighCorner();
+
+    if (info.numPrims > 0) {
+      EBGEOMETRY_EXPECT(info.children.empty());
+      EBGEOMETRY_EXPECT(size_t(info.primOff) + size_t(info.numPrims) <= a_primitives.size());
+
+      node.leafBegin = leafBase + info.primOff;
+      node.leafCount = info.numPrims;
+    }
+    else {
+      EBGEOMETRY_EXPECT(!info.children.empty());
+      EBGEOMETRY_EXPECT(info.children.size() <= size_t(TapeBVHMaxChildren));
+
+      node.childBegin = static_cast<uint32_t>(m_tape.m_bvhChildren.size());
+      node.childCount = static_cast<uint32_t>(info.children.size());
+
+      for (const uint32_t child : info.children) {
+        EBGEOMETRY_EXPECT(size_t(child) < a_nodes.size());
+
+        m_tape.m_bvhChildren.push_back(nodeBase + child);
+      }
+    }
+
+    m_tape.m_bvhNodes.push_back(node);
+  }
+
+  // Placeholder leaf entries; finish()'s deferred phase fills them once each primitive's subtree
+  // has been flattened into the tail clause region.
+  m_tape.m_bvhLeaves.resize(size_t(leafBase) + a_primitives.size());
+
+  TapeBVHBlock<T> block;
+
+  block.smoothLen = a_smoothLen;
+  block.rootNode  = nodeBase;
+  block.numNodes  = static_cast<uint32_t>(a_nodes.size());
+  block.leafBegin = leafBase;
+  block.numLeaves = static_cast<uint32_t>(a_primitives.size());
+  block.blend     = a_blend;
+
+  m_tape.m_bvhBlocks.push_back(block);
+
+  m_tape.m_clauses.push_back(TapeClause{a_smooth ? Opcode::BVH_SMOOTH_UNION : Opcode::BVH_UNION,
+                                        static_cast<uint16_t>(blockIndex),
+                                        static_cast<uint32_t>(a_inCoord),
+                                        0,
+                                        static_cast<uint32_t>(out)});
+
+  m_pendingBlocks.push_back(PendingBVHBlock{static_cast<uint32_t>(blockIndex), a_inCoord, std::move(a_primitives)});
+
+  return out;
+}
+
+template <class T>
+bool
+TapeBuilder<T>::isFlatteningBVHLeaf() const noexcept
+{
+  return m_flatteningBVHLeaf;
+}
+
+template <class T>
 Tape<T>
 TapeBuilder<T>::finish(int a_rootValueSlot)
 {
+  // Freeze the main clause region; everything appended below lands in the deferred region
+  // [numMainClauses, numClauses) and only runs on demand through a BVH clause.
+  m_tape.m_numMainClauses = static_cast<uint32_t>(m_tape.m_clauses.size());
+
+  // Slot-window reuse across BVH leaves: all leaf subtrees (of ALL blocks) share one coordinate/
+  // value slot window starting at the main program's slot counts. This is safe because
+  //
+  //   1. leaf sub-ranges execute strictly sequentially -- the interpreter runs one leaf's clause
+  //      range to completion and folds its valueSlot into the traversal state immediately, before
+  //      any other leaf (of this or any other BVH clause) executes, so no two leaves' slots are
+  //      ever live at the same time;
+  //   2. a leaf subtree reads nothing from the main program except its input coordinate slot
+  //      (block.coordSlot, allocated during the main phase and therefore below the window base),
+  //      and writes only slots it allocates itself (inside the window) -- asserted below;
+  //   3. a BVH clause's own output slot is likewise allocated during the main phase, so folding a
+  //      block's result cannot be clobbered by a later block's leaves.
+  //
+  // Scratch is therefore sized as main program + max over leaves instead of main + sum over
+  // leaves.
+  const uint32_t coordBase = m_tape.m_numCoordSlots;
+  const uint32_t valueBase = m_tape.m_numValueSlots;
+
+  uint32_t maxCoordSlots = coordBase;
+  uint32_t maxValueSlots = valueBase;
+
+  const size_t numPendingBlocks = m_pendingBlocks.size();
+
+  m_flatteningBVHLeaf = true;
+
+  for (const auto& block : m_pendingBlocks) {
+    EBGEOMETRY_EXPECT(block.coordSlot >= 0);
+    EBGEOMETRY_EXPECT(static_cast<uint32_t>(block.coordSlot) < coordBase);
+
+    for (size_t i = 0; i < block.primitives.size(); i++) {
+      // Rewind the slot counters to the shared window base before each leaf.
+      m_tape.m_numCoordSlots = coordBase;
+      m_tape.m_numValueSlots = valueBase;
+
+      const uint32_t begin = static_cast<uint32_t>(m_tape.m_clauses.size());
+      const int      slot  = block.primitives[i]->flatten(*this, block.coordSlot);
+
+      // Every flatten emits at least one clause and returns a freshly-allocated value slot, so the
+      // sub-range is non-empty and the leaf's result lives inside the reused window.
+      EBGEOMETRY_EXPECT(static_cast<uint32_t>(m_tape.m_clauses.size()) > begin);
+      EBGEOMETRY_EXPECT(slot >= 0);
+      EBGEOMETRY_EXPECT(static_cast<uint32_t>(slot) >= valueBase);
+
+      maxCoordSlots = std::max(maxCoordSlots, m_tape.m_numCoordSlots);
+      maxValueSlots = std::max(maxValueSlots, m_tape.m_numValueSlots);
+
+      m_tape.m_bvhLeaves[size_t(m_tape.m_bvhBlocks[block.blockIndex].leafBegin) + i] =
+        TapeBVHLeaf{begin, static_cast<uint32_t>(m_tape.m_clauses.size()) - begin, static_cast<uint32_t>(slot)};
+    }
+  }
+
+  // Nested BVH unions lower to host callbacks during the deferred phase, so no new pending block
+  // can have appeared while this loop ran.
+  EBGEOMETRY_EXPECT(m_pendingBlocks.size() == numPendingBlocks);
+
+  m_flatteningBVHLeaf = false;
+
+  m_tape.m_numCoordSlots = maxCoordSlots;
+  m_tape.m_numValueSlots = maxValueSlots;
+
   m_tape.m_rootValueSlot = static_cast<uint32_t>(a_rootValueSlot);
 
   return std::move(m_tape);
@@ -229,36 +394,191 @@ compile(const ImplicitFunction<T>& a_tree)
 }
 
 // ── Interpreter: TapeView::value / Tape::value ────────────────────────────────
-template <class T>
-EBGEOMETRY_HOST_DEVICE T
-TapeView<T>::value(const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_valueScratch) const noexcept
+namespace TapeDetail {
+
+// Forward declaration: the clause loop and the BVH clause handler are mutually referential (a BVH
+// clause executes leaf sub-ranges through the inner clause loop). The recursion is statically
+// bounded at depth two -- executeClauses<false> -> executeBVHClause -> executeClauses<true> -- and
+// executeClauses<true> treats a BVH clause as unreachable (the builder lowers nested BVH unions to
+// host callbacks).
+template <bool INNER, class T>
+EBGEOMETRY_HOST_DEVICE void
+executeClauses(
+  const TapeView<T>& a_view, uint32_t a_begin, uint32_t a_end, Vec3T<T>* a_coordScratch, T* a_valueScratch) noexcept;
+
+// One BVH_UNION (SMOOTH == false) or BVH_SMOOTH_UNION (SMOOTH == true) clause: an iterative,
+// pruned branch-and-bound traversal mirroring PackedBVH::pruneTraverse (fixed 256-entry stack,
+// fresh pop-time bound recheck, children sorted by descending box distance so the nearest pops
+// first, push-time filter) with BVHUnionIF::value's running-minimum state (sharp) or
+// BVHSmoothUnionIF::value's two-smallest state and max(0, b)^2 bound (smooth). Leaf "evaluation"
+// executes the leaf's flattened clause sub-range from the tape's deferred region and folds its
+// value slot.
+//
+// Known ULP caveat: the SIMD pruneTraverse paths sum dx^2 + (dy^2 + dz^2) in vector registers and
+// use an unstable std::sort; this path uses AABBT::getDistance2 and a stable insertion sort.
+// Visited *sets* can differ on ULP-level box-distance ties, but the folded result is identical
+// whenever the box distance lower-bounds the leaf values (true for all metric primitives).
+template <bool SMOOTH, class T>
+EBGEOMETRY_HOST_DEVICE void
+executeBVHClause(const TapeView<T>& a_view,
+                 const TapeClause&  a_clause,
+                 Vec3T<T>*          a_coordScratch,
+                 T*                 a_valueScratch) noexcept
 {
-  EBGEOMETRY_EXPECT(numCoordSlots > 0);
-  EBGEOMETRY_EXPECT(numValueSlots > 0);
+  const TapeBVHBlock<T>& block = a_view.bvhBlocks[a_clause.paramIndex];
+  const Vec3T<T>         point = a_coordScratch[a_clause.in0];
 
-  a_coordScratch[0] = a_point;
+  // Sharp: 'a' is the running minimum ('b' unused). Smooth: 'a' <= 'b' are the two smallest leaf
+  // values, exactly as in BVHSmoothUnionIF::value.
+  T a = std::numeric_limits<T>::infinity();
+  T b = std::numeric_limits<T>::infinity();
 
-  for (uint32_t i = 0; i < numClauses; i++) {
-    const TapeClause& c = clauses[i];
+  struct StackEntry
+  {
+    uint32_t node;
+    T        dist2;
+  };
+
+  StackEntry stack[TapeBVHStackSize];
+
+  int top = 0;
+
+  stack[top++] = {block.rootNode, T(0)};
+
+  while (top > 0) {
+    const StackEntry entry = stack[--top];
+
+    // Re-read the pruning bound fresh at every pop: max(0, best)^2 keyed on the running minimum
+    // (sharp) or on the second-smallest value (smooth) -- identical to the pruneDist2 lambdas in
+    // BVHUnionIF::value / BVHSmoothUnionIF::value.
+    const T bound  = std::max(T(0), SMOOTH ? b : a);
+    const T bound2 = bound * bound;
+
+    if (entry.dist2 > bound2) {
+      continue;
+    }
+
+    const TapeBVHNode<T>& node = a_view.bvhNodes[entry.node];
+
+    if (node.leafCount > 0) {
+
+      for (uint32_t l = 0; l < node.leafCount; l++) {
+        const TapeBVHLeaf& leaf = a_view.bvhLeaves[node.leafBegin + l];
+
+        executeClauses<true>(
+          a_view, leaf.clauseBegin, leaf.clauseBegin + leaf.clauseCount, a_coordScratch, a_valueScratch);
+
+        const T v = a_valueScratch[leaf.valueSlot];
+
+        if constexpr (SMOOTH) {
+          if (v < a) {
+            b = a;
+            a = v;
+          }
+          else if (v < b) {
+            b = v;
+          }
+        }
+        else {
+          a = UnionOp<T>::combine(a, v);
+        }
+      }
+    }
+    else {
+      T        childDist2[TapeBVHMaxChildren];
+      uint32_t childIndex[TapeBVHMaxChildren];
+
+      for (uint32_t k = 0; k < node.childCount; k++) {
+        childIndex[k] = a_view.bvhChildren[node.childBegin + k];
+
+        const TapeBVHNode<T>& child = a_view.bvhNodes[childIndex[k]];
+
+        childDist2[k] = BoundingVolumes::AABBT<T>(child.lo, child.hi).getDistance2(point);
+      }
+
+      // Insertion sort, descending on box distance: the farthest child is pushed first so the
+      // nearest is popped first (childCount <= 16; strict comparison keeps the sort stable and
+      // deterministic).
+      for (uint32_t k = 1; k < node.childCount; k++) {
+        const T        d2  = childDist2[k];
+        const uint32_t idx = childIndex[k];
+
+        uint32_t j = k;
+
+        while (j > 0 && childDist2[j - 1] < d2) {
+          childDist2[j] = childDist2[j - 1];
+          childIndex[j] = childIndex[j - 1];
+
+          j--;
+        }
+
+        childDist2[j] = d2;
+        childIndex[j] = idx;
+      }
+
+      // Push-time filter against the pop-time bound (the state cannot change between pop and push
+      // within one interior visit, so re-reading it here would be identical); the pop-time recheck
+      // above keeps this semantics-neutral as the bound only tightens.
+      for (uint32_t k = 0; k < node.childCount; k++) {
+        if (childDist2[k] <= bound2) {
+          EBGEOMETRY_EXPECT(top < static_cast<int>(TapeBVHStackSize));
+
+          stack[top++] = {childIndex[k], childDist2[k]};
+        }
+      }
+    }
+  }
+
+  if constexpr (SMOOTH) {
+    // Blend the two nearest values with the block's registered smooth operator. The one-primitive
+    // edge case (b == +inf) flows into the blend unchanged, exactly as in
+    // BVHSmoothUnionIF::value.
+    switch (block.blend) {
+#define EBGEOMETRY_TAPE_EVAL_BVH_BLEND(TAG, OP)                        \
+  case Opcode::TAG:                                                    \
+    a_valueScratch[a_clause.out] = OP<T>::eval(a, b, block.smoothLen); \
+    break;
+      EBGEOMETRY_TAPE_SMOOTH_OPS(EBGEOMETRY_TAPE_EVAL_BVH_BLEND)
+#undef EBGEOMETRY_TAPE_EVAL_BVH_BLEND
+
+    default: {
+      EBGEOMETRY_EXPECT(false && "BVH_SMOOTH_UNION block carries an unregistered blend tag");
+
+      break;
+    }
+    }
+  }
+  else {
+    a_valueScratch[a_clause.out] = a;
+  }
+}
+
+template <bool INNER, class T>
+EBGEOMETRY_HOST_DEVICE void
+executeClauses(
+  const TapeView<T>& a_view, uint32_t a_begin, uint32_t a_end, Vec3T<T>* a_coordScratch, T* a_valueScratch) noexcept
+{
+  for (uint32_t i = a_begin; i < a_end; i++) {
+    const TapeClause& c = a_view.clauses[i];
 
     switch (c.opcode) {
-#define EBGEOMETRY_TAPE_EVAL_LEAF(TAG, OP, MEMBER)                                    \
-  case Opcode::TAG:                                                                   \
-    a_valueScratch[c.out] = OP<T>::eval(MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
+#define EBGEOMETRY_TAPE_EVAL_LEAF(TAG, OP, MEMBER)                                           \
+  case Opcode::TAG:                                                                          \
+    a_valueScratch[c.out] = OP<T>::eval(a_view.MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
     break;
       EBGEOMETRY_TAPE_LEAF_OPS(EBGEOMETRY_TAPE_EVAL_LEAF)
 #undef EBGEOMETRY_TAPE_EVAL_LEAF
 
-#define EBGEOMETRY_TAPE_EVAL_MAPPOINT(TAG, OP, MEMBER)                                    \
-  case Opcode::TAG:                                                                       \
-    a_coordScratch[c.out] = OP<T>::mapPoint(MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
+#define EBGEOMETRY_TAPE_EVAL_MAPPOINT(TAG, OP, MEMBER)                                           \
+  case Opcode::TAG:                                                                              \
+    a_coordScratch[c.out] = OP<T>::mapPoint(a_view.MEMBER[c.paramIndex], a_coordScratch[c.in0]); \
     break;
       EBGEOMETRY_TAPE_MAPPOINT_OPS(EBGEOMETRY_TAPE_EVAL_MAPPOINT)
 #undef EBGEOMETRY_TAPE_EVAL_MAPPOINT
 
-#define EBGEOMETRY_TAPE_EVAL_MAPVALUE(TAG, OP, MEMBER)                                    \
-  case Opcode::TAG:                                                                       \
-    a_valueScratch[c.out] = OP<T>::mapValue(MEMBER[c.paramIndex], a_valueScratch[c.in0]); \
+#define EBGEOMETRY_TAPE_EVAL_MAPVALUE(TAG, OP, MEMBER)                                           \
+  case Opcode::TAG:                                                                              \
+    a_valueScratch[c.out] = OP<T>::mapValue(a_view.MEMBER[c.paramIndex], a_valueScratch[c.in0]); \
     break;
       EBGEOMETRY_TAPE_MAPVALUE_OPS(EBGEOMETRY_TAPE_EVAL_MAPVALUE)
 #undef EBGEOMETRY_TAPE_EVAL_MAPVALUE
@@ -270,16 +590,41 @@ TapeView<T>::value(const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_value
       EBGEOMETRY_TAPE_COMBINE_OPS(EBGEOMETRY_TAPE_EVAL_COMBINE)
 #undef EBGEOMETRY_TAPE_EVAL_COMBINE
 
-#define EBGEOMETRY_TAPE_EVAL_SMOOTH(TAG, OP)                                                                       \
-  case Opcode::TAG:                                                                                                \
-    a_valueScratch[c.out] = OP<T>::eval(a_valueScratch[c.in0], a_valueScratch[c.in1], scalarParams[c.paramIndex]); \
+#define EBGEOMETRY_TAPE_EVAL_SMOOTH(TAG, OP)                                                        \
+  case Opcode::TAG:                                                                                 \
+    a_valueScratch[c.out] =                                                                         \
+      OP<T>::eval(a_valueScratch[c.in0], a_valueScratch[c.in1], a_view.scalarParams[c.paramIndex]); \
     break;
       EBGEOMETRY_TAPE_SMOOTH_OPS(EBGEOMETRY_TAPE_EVAL_SMOOTH)
 #undef EBGEOMETRY_TAPE_EVAL_SMOOTH
 
+    case Opcode::BVH_UNION: {
+      if constexpr (INNER) {
+        // Unreachable by construction: the builder lowers a BVH union encountered inside a BVH
+        // leaf subtree to a host callback, so the deferred region never contains a BVH clause.
+        EBGEOMETRY_EXPECT(false && "nested BVH clause in a leaf sub-range");
+      }
+      else {
+        executeBVHClause<false>(a_view, c, a_coordScratch, a_valueScratch);
+      }
+
+      break;
+    }
+
+    case Opcode::BVH_SMOOTH_UNION: {
+      if constexpr (INNER) {
+        EBGEOMETRY_EXPECT(false && "nested BVH clause in a leaf sub-range");
+      }
+      else {
+        executeBVHClause<true>(a_view, c, a_coordScratch, a_valueScratch);
+      }
+
+      break;
+    }
+
     case Opcode::HOST_CALLBACK: {
 #ifndef EBGEOMETRY_DEVICE_COMPILE
-      a_valueScratch[c.out] = hostNodes[c.paramIndex]->value(a_coordScratch[c.in0]);
+      a_valueScratch[c.out] = a_view.hostNodes[c.paramIndex]->value(a_coordScratch[c.in0]);
 #else
       EBGEOMETRY_EXPECT(false && "HOST_CALLBACK clause is not evaluable on device");
 #endif
@@ -287,6 +632,22 @@ TapeView<T>::value(const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_value
     }
     }
   }
+}
+
+} // namespace TapeDetail
+
+template <class T>
+EBGEOMETRY_HOST_DEVICE T
+TapeView<T>::value(const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_valueScratch) const noexcept
+{
+  EBGEOMETRY_EXPECT(numCoordSlots > 0);
+  EBGEOMETRY_EXPECT(numValueSlots > 0);
+
+  a_coordScratch[0] = a_point;
+
+  // The forward pass covers the main region only; the deferred region [numMainClauses, numClauses)
+  // holds BVH leaf subtrees executed on demand by BVH clauses.
+  TapeDetail::executeClauses<false>(*this, 0, numMainClauses, a_coordScratch, a_valueScratch);
 
   return a_valueScratch[rootValueSlot];
 }
@@ -330,7 +691,8 @@ Tape<T>::value(const Vec3T<T>& a_point) const noexcept
 
 // ── flatten() overrides ───────────────────────────────────────────────────────
 // Base default: any node without its own override lowers to an opaque host callback (Perlin, Blur,
-// Mollify, FiniteRepetition, BVH unions, and any user subclass).
+// Mollify, FiniteRepetition, and any user subclass). BVH unions have their own native lowering
+// below.
 template <class T>
 int
 ImplicitFunction<T, void>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
@@ -535,6 +897,115 @@ int
 SmoothDifferenceIF<T, Blend>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
 {
   return m_smoothIntersectionIF->flatten(a_builder, a_coordSlot);
+}
+
+// BVH unions lower to a native BVH clause plus deferred leaf subtrees. The builder receives a
+// K-erased copy of the PackedBVH's node topology (bounding boxes, child tables, leaf primitive
+// ranges) and the primitive list in leaf-traversal order -- exactly the order the nodes'
+// primitive offsets index. Child tables are copied verbatim, including any duplicate entries from
+// PackedBVH's power-of-K padding, so the tape traversal visits exactly what pruneTraverse would.
+//
+// On that padding: the BVH unions build their internal BVH exclusively through TreeBVH + pack()
+// (CSGDetail::buildBVH), and both TreeBVH builds give every interior node K distinct children --
+// only PackedBVH's direct SFC constructor pads a non-power-of-K leaf level by repeating the last
+// real leaf, and no BVH-union code path reaches it today. Should such duplicates ever appear,
+// copying them verbatim is still the right call: a duplicate leaf visit is idempotent for the
+// sharp union's min-fold, and while it is NOT idempotent for the smooth union's two-smallest state
+// in isolation (revisiting a leaf could seat the same primitive's value in both slots), today's
+// pruneTraverse-based BVHSmoothUnionIF::value would visit those same duplicates through the same
+// push/pop logic -- so the tape reproduces its behavior by construction either way.
+namespace TapeDetail {
+
+template <class T, class PackedBVHType>
+[[nodiscard]] EBGEOMETRY_HOST std::vector<typename TapeBuilder<T>::BVHNodeInfo>
+                              collectBVHNodeInfo(const PackedBVHType& a_bvh)
+{
+  const auto& nodes = a_bvh.getNodes();
+
+  std::vector<typename TapeBuilder<T>::BVHNodeInfo> info(nodes.size());
+
+  for (size_t i = 0; i < nodes.size(); i++) {
+    info[i].aabb = nodes[i].getBoundingVolume();
+
+    if (nodes[i].isLeaf()) {
+      info[i].primOff  = nodes[i].getPrimitivesOffset();
+      info[i].numPrims = nodes[i].getNumPrimitives();
+    }
+    else {
+      const auto& offsets = nodes[i].getChildOffsets();
+
+      info[i].children.assign(offsets.begin(), offsets.end());
+    }
+  }
+
+  return info;
+}
+
+template <class T, class PackedBVHType>
+[[nodiscard]] EBGEOMETRY_HOST std::vector<const ImplicitFunction<T>*>
+                              collectBVHLeafPrimitives(const PackedBVHType& a_bvh)
+{
+  const auto& primitives = a_bvh.getPrimitives();
+
+  std::vector<const ImplicitFunction<T>*> leafPrimitives;
+
+  leafPrimitives.reserve(primitives.size());
+
+  for (const auto& primitive : primitives) {
+    leafPrimitives.push_back(primitive.get());
+  }
+
+  return leafPrimitives;
+}
+
+} // namespace TapeDetail
+
+template <class T, class P, class BV, size_t K>
+int
+BVHUnionIF<T, P, BV, K>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
+{
+  static_assert(K <= TapeBVHMaxChildren, "BVHUnionIF::flatten: K exceeds the tape traversal child bound");
+
+  EBGEOMETRY_EXPECT(m_bvh != nullptr);
+
+  // Nested BVH union (this union is a leaf primitive of an enclosing BVH union): Tier 6 keeps it
+  // opaque -- the host callback runs this union's own pruneTraverse, which is exact but marks the
+  // tape device-ineligible.
+  if (a_builder.isFlatteningBVHLeaf()) {
+    return a_builder.emitHostCallback(a_coordSlot, this);
+  }
+
+  return a_builder.emitBVHUnion(a_coordSlot,
+                                TapeDetail::collectBVHNodeInfo<T>(*m_bvh),
+                                TapeDetail::collectBVHLeafPrimitives<T>(*m_bvh),
+                                false,
+                                Opcode::SMOOTH_MIN, // blend tag is unused for the sharp union
+                                T(0));
+}
+
+template <class T, class P, class BV, size_t K, class Blend>
+int
+BVHSmoothUnionIF<T, P, BV, K, Blend>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
+{
+  static_assert(K <= TapeBVHMaxChildren, "BVHSmoothUnionIF::flatten: K exceeds the tape traversal child bound");
+
+  EBGEOMETRY_EXPECT(m_bvh != nullptr);
+
+  // Native lowering requires a registered blend (one with a smooth ISA opcode) and must not run
+  // inside another BVH union's leaf subtree (see BVHUnionIF::flatten above); everything else stays
+  // an opaque host callback, which reproduces value() exactly.
+  if constexpr (isRegisteredBlend<Blend>) {
+    if (!a_builder.isFlatteningBVHLeaf()) {
+      return a_builder.emitBVHUnion(a_coordSlot,
+                                    TapeDetail::collectBVHNodeInfo<T>(*m_bvh),
+                                    TapeDetail::collectBVHLeafPrimitives<T>(*m_bvh),
+                                    true,
+                                    BlendOpcodeOf<Blend>::value,
+                                    m_smoothLen);
+    }
+  }
+
+  return a_builder.emitHostCallback(a_coordSlot, this);
 }
 
 } // namespace EBGeometry

--- a/Source/EBGeometry_TapeImplem.hpp
+++ b/Source/EBGeometry_TapeImplem.hpp
@@ -126,7 +126,7 @@ TapeBuilder<T>::emitLeaf(int a_inCoord, const typename Op::Params& a_params)
   auto& array = this->template paramArrayFor<Op>();
   array.push_back(a_params);
 
-  const uint16_t paramIndex = static_cast<uint16_t>(array.size() - 1);
+  const uint32_t paramIndex = static_cast<uint32_t>(array.size() - 1);
 
   m_tape.m_clauses.push_back(
     TapeClause{OpcodeOf<Op>::value, paramIndex, static_cast<uint32_t>(a_inCoord), 0, static_cast<uint32_t>(out)});
@@ -144,7 +144,7 @@ TapeBuilder<T>::emitCoordTransform(Opcode a_opcode, int a_inCoord, const typenam
   auto& array = this->template paramArrayFor<Op>();
   array.push_back(a_params);
 
-  const uint16_t paramIndex = static_cast<uint16_t>(array.size() - 1);
+  const uint32_t paramIndex = static_cast<uint32_t>(array.size() - 1);
 
   m_tape.m_clauses.push_back(
     TapeClause{a_opcode, paramIndex, static_cast<uint32_t>(a_inCoord), 0, static_cast<uint32_t>(out)});
@@ -162,7 +162,7 @@ TapeBuilder<T>::emitValueTransform(Opcode a_opcode, int a_inValue, const typenam
   auto& array = this->template paramArrayFor<Op>();
   array.push_back(a_params);
 
-  const uint16_t paramIndex = static_cast<uint16_t>(array.size() - 1);
+  const uint32_t paramIndex = static_cast<uint32_t>(array.size() - 1);
 
   m_tape.m_clauses.push_back(
     TapeClause{a_opcode, paramIndex, static_cast<uint32_t>(a_inValue), 0, static_cast<uint32_t>(out)});
@@ -190,7 +190,7 @@ TapeBuilder<T>::emitSmooth(Opcode a_opcode, int a_valA, int a_valB, T a_smoothLe
 
   m_tape.m_scalarParams.push_back(a_smoothLen);
 
-  const uint16_t paramIndex = static_cast<uint16_t>(m_tape.m_scalarParams.size() - 1);
+  const uint32_t paramIndex = static_cast<uint32_t>(m_tape.m_scalarParams.size() - 1);
 
   m_tape.m_clauses.push_back(TapeClause{
     a_opcode, paramIndex, static_cast<uint32_t>(a_valA), static_cast<uint32_t>(a_valB), static_cast<uint32_t>(out)});
@@ -206,7 +206,7 @@ TapeBuilder<T>::emitHostCallback(int a_inCoord, const ImplicitFunction<T>* a_nod
 
   m_tape.m_hostNodes.push_back(a_node);
 
-  const uint16_t paramIndex = static_cast<uint16_t>(m_tape.m_hostNodes.size() - 1);
+  const uint32_t paramIndex = static_cast<uint32_t>(m_tape.m_hostNodes.size() - 1);
 
   m_tape.m_clauses.push_back(
     TapeClause{Opcode::HOST_CALLBACK, paramIndex, static_cast<uint32_t>(a_inCoord), 0, static_cast<uint32_t>(out)});
@@ -237,7 +237,7 @@ TapeBuilder<T>::emitBVHUnion(int                                       a_inCoord
 
   const size_t blockIndex = m_tape.m_bvhBlocks.size();
 
-  EBGEOMETRY_EXPECT(blockIndex <= size_t(std::numeric_limits<uint16_t>::max()));
+  EBGEOMETRY_EXPECT(blockIndex <= size_t(std::numeric_limits<uint32_t>::max()));
 
   // Globalise the block-local node/child/leaf indices into the tape's shared arrays (blocks are
   // appended back to back, so a block-local index maps to base + local).
@@ -290,7 +290,7 @@ TapeBuilder<T>::emitBVHUnion(int                                       a_inCoord
   m_tape.m_bvhBlocks.push_back(block);
 
   m_tape.m_clauses.push_back(TapeClause{a_smooth ? Opcode::BVH_SMOOTH_UNION : Opcode::BVH_UNION,
-                                        static_cast<uint16_t>(blockIndex),
+                                        static_cast<uint32_t>(blockIndex),
                                         static_cast<uint32_t>(a_inCoord),
                                         0,
                                         static_cast<uint32_t>(out)});
@@ -340,7 +340,12 @@ TapeBuilder<T>::finish(int a_rootValueSlot)
 
   m_flatteningBVHLeaf = true;
 
-  for (const auto& block : m_pendingBlocks) {
+  // Indexed loop rather than a range-for: nested BVH unions lower to host callbacks during this
+  // phase (asserted below), but an index stays valid even if m_pendingBlocks were ever to grow
+  // mid-loop, where a range-for iterator would be silently invalidated.
+  for (size_t b = 0; b < m_pendingBlocks.size(); b++) {
+    const PendingBVHBlock& block = m_pendingBlocks[b];
+
     EBGEOMETRY_EXPECT(block.coordSlot >= 0);
     EBGEOMETRY_EXPECT(static_cast<uint32_t>(block.coordSlot) < coordBase);
 
@@ -941,6 +946,39 @@ template <class T, class PackedBVHType>
   return info;
 }
 
+// Worst-case occupancy of the interpreter's fixed traversal stack for one BVH block: when the
+// traversal descends into a child, the child's up-to-(childCount - 1) siblings stay stacked, so the
+// occupancy along any root-to-leaf path is bounded by depth * (maxChildCount - 1) + 1. Computed
+// iteratively (explicit stack, no recursion) so an adversarially deep, unbalanced tree -- the very
+// case this guards against -- cannot overflow the host call stack while being measured.
+template <class T>
+[[nodiscard]] EBGEOMETRY_HOST uint32_t
+tapeBVHStackBound(const std::vector<typename TapeBuilder<T>::BVHNodeInfo>& a_nodes)
+{
+  uint32_t maxDepth      = 0;
+  uint32_t maxChildCount = 1;
+
+  std::vector<std::pair<uint32_t, uint32_t>> stack;
+
+  stack.emplace_back(0, 0);
+
+  while (!stack.empty()) {
+    const auto [node, depth] = stack.back();
+
+    stack.pop_back();
+
+    maxDepth = std::max(maxDepth, depth);
+
+    for (const uint32_t child : a_nodes[node].children) {
+      stack.emplace_back(child, depth + 1);
+    }
+
+    maxChildCount = std::max(maxChildCount, static_cast<uint32_t>(a_nodes[node].children.size()));
+  }
+
+  return maxDepth * (maxChildCount - 1) + 1;
+}
+
 template <class T, class PackedBVHType>
 [[nodiscard]] EBGEOMETRY_HOST std::vector<const ImplicitFunction<T>*>
                               collectBVHLeafPrimitives(const PackedBVHType& a_bvh)
@@ -975,8 +1013,17 @@ BVHUnionIF<T, P, BV, K>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) con
     return a_builder.emitHostCallback(a_coordSlot, this);
   }
 
+  auto nodes = TapeDetail::collectBVHNodeInfo<T>(*m_bvh);
+
+  // An adversarially unbalanced tree (e.g. chain splits from degenerate centroid distributions)
+  // could exceed the interpreter's fixed traversal stack; keep such a block opaque rather than risk
+  // an out-of-bounds stack write in release builds.
+  if (TapeDetail::tapeBVHStackBound<T>(nodes) > TapeBVHStackSize) {
+    return a_builder.emitHostCallback(a_coordSlot, this);
+  }
+
   return a_builder.emitBVHUnion(a_coordSlot,
-                                TapeDetail::collectBVHNodeInfo<T>(*m_bvh),
+                                std::move(nodes),
                                 TapeDetail::collectBVHLeafPrimitives<T>(*m_bvh),
                                 false,
                                 Opcode::SMOOTH_MIN, // blend tag is unused for the sharp union
@@ -996,12 +1043,17 @@ BVHSmoothUnionIF<T, P, BV, K, Blend>::flatten(TapeBuilder<T>& a_builder, int a_c
   // an opaque host callback, which reproduces value() exactly.
   if constexpr (isRegisteredBlend<Blend>) {
     if (!a_builder.isFlatteningBVHLeaf()) {
-      return a_builder.emitBVHUnion(a_coordSlot,
-                                    TapeDetail::collectBVHNodeInfo<T>(*m_bvh),
-                                    TapeDetail::collectBVHLeafPrimitives<T>(*m_bvh),
-                                    true,
-                                    BlendOpcodeOf<Blend>::value,
-                                    m_smoothLen);
+      auto nodes = TapeDetail::collectBVHNodeInfo<T>(*m_bvh);
+
+      // Same fixed-traversal-stack guard as BVHUnionIF::flatten above.
+      if (TapeDetail::tapeBVHStackBound<T>(nodes) <= TapeBVHStackSize) {
+        return a_builder.emitBVHUnion(a_coordSlot,
+                                      std::move(nodes),
+                                      TapeDetail::collectBVHLeafPrimitives<T>(*m_bvh),
+                                      true,
+                                      BlendOpcodeOf<Blend>::value,
+                                      m_smoothLen);
+      }
     }
   }
 

--- a/Source/EBGeometry_TapeImplem.hpp
+++ b/Source/EBGeometry_TapeImplem.hpp
@@ -470,34 +470,69 @@ DifferenceIF<T>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
   return a_builder.emitCombine(Opcode::DIFFERENCE, valueA, valueB);
 }
 
-// Smooth combiners carry a user-overridable std::function blend operator (SmoothMinIF's m_smoothMin,
-// SmoothIntersectionIF's m_smoothMax) that defaults to SmoothMin/SmoothMax but may be any callable --
-// including the enumerated ExpMin or an arbitrary user lambda. A std::function cannot be introspected
-// to recover which enumerated ISA op it is, so, per the project rule that user-supplied std::function
-// blends stay host-only, every smooth combiner lowers to an opaque host callback (keeping tape
-// evaluation == value() exact for any operator, at the cost of device-eligibility). The SMOOTH_MIN/
-// SMOOTH_MAX/EXP_MIN opcodes remain the device ISA for blends emitted with a known operator (e.g. the
-// builder API directly, and the BVH smooth union of a later tier); they are not reachable from a
-// std::function-carrying node here.
-template <class T>
+// Smooth combiners are templated on their blend operator (the Blend parameter, defaulting to
+// SmoothMinOp/SmoothMaxOp), so the blend's identity is known at compile time and a registered blend
+// (one with a BlendOpcodeOf specialisation: SmoothMinOp, SmoothMaxOp, ExpMinOp) lowers to its native
+// SMOOTH_MIN/SMOOTH_MAX/EXP_MIN clause. The lowering must reproduce value() exactly, and value()
+// blends only the two closest (union) / two largest (intersection) of its N child values in a single
+// Blend::eval call -- so only the arities where that selection is trivial lower natively:
+//
+//   - one child:  value() returns the child unblended, so lower the child directly (exact for ANY
+//                 Blend, registered or not);
+//   - two children: value() blends exactly those two, so emit one native smooth clause (the
+//                 registered blends are all symmetric in (a, b), so child order is immaterial);
+//   - N > 2:      two-closest-of-N is NOT a left-fold of binary blend clauses, so lowering it as a
+//                 fold would change results -- keep the opaque host callback;
+//   - unregistered custom Blend: no ISA opcode exists -- keep the opaque host callback.
+//
+// The host-callback fallback keeps tape evaluation == value() exact in every case, at the cost of
+// device-eligibility.
+template <class T, class Blend>
 int
-SmoothUnionIF<T>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
+SmoothUnionIF<T, Blend>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
 {
+  if (m_implicitFunctions.size() == 1) {
+    return m_implicitFunctions.front()->flatten(a_builder, a_coordSlot);
+  }
+
+  if constexpr (isRegisteredBlend<Blend>) {
+    if (m_implicitFunctions.size() == 2) {
+      const int valueA = m_implicitFunctions[0]->flatten(a_builder, a_coordSlot);
+      const int valueB = m_implicitFunctions[1]->flatten(a_builder, a_coordSlot);
+
+      return a_builder.emitSmooth(BlendOpcodeOf<Blend>::value, valueA, valueB, m_smoothLen);
+    }
+  }
+
   return a_builder.emitHostCallback(a_coordSlot, this);
 }
 
-template <class T>
+template <class T, class Blend>
 int
-SmoothIntersectionIF<T>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
+SmoothIntersectionIF<T, Blend>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
 {
+  if (m_implicitFunctions.size() == 1) {
+    return m_implicitFunctions.front()->flatten(a_builder, a_coordSlot);
+  }
+
+  if constexpr (isRegisteredBlend<Blend>) {
+    if (m_implicitFunctions.size() == 2) {
+      const int valueA = m_implicitFunctions[0]->flatten(a_builder, a_coordSlot);
+      const int valueB = m_implicitFunctions[1]->flatten(a_builder, a_coordSlot);
+
+      return a_builder.emitSmooth(BlendOpcodeOf<Blend>::value, valueA, valueB, m_smoothLen);
+    }
+  }
+
   return a_builder.emitHostCallback(a_coordSlot, this);
 }
 
 // Smooth difference is stored as a SmoothIntersectionIF of A with complement(B): recurse into it so
-// it takes the same opaque-host path.
-template <class T>
+// it takes the same native-or-host path (native for the pairwise A \ B with a registered Blend,
+// host callback for multiple subtrahends or an unregistered Blend).
+template <class T, class Blend>
 int
-SmoothDifferenceIF<T>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
+SmoothDifferenceIF<T, Blend>::flatten(TapeBuilder<T>& a_builder, int a_coordSlot) const
 {
   return m_smoothIntersectionIF->flatten(a_builder, a_coordSlot);
 }

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -90,6 +90,16 @@ using Meta = short;
   template class SmoothDifferenceIF<PREC, ExpMinOp<PREC>>;                   \
   template class FiniteRepetitionIF<PREC>;                                   \
                                                                                \
+  /* -- BVH-accelerated CSG unions (default + non-default Blend, so both  */ \
+  /* -- native and host-fallback tape lowerings stay compile-checked) ------*/ \
+  template class BVHUnionIF<PREC, ImplicitFunction<PREC>,                    \
+                            BoundingVolumes::AABBT<PREC>, 4>;                \
+  template class BVHSmoothUnionIF<PREC, ImplicitFunction<PREC>,              \
+                                  BoundingVolumes::AABBT<PREC>, 4>;          \
+  template class BVHSmoothUnionIF<PREC, ImplicitFunction<PREC>,              \
+                                  BoundingVolumes::AABBT<PREC>, 4,           \
+                                  ExpMinOp<PREC>>;                           \
+                                                                               \
   /* -- Transformation distance-formula traits ----------------------------*/ \
   template struct ComplementOp<PREC>;                                       \
   template struct TranslateOp<PREC>;                                        \
@@ -104,6 +114,8 @@ using Meta = short;
   template class Tape<PREC>;                                                 \
   template struct TapeView<PREC>;                                            \
   template class TapeBuilder<PREC>;                                          \
+  template struct TapeBVHNode<PREC>;                                         \
+  template struct TapeBVHBlock<PREC>;                                        \
                                                                                \
   /* -- Transformation implicit functions ----------------------------------*/\
   template class ComplementIF<PREC>;                                         \

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -77,13 +77,17 @@ using Meta = short;
   template struct SmoothMaxOp<PREC>;                                        \
   template struct ExpMinOp<PREC>;                                           \
                                                                                \
-  /* -- CSG implicit functions --------------------------------------------*/ \
+  /* -- CSG implicit functions (smooth combiners: default Blend plus one  */ \
+  /* -- non-default Blend each, so both lowerings stay compile-checked) ---*/ \
   template class UnionIF<PREC>;                                              \
   template class SmoothUnionIF<PREC>;                                        \
+  template class SmoothUnionIF<PREC, ExpMinOp<PREC>>;                        \
   template class IntersectionIF<PREC>;                                       \
   template class SmoothIntersectionIF<PREC>;                                 \
+  template class SmoothIntersectionIF<PREC, ExpMinOp<PREC>>;                 \
   template class DifferenceIF<PREC>;                                         \
   template class SmoothDifferenceIF<PREC>;                                   \
+  template class SmoothDifferenceIF<PREC, ExpMinOp<PREC>>;                   \
   template class FiniteRepetitionIF<PREC>;                                   \
                                                                                \
   /* -- Transformation distance-formula traits ----------------------------*/ \

--- a/Tests/TestCSG.cpp
+++ b/Tests/TestCSG.cpp
@@ -3,7 +3,7 @@
 
 // Test suite for EBGeometry_CSG.hpp: the sharp and smoothly-blended CSG combinators (union,
 // intersection, difference), their BVH-accelerated counterparts, finite periodic repetition, and
-// the SmoothMin/SmoothMax/ExpMin blending primitives they're built on. Uses analytic spheres as
+// the SmoothMinOp/SmoothMaxOp/ExpMinOp blend operator traits they're built on. Uses analytic spheres as
 // fixtures so every expected value is hand-computable.
 
 #include "EBGeometry.hpp"
@@ -93,7 +93,7 @@ exactMargin()
   return std::is_same_v<T, float> ? 1.0e-4 : 1.0e-12;
 }
 
-// A hand-computed closed-form expected value (SmoothMin's exact blend formula, FiniteRepetition's
+// A hand-computed closed-form expected value (SmoothMinOp's exact blend formula, FiniteRepetition's
 // tile folding, ...), or a "never worse than the sharp value" bound that holds by construction of
 // the blending formula, swept over many sample points.
 template <class T>
@@ -115,97 +115,97 @@ asymptoticMargin()
 } // namespace
 
 // ─────────────────────────────────────────────────────────────────────────────
-// SmoothMin / SmoothMax / ExpMin
+// SmoothMinOp / SmoothMaxOp / ExpMinOp
 // ─────────────────────────────────────────────────────────────────────────────
 
-TEMPLATE_TEST_CASE("SmoothMin: reduces to the sharp minimum once |a - b| exceeds the smoothing length",
-                   "[CSG][SmoothMin]",
+TEMPLATE_TEST_CASE("SmoothMinOp: reduces to the sharp minimum once |a - b| exceeds the smoothing length",
+                   "[CSG][SmoothMinOp]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   const T s = T(0.5);
 
-  REQUIRE_THAT(SmoothMin<T>(T(1.0), T(3.0), s), withinAbsT(T(1.0), exactMargin<T>()));
-  REQUIRE_THAT(SmoothMin<T>(T(3.0), T(1.0), s), withinAbsT(T(1.0), exactMargin<T>()));
-  REQUIRE_THAT(SmoothMin<T>(T(-5.0), T(-1.0), s), withinAbsT(T(-5.0), exactMargin<T>()));
+  REQUIRE_THAT(SmoothMinOp<T>::eval(T(1.0), T(3.0), s), withinAbsT(T(1.0), exactMargin<T>()));
+  REQUIRE_THAT(SmoothMinOp<T>::eval(T(3.0), T(1.0), s), withinAbsT(T(1.0), exactMargin<T>()));
+  REQUIRE_THAT(SmoothMinOp<T>::eval(T(-5.0), T(-1.0), s), withinAbsT(T(-5.0), exactMargin<T>()));
 }
 
-TEMPLATE_TEST_CASE("SmoothMin: equal inputs blend to a - 0.25*s", "[CSG][SmoothMin]", EBGEOMETRY_TEST_PRECISIONS)
+TEMPLATE_TEST_CASE("SmoothMinOp: equal inputs blend to a - 0.25*s", "[CSG][SmoothMinOp]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   const T a = T(2.0);
   const T s = T(0.4);
 
-  REQUIRE_THAT(SmoothMin<T>(a, a, s), withinAbsT(a - T(0.25) * s, exactMargin<T>()));
+  REQUIRE_THAT(SmoothMinOp<T>::eval(a, a, s), withinAbsT(a - T(0.25) * s, exactMargin<T>()));
 }
 
-TEMPLATE_TEST_CASE("SmoothMin: never returns a value smaller (more negative) than the sharp minimum",
-                   "[CSG][SmoothMin]",
+TEMPLATE_TEST_CASE("SmoothMinOp: never returns a value smaller (more negative) than the sharp minimum",
+                   "[CSG][SmoothMinOp]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   for (const T a : sweepValues<T>(T(-3.0), T(3.0), 16)) {
     for (const T b : sweepValues<T>(T(-3.0), T(3.0), 14)) {
-      REQUIRE(SmoothMin<T>(a, b, T(1.0)) <= std::min(a, b) + T(exactMargin<T>()));
+      REQUIRE(SmoothMinOp<T>::eval(a, b, T(1.0)) <= std::min(a, b) + T(exactMargin<T>()));
     }
   }
 }
 
-TEMPLATE_TEST_CASE("SmoothMax: reduces to the sharp maximum once |a - b| exceeds the smoothing length",
-                   "[CSG][SmoothMax]",
+TEMPLATE_TEST_CASE("SmoothMaxOp: reduces to the sharp maximum once |a - b| exceeds the smoothing length",
+                   "[CSG][SmoothMaxOp]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   const T s = T(0.5);
 
-  REQUIRE_THAT(SmoothMax<T>(T(1.0), T(3.0), s), withinAbsT(T(3.0), exactMargin<T>()));
-  REQUIRE_THAT(SmoothMax<T>(T(-5.0), T(-1.0), s), withinAbsT(T(-1.0), exactMargin<T>()));
+  REQUIRE_THAT(SmoothMaxOp<T>::eval(T(1.0), T(3.0), s), withinAbsT(T(3.0), exactMargin<T>()));
+  REQUIRE_THAT(SmoothMaxOp<T>::eval(T(-5.0), T(-1.0), s), withinAbsT(T(-1.0), exactMargin<T>()));
 }
 
-TEMPLATE_TEST_CASE("SmoothMax: equal inputs blend to a + 0.25*s", "[CSG][SmoothMax]", EBGEOMETRY_TEST_PRECISIONS)
+TEMPLATE_TEST_CASE("SmoothMaxOp: equal inputs blend to a + 0.25*s", "[CSG][SmoothMaxOp]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   const T a = T(2.0);
   const T s = T(0.4);
 
-  REQUIRE_THAT(SmoothMax<T>(a, a, s), withinAbsT(a + T(0.25) * s, exactMargin<T>()));
+  REQUIRE_THAT(SmoothMaxOp<T>::eval(a, a, s), withinAbsT(a + T(0.25) * s, exactMargin<T>()));
 }
 
-TEMPLATE_TEST_CASE("SmoothMax: never returns a value larger than the sharp maximum",
-                   "[CSG][SmoothMax]",
+TEMPLATE_TEST_CASE("SmoothMaxOp: never returns a value larger than the sharp maximum",
+                   "[CSG][SmoothMaxOp]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   for (const T a : sweepValues<T>(T(-3.0), T(3.0), 16)) {
     for (const T b : sweepValues<T>(T(-3.0), T(3.0), 14)) {
-      REQUIRE(SmoothMax<T>(a, b, T(1.0)) >= std::max(a, b) - T(exactMargin<T>()));
+      REQUIRE(SmoothMaxOp<T>::eval(a, b, T(1.0)) >= std::max(a, b) - T(exactMargin<T>()));
     }
   }
 }
 
-TEMPLATE_TEST_CASE("ExpMin: equal inputs blend to a - s*ln(2)", "[CSG][ExpMin]", EBGEOMETRY_TEST_PRECISIONS)
+TEMPLATE_TEST_CASE("ExpMinOp: equal inputs blend to a - s*ln(2)", "[CSG][ExpMinOp]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   const T a = T(2.0);
   const T s = T(0.4);
 
-  REQUIRE_THAT(ExpMin<T>(a, a, s), withinAbsT(a - s * std::log(T(2.0)), formulaMargin<T>()));
+  REQUIRE_THAT(ExpMinOp<T>::eval(a, a, s), withinAbsT(a - s * std::log(T(2.0)), formulaMargin<T>()));
 }
 
-TEMPLATE_TEST_CASE("ExpMin: never exceeds the sharp minimum", "[CSG][ExpMin]", EBGEOMETRY_TEST_PRECISIONS)
+TEMPLATE_TEST_CASE("ExpMinOp: never exceeds the sharp minimum", "[CSG][ExpMinOp]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
   for (const T a : sweepValues<T>(T(-3.0), T(3.0), 16)) {
     for (const T b : sweepValues<T>(T(-3.0), T(3.0), 14)) {
-      REQUIRE(ExpMin<T>(a, b, T(1.0)) <= std::min(a, b) + T(formulaMargin<T>()));
+      REQUIRE(ExpMinOp<T>::eval(a, b, T(1.0)) <= std::min(a, b) + T(formulaMargin<T>()));
     }
   }
 }
@@ -311,14 +311,34 @@ TEMPLATE_TEST_CASE("SmoothUnion: free function matches SmoothUnionIF for both th
   const auto a = sphereA<T>();
   const auto b = sphereB<T>();
 
-  const T    smoothLen = T(0.5);
-  const auto pairwise  = SmoothUnion<T>(a, b, smoothLen);
-  const auto vectorArg = SmoothUnion<T, Sphere<T>>(std::vector<std::shared_ptr<Sphere<T>>>{a, b}, smoothLen);
+  const T                smoothLen = T(0.5);
+  const auto             pairwise  = SmoothUnion<T>(a, b, smoothLen);
+  const auto             vectorArg = SmoothUnion<T>(std::vector<std::shared_ptr<Sphere<T>>>{a, b}, smoothLen);
   const SmoothUnionIF<T> direct({a, b}, smoothLen);
 
   for (const Vec3 p : {Vec3::zeros(), Vec3(1.5, 0, 0), Vec3(3, 0, 0)}) {
     REQUIRE_THAT(pairwise->value(p), withinAbsT(direct.value(p), exactMargin<T>()));
     REQUIRE_THAT(vectorArg->value(p), withinAbsT(direct.value(p), exactMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("SmoothUnion: an explicitly chosen ExpMinOp blend applies the exponential formula",
+                   "[CSG][SmoothUnion]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T    = TestType;
+  using Vec3 = Vec3T<T>;
+
+  const auto a = sphereA<T>();
+  const auto b = sphereB<T>();
+
+  const T    smoothLen = T(0.5);
+  const auto expUnion  = SmoothUnion<T, ExpMinOp<T>>(a, b, smoothLen);
+
+  for (const Vec3 p : {Vec3::zeros(), Vec3(1.5, 0, 0), Vec3(3, 0, 0)}) {
+    const T expected = ExpMinOp<T>::eval(a->value(p), b->value(p), smoothLen);
+
+    REQUIRE_THAT(expUnion->value(p), withinAbsT(expected, formulaMargin<T>()));
   }
 }
 
@@ -480,7 +500,7 @@ TEMPLATE_TEST_CASE("BVHSmoothUnionIF: matches a brute-force two-nearest smooth-m
       }
     }
 
-    return SmoothMin<T>(a, b, smoothLen);
+    return SmoothMinOp<T>::eval(a, b, smoothLen);
   };
 
   for (const auto& p : lineQueryPoints<T>()) {

--- a/Tests/TestTape.cpp
+++ b/Tests/TestTape.cpp
@@ -294,8 +294,49 @@ TEMPLATE_TEST_CASE("Tape: a single-child smooth union lowers to the child itself
 }
 
 // The SMOOTH_MIN/SMOOTH_MAX/EXP_MIN opcodes are the device ISA for the registered blends. They are
-// also exercised here directly through the builder API (the path a later BVH-smooth tier uses),
-// decoupled from the smooth combiner nodes above.
+// also exercised here directly through the builder API (decoupled from any combiner node) and are
+// the same clauses the BVH smooth union epilogue selects from its block blend tag.
+TEMPLATE_TEST_CASE("Tape: parameter indices address more than 65536 bundles per op type",
+                   "[Tape][Builder][ParamIndex]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // Regression test: paramIndex was once uint16_t, so bundle 65536 silently aliased bundle 0 --
+  // wrong geometry with no assertion. BVH unions over 10^5+ primitives are the flagship use case,
+  // so the clause index must be 32 bits wide. Built via the builder (a union fold of 70000 sphere
+  // leaves) to keep the test independent of BVH construction cost.
+  constexpr int numSpheres = 70000;
+  constexpr int probe      = 65536;
+
+  TapeBuilder<T> builder;
+
+  const int coord0 = builder.newCoordSlot();
+
+  int root = -1;
+
+  for (int i = 0; i < numSpheres; i++) {
+    const typename SphereOp<T>::Params params{Vec3T<T>(T(3 * i), 0, 0), T(1)};
+
+    const int leaf = builder.template emitLeaf<SphereOp<T>>(coord0, params);
+
+    root = (root < 0) ? leaf : builder.emitCombine(Opcode::UNION, root, leaf);
+  }
+
+  const Tape<T> tape = builder.finish(root);
+
+  // Leaf 0 sits at clause 0; every later leaf i sits at clause 2i - 1 (a fold clause follows each).
+  // The probe leaf must reference its own parameter bundle, not bundle (probe % 65536) == 0.
+  REQUIRE(tape.getClauses()[size_t(2) * probe - 1].paramIndex == uint32_t(probe));
+
+  // Inside sphere #65536: the old wraparound read sphere #0's parameters and returned a large
+  // positive distance here instead of -1.
+  const Vec3T<T> probeCenter(T(3 * probe), 0, 0);
+
+  REQUIRE_THAT(tape.value(probeCenter), withinAbsT(T(-1), exactMargin<T>()));
+  REQUIRE_THAT(tape.value(Vec3T<T>::zeros()), withinAbsT(T(-1), exactMargin<T>()));
+}
+
 TEMPLATE_TEST_CASE("Tape: smooth ISA opcodes match their trait eval via the builder",
                    "[Tape][Smooth][Opcode]",
                    EBGEOMETRY_TEST_PRECISIONS)

--- a/Tests/TestTape.cpp
+++ b/Tests/TestTape.cpp
@@ -4,9 +4,10 @@
 // Test suite for EBGeometry_Tape.hpp: the flat linear-SSA tape and its single-pass interpreter.
 // Validates the tape against the recursive value() oracle -- for every covered tree,
 // compile(tree).value(p) must reproduce tree.value(p). It also checks device-eligibility
-// bookkeeping: pure-primitive trees (including binary smooth combiners with a registered Blend) are
-// device-eligible, while opaque-host fallbacks (Perlin, Blur, smooth combiners over more than two
-// children, custom unregistered blends, BVH unions) are not.
+// bookkeeping: pure-primitive trees (including binary smooth combiners with a registered Blend and
+// the BVH-accelerated unions, which lower to native BVH clauses with an in-interpreter pruned
+// traversal) are device-eligible, while opaque-host fallbacks (Perlin, Blur, smooth combiners over
+// more than two children, custom unregistered blends, nested BVH unions) are not.
 
 #include "EBGeometry.hpp"
 #include "TestFloatingPointUtils.hpp"
@@ -462,40 +463,471 @@ TEMPLATE_TEST_CASE("Tape: TapeView::value with caller-provided scratch matches T
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// (11) BVH-accelerated union -> opaque host fallback (Tier 6 gives it a native BVH opcode)
+// (11) BVH-accelerated unions -> native BVH clauses (Tier 6): the tape carries the PackedBVH's
+//      topology and the interpreter runs a pruned traversal that executes leaf clause sub-ranges
+//      from the deferred region on demand.
 // ─────────────────────────────────────────────────────────────────────────────
 
-TEMPLATE_TEST_CASE("Tape: BVH-accelerated union compiles via the opaque-host fallback",
-                   "[Tape][DeviceEligible][BVH]",
+namespace {
+
+// A row of disjoint unit spheres, centers a_spacing apart, with tight AABBs.
+template <class T>
+void
+makeSphereRow(int                                         a_numSpheres,
+              T                                           a_spacing,
+              std::vector<std::shared_ptr<SphereSDF<T>>>& a_spheres,
+              std::vector<BoundingVolumes::AABBT<T>>&     a_bvs)
+{
+  for (int i = 0; i < a_numSpheres; i++) {
+    const Vec3T<T> center(T(i) * a_spacing, 0, 0);
+
+    a_spheres.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
+    a_bvs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
+  }
+}
+
+// A 6x6x6 grid (216 entries) of mixed, transformed primitives -- spheres, rotated boxes, scaled
+// tori, offset capsules -- with conservative AABBs. Every entry is a metric SDF built from
+// registered primitives/transforms only, so the whole scene lowers natively.
+template <class T>
+void
+makeMixedScene(std::vector<std::shared_ptr<IF<T>>>& a_primitives, std::vector<BoundingVolumes::AABBT<T>>& a_bvs)
+{
+  constexpr int n = 6;
+
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < n; j++) {
+      for (int k = 0; k < n; k++) {
+        const Vec3T<T> center(T(3 * i), T(3 * j), T(3 * k));
+
+        std::shared_ptr<IF<T>> primitive;
+
+        switch ((i + j + k) % 4) {
+        case 0: {
+          primitive = Translate<T>(std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(0.8)), center);
+
+          break;
+        }
+        case 1: {
+          primitive = Translate<T>(
+            Rotate<T>(std::make_shared<BoxSDF<T>>(Vec3T<T>(-0.7, -0.7, -0.7), Vec3T<T>(0.7, 0.7, 0.7)), T(30), 2),
+            center);
+
+          break;
+        }
+        case 2: {
+          primitive =
+            Translate<T>(Scale<T>(std::make_shared<TorusSDF<T>>(Vec3T<T>::zeros(), T(0.5), T(0.2)), T(1.5)), center);
+
+          break;
+        }
+        default: {
+          primitive = Translate<T>(
+            Offset<T>(std::make_shared<CapsuleSDF<T>>(Vec3T<T>(0, -0.4, 0), Vec3T<T>(0, 0.4, 0), T(0.3)), T(0.1)),
+            center);
+
+          break;
+        }
+        }
+
+        a_primitives.push_back(primitive);
+        a_bvs.emplace_back(center - Vec3T<T>(1.5, 1.5, 1.5), center + Vec3T<T>(1.5, 1.5, 1.5));
+      }
+    }
+  }
+}
+
+// A dense-ish grid of query points spanning the mixed scene (inside, on-surface, and far), plus
+// the standard query spread.
+template <class T>
+std::vector<Vec3T<T>>
+mixedScenePoints()
+{
+  std::vector<Vec3T<T>> points = queryPoints<T>();
+
+  const T coords[6] = {T(-2.0), T(1.3), T(4.9), T(8.1), T(11.7), T(16.4)};
+
+  for (const T x : coords) {
+    for (const T y : coords) {
+      for (const T z : coords) {
+        points.emplace_back(x, y, z);
+      }
+    }
+  }
+
+  return points;
+}
+
+// Golden equivalence for one branching factor: the tape must be device-eligible and reproduce
+// BVHUnionIF::value. Exact agreement is expected for metric primitives: both sides fold identical
+// clause-evaluated leaf values, and branch-and-bound with a valid lower bound returns the exact
+// minimum regardless of visited-set differences.
+template <class T, size_t K>
+void
+requireBVHUnionGolden()
+{
+  using BV = BoundingVolumes::AABBT<T>;
+
+  std::vector<std::shared_ptr<IF<T>>> primitives;
+  std::vector<BV>                     bvs;
+
+  makeMixedScene<T>(primitives, bvs);
+
+  const BVHUnionIF<T, IF<T>, BV, K> bvhUnion(primitives, bvs);
+
+  const Tape<T> tape = compile<T>(bvhUnion);
+
+  REQUIRE(tape.isDeviceEligible());
+
+  for (const auto& p : mixedScenePoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(bvhUnion.value(p), exactMargin<T>()));
+  }
+}
+
+} // namespace
+
+TEMPLATE_TEST_CASE("Tape: BVH union over mixed transformed primitives lowers natively (K in {2,4,8})",
+                   "[Tape][BVH]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  requireBVHUnionGolden<T, 2>();
+  requireBVHUnionGolden<T, 4>();
+  requireBVHUnionGolden<T, 8>();
+}
+
+TEMPLATE_TEST_CASE("Tape: BVH tape structure: deferred clause region and block/leaf tables",
+                   "[Tape][BVH]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T  = TestType;
   using BV = BoundingVolumes::AABBT<T>;
 
-  constexpr size_t K          = 4;
-  constexpr int    numSpheres = 4;
+  constexpr int numSpheres = 4;
 
-  // A row of disjoint unit spheres, centers 3 apart (mirrors TestCSG's sphereRow fixture).
   std::vector<std::shared_ptr<SphereSDF<T>>> spheres;
   std::vector<BV>                            bvs;
 
-  for (int i = 0; i < numSpheres; i++) {
+  makeSphereRow<T>(numSpheres, T(3), spheres, bvs);
+
+  const BVHUnionIF<T, SphereSDF<T>, BV, 2> bvhUnion(spheres, bvs);
+
+  const Tape<T> tape = compile<T>(bvhUnion);
+
+  // The whole main program is the single BVH clause; every sphere's subtree lives in the deferred
+  // region behind it.
+  REQUIRE(tape.getNumMainClauses() == 1);
+  REQUIRE(tape.getNumMainClauses() < static_cast<uint32_t>(tape.getClauses().size()));
+  REQUIRE(tape.getBVHBlocks().size() == 1);
+  REQUIRE(tape.getBVHBlocks()[0].numLeaves == static_cast<uint32_t>(numSpheres));
+  REQUIRE(tape.getBVHBlocks()[0].numNodes == static_cast<uint32_t>(tape.getBVHNodes().size()));
+  REQUIRE(tape.getBVHLeaves().size() == static_cast<size_t>(numSpheres));
+
+  for (const auto& leaf : tape.getBVHLeaves()) {
+    REQUIRE(leaf.clauseBegin >= tape.getNumMainClauses());
+    REQUIRE(leaf.clauseCount > 0);
+    REQUIRE(leaf.clauseBegin + leaf.clauseCount <= static_cast<uint32_t>(tape.getClauses().size()));
+  }
+
+  // A tape without BVH clauses has no deferred region.
+  const auto sphereA = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+  const auto sphereB = std::make_shared<SphereSDF<T>>(Vec3T<T>(3, 0, 0), T(1));
+
+  const Tape<T> plainTape = compile<T>(*Union<T>(sphereA, sphereB));
+
+  REQUIRE(plainTape.getNumMainClauses() == static_cast<uint32_t>(plainTape.getClauses().size()));
+  REQUIRE(plainTape.getBVHBlocks().empty());
+}
+
+namespace {
+
+// A sphere that counts its value() evaluations. It has no flatten() override and no leaf trait, so
+// inside a BVH leaf subtree it lowers to a HOST_CALLBACK clause -- allowed (the tape merely
+// becomes host-only), and the counter then observes directly whether the interpreter's traversal
+// executed or skipped that leaf's clause sub-range.
+template <class T>
+class CountingSphereIF : public ImplicitFunction<T>
+{
+public:
+  CountingSphereIF(const Vec3T<T>& a_center, const T a_radius, int* a_counter) noexcept
+    : m_sphere(a_center, a_radius), m_counter(a_counter)
+  {}
+
+  [[nodiscard]] T
+  value(const Vec3T<T>& a_point) const noexcept override
+  {
+    (*m_counter)++;
+
+    return m_sphere.value(a_point);
+  }
+
+private:
+  SphereSDF<T> m_sphere;
+  int*         m_counter;
+};
+
+} // namespace
+
+TEMPLATE_TEST_CASE("Tape: BVH traversal prunes leaf clause sub-ranges (observed via a counting leaf)",
+                   "[Tape][BVH]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  int counter = 0;
+
+  // Four unit spheres near the origin plus a counting sphere far away at x = 30.
+  std::vector<std::shared_ptr<IF<T>>> primitives;
+  std::vector<BV>                     bvs;
+
+  for (int i = 0; i < 4; i++) {
     const Vec3T<T> center(T(3 * i), 0, 0);
 
-    spheres.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
+    primitives.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
     bvs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
   }
 
-  const BVHUnionIF<T, SphereSDF<T>, BV, K> bvhUnion(spheres, bvs);
+  const Vec3T<T> farCenter(T(30), 0, 0);
 
-  // BVHUnionIF has no flatten() lowering override, so the whole node lowers to a single opaque
-  // host-callback clause -- correct but host-only. Tier 6 gives it a native BVH opcode.
+  primitives.push_back(std::make_shared<CountingSphereIF<T>>(farCenter, T(1), &counter));
+  bvs.emplace_back(farCenter - Vec3T<T>::ones(), farCenter + Vec3T<T>::ones());
+
+  const BVHUnionIF<T, IF<T>, BV, 2> bvhUnion(primitives, bvs);
+
   const Tape<T> tape = compile<T>(bvhUnion);
+
+  // The counting leaf's subtree is a host callback, so the tape is host-only -- but the BVH clause
+  // itself is still native.
+  REQUIRE_FALSE(tape.isDeviceEligible());
+  REQUIRE(counter == 0);
+
+  // Querying inside the first sphere gives a negative running best, collapsing the pruning bound
+  // to zero: the far leaf's sub-range must never execute.
+  const T nearValue = tape.value(Vec3T<T>::zeros());
+
+  REQUIRE(counter == 0);
+  REQUIRE_THAT(nearValue, withinAbsT(T(-1), exactMargin<T>()));
+
+  // Querying at the far sphere's center must execute its sub-range.
+  const T farValue = tape.value(farCenter);
+
+  REQUIRE(counter > 0);
+  REQUIRE_THAT(farValue, withinAbsT(T(-1), exactMargin<T>()));
+}
+
+TEMPLATE_TEST_CASE("Tape: a nested BVH union lowers to a host callback and stays exact",
+                   "[Tape][BVH][DeviceEligible]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  std::vector<std::shared_ptr<SphereSDF<T>>> innerSpheres;
+  std::vector<BV>                            innerBVs;
+
+  makeSphereRow<T>(4, T(3), innerSpheres, innerBVs);
+
+  const auto inner = std::make_shared<BVHUnionIF<T, SphereSDF<T>, BV, 2>>(innerSpheres, innerBVs);
+
+  // Outer union: the inner BVH union is one leaf primitive among ordinary spheres.
+  std::vector<std::shared_ptr<IF<T>>> outerPrimitives;
+  std::vector<BV>                     outerBVs;
+
+  outerPrimitives.push_back(inner);
+  outerBVs.push_back(inner->getBoundingVolume());
+
+  for (int i = 0; i < 3; i++) {
+    const Vec3T<T> center(T(3 * i), T(5), 0);
+
+    outerPrimitives.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
+    outerBVs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
+  }
+
+  const BVHUnionIF<T, IF<T>, BV, 2> outer(outerPrimitives, outerBVs);
+
+  const Tape<T> tape = compile<T>(outer);
+
+  // The inner union's leaf subtree is an opaque host callback (Tier 6 forbids nested BVH clauses),
+  // so the tape is host-only -- but values still match the recursive oracle exactly.
+  REQUIRE_FALSE(tape.isDeviceEligible());
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(outer.value(p), exactMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: BVH smooth union with the default SmoothMinOp blend lowers natively",
+                   "[Tape][BVH][Smooth]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  // Overlapping spheres (centers 1.5 apart, radius 1) so the two-nearest blend is active over much
+  // of the row.
+  std::vector<std::shared_ptr<SphereSDF<T>>> spheres;
+  std::vector<BV>                            bvs;
+
+  makeSphereRow<T>(8, T(1.5), spheres, bvs);
+
+  const T smoothLen = T(0.25);
+
+  const BVHSmoothUnionIF<T, SphereSDF<T>, BV, 4> smooth(spheres, bvs, smoothLen);
+
+  const Tape<T> tape = compile<T>(smooth);
+
+  REQUIRE(tape.isDeviceEligible());
+
+  for (const auto& p : mixedScenePoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(smooth.value(p), formulaMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: BVH smooth union with an explicit ExpMinOp blend lowers natively",
+                   "[Tape][BVH][Smooth]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  std::vector<std::shared_ptr<SphereSDF<T>>> spheres;
+  std::vector<BV>                            bvs;
+
+  makeSphereRow<T>(8, T(1.5), spheres, bvs);
+
+  const T smoothLen = T(0.25);
+
+  const BVHSmoothUnionIF<T, SphereSDF<T>, BV, 4, ExpMinOp<T>> smooth(spheres, bvs, smoothLen);
+
+  const Tape<T> tape = compile<T>(smooth);
+
+  REQUIRE(tape.isDeviceEligible());
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(smooth.value(p), formulaMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: BVH smooth union with an unregistered custom blend falls back to a host callback",
+                   "[Tape][BVH][Smooth][DeviceEligible]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  std::vector<std::shared_ptr<SphereSDF<T>>> spheres;
+  std::vector<BV>                            bvs;
+
+  makeSphereRow<T>(8, T(1.5), spheres, bvs);
+
+  const T smoothLen = T(0.25);
+
+  const BVHSmoothUnionIF<T, SphereSDF<T>, BV, 4, QuadraticBlend<T>> smooth(spheres, bvs, smoothLen);
+
+  const Tape<T> tape = compile<T>(smooth);
 
   REQUIRE_FALSE(tape.isDeviceEligible());
 
   for (const auto& p : queryPoints<T>()) {
-    REQUIRE_THAT(tape.value(p), withinAbsT(bvhUnion.value(p), exactMargin<T>()));
+    REQUIRE_THAT(tape.value(p), withinAbsT(smooth.value(p), formulaMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: single-primitive BVH smooth union blends against +inf, matching value()",
+                   "[Tape][BVH][Smooth]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  std::vector<std::shared_ptr<SphereSDF<T>>> spheres{std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1))};
+  std::vector<BV>                            bvs{BV(-Vec3T<T>::ones(), Vec3T<T>::ones())};
+
+  const BVHSmoothUnionIF<T, SphereSDF<T>, BV, 2> smooth(spheres, bvs, T(0.25));
+
+  const Tape<T> tape = compile<T>(smooth);
+
+  REQUIRE(tape.isDeviceEligible());
+
+  // With a single primitive the second-nearest value stays +inf and the blend must reduce to the
+  // primitive's own value, exactly as in BVHSmoothUnionIF::value.
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(smooth.value(p), formulaMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: BVH leaf subtrees share one scratch slot window",
+                   "[Tape][BVH][Slots]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  constexpr int numLeaves = 128;
+
+  // Every leaf is Translate(Sphere): one coordinate slot (the translated frame) plus one value
+  // slot (the sphere) per leaf if slots were disjoint.
+  std::vector<std::shared_ptr<IF<T>>> primitives;
+  std::vector<BV>                     bvs;
+
+  for (int i = 0; i < numLeaves; i++) {
+    const Vec3T<T> center(T(3 * i), 0, 0);
+
+    primitives.push_back(Translate<T>(std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1)), center));
+    bvs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
+  }
+
+  const BVHUnionIF<T, IF<T>, BV, 8> bvhUnion(primitives, bvs);
+
+  const Tape<T> tape = compile<T>(bvhUnion);
+
+  REQUIRE(tape.isDeviceEligible());
+
+  // Leaf sub-ranges execute strictly sequentially and each leaf's value slot is folded immediately
+  // after its range runs, so all 128 leaves share one slot window: scratch is main program + max
+  // over leaves, not main + sum. Disjoint slots would need >= numLeaves entries here.
+  REQUIRE(tape.getNumValueSlots() < static_cast<uint32_t>(numLeaves));
+  REQUIRE(tape.getNumCoordSlots() < static_cast<uint32_t>(numLeaves));
+
+  // Exact budget for this tape: {BVH output, shared leaf value} and {root frame, shared translated
+  // frame}.
+  REQUIRE(tape.getNumValueSlots() == 2);
+  REQUIRE(tape.getNumCoordSlots() == 2);
+
+  const BVHUnionIF<T, IF<T>, BV, 8>& oracle = bvhUnion;
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(oracle.value(p), exactMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: TapeView::value with exactly-sized caller scratch works on a BVH tape",
+                   "[Tape][BVH][Value]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  std::vector<std::shared_ptr<IF<T>>> primitives;
+  std::vector<BV>                     bvs;
+
+  makeMixedScene<T>(primitives, bvs);
+
+  const BVHUnionIF<T, IF<T>, BV, 4> bvhUnion(primitives, bvs);
+
+  const Tape<T>     tape = compile<T>(bvhUnion);
+  const TapeView<T> view = tape.view();
+
+  // Buffers sized to exactly the advertised slot counts: the deferred leaf sub-ranges must fit in
+  // the same scratch as the main pass (the shared slot window), with no out-of-bounds access
+  // (verified under ASan in the debug-san preset).
+  std::vector<Vec3T<T>> coordScratch(tape.getNumCoordSlots());
+  std::vector<T>        valueScratch(tape.getNumValueSlots());
+
+  for (const auto& p : queryPoints<T>()) {
+    REQUIRE_THAT(view.value(p, coordScratch.data(), valueScratch.data()), withinAbsT(tape.value(p), exactMargin<T>()));
   }
 }
 
@@ -556,5 +988,53 @@ TEMPLATE_TEST_CASE("Tape: nested tape evaluation through a host callback is safe
 
   for (const auto& p : queryPoints<T>()) {
     REQUIRE_THAT(tape.value(p), withinAbsT(outer->value(p), exactMargin<T>()));
+  }
+}
+
+TEMPLATE_TEST_CASE("Tape: nested tape evaluation through a BVH leaf host callback is safe",
+                   "[Tape][BVH][HostCallback][Reentrancy]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T  = TestType;
+  using BV = BoundingVolumes::AABBT<T>;
+
+  // The adapter's inner tree is deliberately deeper (more slots) than the enclosing BVH tape, so a
+  // naively shared scratch buffer would be regrown and overwritten when the BVH leaf's HOST_CALLBACK
+  // re-enters Tape::value mid-traversal on this same thread.
+  const Vec3T<T> adapterCenter(T(9), 0, 0);
+
+  const auto box   = std::make_shared<BoxSDF<T>>(Vec3T<T>(-1, -1, -1), Vec3T<T>(1, 1, 1));
+  const auto inner = Offset<T>(Translate<T>(Rotate<T>(Scale<T>(box, T(0.5)), T(20), 1), adapterCenter), T(0.1));
+
+  const auto adapter = std::make_shared<TapeBackedIF<T>>(inner);
+
+  std::vector<std::shared_ptr<IF<T>>> primitives;
+  std::vector<BV>                     bvs;
+
+  for (int i = 0; i < 3; i++) {
+    const Vec3T<T> center(T(3 * i), 0, 0);
+
+    primitives.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
+    bvs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
+  }
+
+  primitives.push_back(adapter);
+  bvs.emplace_back(adapterCenter - Vec3T<T>(2, 2, 2), adapterCenter + Vec3T<T>(2, 2, 2));
+
+  const BVHUnionIF<T, IF<T>, BV, 2> bvhUnion(primitives, bvs);
+
+  const Tape<T> tape = compile<T>(bvhUnion);
+
+  REQUIRE_FALSE(tape.isDeviceEligible());
+
+  // Points near the adapter force its leaf sub-range (and thus the nested tape evaluation) to run;
+  // the standard spread covers the pruned side too.
+  std::vector<Vec3T<T>> points = queryPoints<T>();
+
+  points.push_back(adapterCenter);
+  points.emplace_back(T(8.4), T(0.2), T(-0.1));
+
+  for (const auto& p : points) {
+    REQUIRE_THAT(tape.value(p), withinAbsT(bvhUnion.value(p), exactMargin<T>()));
   }
 }

--- a/Tests/TestTape.cpp
+++ b/Tests/TestTape.cpp
@@ -4,8 +4,9 @@
 // Test suite for EBGeometry_Tape.hpp: the flat linear-SSA tape and its single-pass interpreter.
 // Validates the tape against the recursive value() oracle -- for every covered tree,
 // compile(tree).value(p) must reproduce tree.value(p). It also checks device-eligibility
-// bookkeeping: pure-primitive trees are device-eligible, while opaque-host fallbacks (Perlin, Blur,
-// smooth combiners over more than two children, BVH unions) are not.
+// bookkeeping: pure-primitive trees (including binary smooth combiners with a registered Blend) are
+// device-eligible, while opaque-host fallbacks (Perlin, Blur, smooth combiners over more than two
+// children, custom unregistered blends, BVH unions) are not.
 
 #include "EBGeometry.hpp"
 #include "TestFloatingPointUtils.hpp"
@@ -183,12 +184,13 @@ TEMPLATE_TEST_CASE("Tape: sharp union/intersection/difference match value(), bin
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// (6) Smooth combiners lower to an opaque host callback (their blend operator is a
-//     user-overridable std::function that cannot be verified against the ISA), so they still match
-//     value() exactly but are not device-eligible.
+// (6) Smooth combiners are templated on their Blend operator, so a binary combiner with a
+//     registered blend (SmoothMinOp/SmoothMaxOp/ExpMinOp) lowers to a native SMOOTH_MIN/
+//     SMOOTH_MAX/EXP_MIN clause: it matches value() AND is device-eligible. An unregistered
+//     custom blend still matches value() exactly, but via an opaque host callback.
 // ─────────────────────────────────────────────────────────────────────────────
 
-TEMPLATE_TEST_CASE("Tape: smooth combiners match value() via an opaque host node",
+TEMPLATE_TEST_CASE("Tape: binary smooth combiners with default blends lower natively and are device-eligible",
                    "[Tape][CSG][Smooth]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
@@ -208,15 +210,91 @@ TEMPLATE_TEST_CASE("Tape: smooth combiners match value() via an opaque host node
   requireTapeMatchesOracle<T>(*smoothInter, formulaMargin<T>());
   requireTapeMatchesOracle<T>(*smoothDiff, formulaMargin<T>());
 
-  // A std::function blend operator keeps every smooth combiner host-only.
-  REQUIRE_FALSE(compile<T>(*smoothUnion).isDeviceEligible());
-  REQUIRE_FALSE(compile<T>(*smoothInter).isDeviceEligible());
-  REQUIRE_FALSE(compile<T>(*smoothDiff).isDeviceEligible());
+  // The default blends (SmoothMinOp/SmoothMaxOp) have registered ISA opcodes, so every binary
+  // smooth combiner now compiles to a native smooth clause -- no host callback involved.
+  REQUIRE(compile<T>(*smoothUnion).isDeviceEligible());
+  REQUIRE(compile<T>(*smoothInter).isDeviceEligible());
+  REQUIRE(compile<T>(*smoothDiff).isDeviceEligible());
 }
 
-// The SMOOTH_MIN/SMOOTH_MAX/EXP_MIN opcodes are the device ISA for blends emitted with a known
-// operator. They are exercised here directly through the builder API (the path a later BVH-smooth
-// tier uses), decoupled from the std::function-carrying smooth combiner nodes above.
+TEMPLATE_TEST_CASE("Tape: an explicitly chosen ExpMinOp blend lowers natively and matches value()",
+                   "[Tape][CSG][Smooth]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  const auto a = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+  const auto b = std::make_shared<SphereSDF<T>>(Vec3T<T>(3, 0, 0), T(1));
+
+  const T s = T(0.5);
+
+  const auto expUnion = SmoothUnion<T, ExpMinOp<T>>(a, b, s);
+
+  requireTapeMatchesOracle<T>(*expUnion, formulaMargin<T>());
+
+  REQUIRE(compile<T>(*expUnion).isDeviceEligible());
+}
+
+namespace {
+
+// A custom smooth blend with the right trait shape but no BlendOpcodeOf registration: the smooth
+// combiners must still reproduce value() exactly (via an opaque host callback), but the tape
+// cannot be device-eligible.
+template <class T>
+struct QuadraticBlend
+{
+  static T
+  eval(T a, T b, T s) noexcept
+  {
+    const T h = std::max(s - std::abs(a - b), T(0)) / s;
+
+    return std::min(a, b) - T(0.5) * h * h * s;
+  }
+};
+
+} // namespace
+
+TEMPLATE_TEST_CASE("Tape: an unregistered custom blend matches value() via an opaque host node",
+                   "[Tape][CSG][Smooth]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  const auto a = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+  const auto b = std::make_shared<SphereSDF<T>>(Vec3T<T>(3, 0, 0), T(1));
+
+  const T s = T(0.5);
+
+  const auto customUnion = SmoothUnion<T, QuadraticBlend<T>>(a, b, s);
+
+  requireTapeMatchesOracle<T>(*customUnion, formulaMargin<T>());
+
+  REQUIRE_FALSE(compile<T>(*customUnion).isDeviceEligible());
+}
+
+TEMPLATE_TEST_CASE("Tape: a single-child smooth union lowers to the child itself",
+                   "[Tape][CSG][Smooth]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  const auto a = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+
+  // value() returns the lone child unblended, so the lowering is the child's own clause -- exact
+  // and device-eligible even for an unregistered blend.
+  const SmoothUnionIF<T>                    oneDefault({a}, T(0.5));
+  const SmoothUnionIF<T, QuadraticBlend<T>> oneCustom({a}, T(0.5));
+
+  requireTapeMatchesOracle<T>(oneDefault, exactMargin<T>());
+  requireTapeMatchesOracle<T>(oneCustom, exactMargin<T>());
+
+  REQUIRE(compile<T>(oneDefault).isDeviceEligible());
+  REQUIRE(compile<T>(oneCustom).isDeviceEligible());
+}
+
+// The SMOOTH_MIN/SMOOTH_MAX/EXP_MIN opcodes are the device ISA for the registered blends. They are
+// also exercised here directly through the builder API (the path a later BVH-smooth tier uses),
+// decoupled from the smooth combiner nodes above.
 TEMPLATE_TEST_CASE("Tape: smooth ISA opcodes match their trait eval via the builder",
                    "[Tape][Smooth][Opcode]",
                    EBGEOMETRY_TEST_PRECISIONS)
@@ -271,6 +349,10 @@ TEMPLATE_TEST_CASE("Tape: deep mixed tree matches value()", "[Tape][CSG][Smooth]
   const auto tree        = Difference<T>(smoothUnion, Rotate<T>(cyl, T(25), 0));
 
   requireTapeMatchesOracle<T>(*tree, formulaMargin<T>());
+
+  // Every node here (including the binary smooth union, whose default SmoothMinOp blend lowers
+  // natively) has a native clause, so the whole mixed tree is device-eligible.
+  REQUIRE(compile<T>(*tree).isDeviceEligible());
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -305,7 +387,9 @@ TEMPLATE_TEST_CASE("Tape: pure-primitive trees are device-eligible; opaque nodes
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// (9) Smooth combiner over more than two children -> opaque host fallback
+// (9) Smooth combiner over more than two children -> opaque host fallback. value() blends only the
+//     two closest of the N child values, which is not expressible as a fold of binary smooth
+//     clauses, so even a registered blend must keep the host callback to stay exact.
 // ─────────────────────────────────────────────────────────────────────────────
 
 TEMPLATE_TEST_CASE("Tape: smooth union over three children falls back to an opaque host node",
@@ -320,7 +404,7 @@ TEMPLATE_TEST_CASE("Tape: smooth union over three children falls back to an opaq
 
   const std::vector<std::shared_ptr<SphereSDF<T>>> three{a, b, c};
 
-  const auto    smoothN    = SmoothUnion<T, SphereSDF<T>>(three, T(0.5));
+  const auto    smoothN    = SmoothUnion<T>(three, T(0.5));
   const Tape<T> smoothTape = compile<T>(*smoothN);
 
   REQUIRE_FALSE(smoothTape.isDeviceEligible());


### PR DESCRIPTION
# Summary

### Background

Tier 6 of the GPU port (issue #115). After Tier 5, BVH-accelerated unions — the library's flagship "union of many objects" feature — still lowered to opaque host callbacks, so any tree containing one was device-ineligible. Smooth combiners were likewise host-only because their blend operator was a `std::function`, which cannot be introspected into a device opcode. The core difficulty: a linear tape executes every clause unconditionally, but a BVH union's entire point is to *skip* subtrees whose bounding volume is further than the current best.

### Solution

**Template `Blend` parameter (replaces `std::function`).** All four smooth combiners (`SmoothUnionIF`, `SmoothIntersectionIF`, `SmoothDifferenceIF`, `BVHSmoothUnionIF`) now take a `Blend` template parameter (defaults `SmoothMinOp`/`SmoothMaxOp`); the `std::function` members/ctor parameters and the `SmoothMin<T>`/`SmoothMax<T>`/`ExpMin<T>` globals are deleted. Registered blends map to the smooth device ISA at compile time via `BlendOpcodeOf`; a custom blend struct still works everywhere on the CPU (now inlined, faster than the old `std::function` call) and lowers to an exact host callback. Binary smooth combiners with registered blends emit native clauses; N > 2 keeps the callback since `value()`'s two-smallest-of-N semantics is not a fold.

**BVH unions into the tape.** `compile()` now flattens a `BVHUnionIF`/`BVHSmoothUnionIF` into a native `BVH_UNION`/`BVH_SMOOTH_UNION` clause: the packed BVH topology is copied into trivially-copyable side arrays (`TapeBVHNode`/`TapeBVHLeaf`/`TapeBVHBlock`), and every leaf primitive's subtree compiles into a *deferred clause region* behind the main program, executed on demand. The interpreter runs an iterative, fixed-stack pruned traversal (pop-time bound recheck against `max(0, best)²`, near-to-far child ordering via `AABBT::getDistance2`, push-time filtering) that mirrors `PackedBVH::pruneTraverse` semantics exactly — sub-linear evaluation inside the single `HOST_DEVICE` forward pass. BVH leaf subtrees share one scratch slot window (counters rewound per leaf during `finish()`), so scratch scales with the largest leaf, not the leaf count — a 128-leaf tape needs 2 value slots, not 129, which keeps Tier 7's per-GPU-thread scratch feasible.

**Review hardening.** An adversarial review confirmed and reproduced one real bug, fixed here: `TapeClause::paramIndex` was `uint16_t` and silently wrapped at 65,536 parameter bundles (a 70,000-sphere union compiled fine and returned wrong geometry); it is now `uint32_t` (20-byte clause), with a 70,000-leaf regression test. Additionally: BVH blocks whose worst-case traversal-stack occupancy exceeds the fixed 256-entry stack fall back to an exact host callback instead of risking an out-of-bounds write in release; `isValidBlend` enforces `noexcept` on `Blend::eval`; assorted stale comments updated.

### Side-effects

Clean breaks: the `std::function` blend ctors and the `SmoothMin<T>`/`SmoothMax<T>`/`ExpMin<T>` globals are gone — custom blends become small functor structs (the trait shape used everywhere else), and choosing a non-default blend is now a template argument (`SmoothUnion<T, ExpMinOp<T>>(...)`). Picking a blend at runtime requires a construction-site switch. `TapeClause` grows from 16 to 20 bytes. Nested BVH unions (a BVH union as a leaf of another) lower to exact host callbacks in this tier — device-ineligible until a later tier. `PackedBVH` gains a read-only `getNodes()` accessor.

### Alternative solutions

An enumerated blend ctor parameter (`SmoothBlend::ExpMin`) was designed first but rejected in favor of the template parameter, which eliminates `std::function` from the hot path entirely and enforces the device/host split through the type system. For the traversal, executing leaf subtrees inline in the main clause region (no deferred region) was rejected because it defeats pruning; disjoint per-leaf slots were rejected because scratch would scale with total leaf count.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation. 
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS

---
_Generated by [Claude Code](https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS)_