### PR TITLE
GPU port (Tier 7): DeviceTape upload + CUDA golden test wired into ctest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -450,8 +450,8 @@ jobs:
           sub-packages: '["nvcc", "cudart"]'
       - name: Configure (CUDA smoke test)
         run: cmake -S . -B build/cuda -DEBGEOMETRY_ENABLE_CUDA=ON
-      - name: Build CUDA smoke test
-        run: cmake --build build/cuda --target EBGeometry_GPUSmoke --parallel 2
+      - name: Build CUDA targets (compile-only)
+        run: cmake --build build/cuda --target EBGeometry_GPUSmoke EBGeometry_GPUTape --parallel 2
 
   CI-passed:
     needs: [Formatting, Codespell, Reuse, Doxygen-check, Linux-GNU, Linux-Intel, Examples-GNUMake, Examples-CMake, Examples-FloatPrecision, Build-documentation, Unit-Tests, Release-Test, Sanitizers]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,24 @@ cmake --build --preset debug --target TestBVH
 ./build/debug/Tests/TestBVH
 ```
 
+### GPU/CUDA
+
+The `cuda` preset builds the CUDA targets (requires nvcc; not part of `Scripts/run-all-checks.sh`):
+
+```bash
+cmake --preset cuda                      # add -DCMAKE_CUDA_ARCHITECTURES=native to match your GPU
+cmake --build --preset cuda --parallel $(nproc)
+ctest --preset cuda                      # runs GPUTapeGolden; reports "Skipped" without a GPU
+```
+
+- `Tests/GPU/*.cu` (the Tier 0 device-portability smoke test and the Tier 7 `EBGeometry_GPUTape`
+  golden test) are compiled only under `EBGEOMETRY_ENABLE_CUDA=ON`; no host preset ever touches
+  them.
+- `GPUTapeGolden` self-skips with exit code 77 (mapped to a ctest "Skipped" via
+  `SKIP_RETURN_CODE`) when no CUDA device is present, so the preset is safe on GPU-less machines.
+- CI's `GPU-CUDA-Compile` lane is compile-only (`continue-on-error`); behavioral GPU validation
+  happens on a developer's CUDA machine.
+
 ## Documentation
 
 Two independent systems; both are also pre-commit hooks (see below) and CI jobs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ cmake --build --preset debug --target TestBVH
 The `cuda` preset builds the CUDA targets (requires nvcc; not part of `Scripts/run-all-checks.sh`):
 
 ```bash
-cmake --preset cuda                      # add -DCMAKE_CUDA_ARCHITECTURES=native to match your GPU
+cmake --preset cuda                      # optionally -DCMAKE_CUDA_ARCHITECTURES=native (needs CMake >= 3.24) to match your GPU
 cmake --build --preset cuda --parallel $(nproc)
 ctest --preset cuda                      # runs GPUTapeGolden; reports "Skipped" without a GPU
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,23 @@ if(EBGEOMETRY_ENABLE_CUDA)
   # __host__ __device__ code; --expt-relaxed-constexpr lets nvcc call those from device code.
   target_compile_options(EBGeometry_GPUSmoke PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
+
+  # Tier 7: device-runtime golden test (DeviceTape upload + kernel evaluation vs CPU references).
+  # Compiles without a GPU (the CI CUDA lane is compile-only); at runtime it exits with code 77
+  # (SKIP_RETURN_CODE below) when no CUDA device is present, so ctest reports it as "Skipped".
+  add_executable(EBGeometry_GPUTape Tests/GPU/EBGeometry_GPUTape.cu)
+  target_link_libraries(EBGeometry_GPUTape PRIVATE EBGeometry::EBGeometry)
+  target_compile_options(EBGeometry_GPUTape PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
+
+  if(EBGEOMETRY_BUILD_TESTS)
+    enable_testing() # idempotent; the Tests block below also calls it
+    add_test(NAME GPUTapeGolden COMMAND EBGeometry_GPUTape)
+    set_tests_properties(GPUTapeGolden PROPERTIES
+      LABELS "gpu"
+      SKIP_RETURN_CODE 77
+      TIMEOUT 120)
+  endif()
 endif()
 
 # ── Tests ─────────────────────────────────────────────────────────────────────

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,13 +53,27 @@
         "EBGEOMETRY_BUILD_TESTS": "ON",
         "EBGEOMETRY_BUILD_EXAMPLES": "ON"
       }
+    },
+    {
+      "name": "cuda",
+      "inherits": "base",
+      "displayName": "CUDA (tests + device golden test)",
+      "description": "Release-type build with the CUDA device runtime and the GPU golden test. Requires nvcc; the GPUTapeGolden test self-skips without a GPU.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "EBGEOMETRY_ENABLE_CUDA": "ON",
+        "EBGEOMETRY_ENABLE_ASSERTIONS": "OFF",
+        "EBGEOMETRY_SIMD": "none",
+        "EBGEOMETRY_BUILD_EXAMPLES": "OFF"
+      }
     }
   ],
   "buildPresets": [
     { "name": "debug",        "configurePreset": "debug"        },
     { "name": "debug-san",    "configurePreset": "debug-san"    },
     { "name": "release",      "configurePreset": "release"      },
-    { "name": "release-test", "configurePreset": "release-test" }
+    { "name": "release-test", "configurePreset": "release-test" },
+    { "name": "cuda",         "configurePreset": "cuda"         }
   ],
   "testPresets": [
     {
@@ -91,6 +105,14 @@
       "displayName": "Unit tests + examples (release)",
       "configurePreset": "release-test",
       "output": { "outputOnFailure": true },
+      "execution": { "timeout": 120 }
+    },
+    {
+      "name": "cuda",
+      "displayName": "GPU golden test (CUDA)",
+      "configurePreset": "cuda",
+      "output": { "outputOnFailure": true },
+      "filter": { "include": { "label": "gpu" } },
       "execution": { "timeout": 120 }
     }
   ]

--- a/EBGeometry.hpp
+++ b/EBGeometry.hpp
@@ -49,6 +49,10 @@
 // node definitions (not just their forward declarations) to define the flatten() overrides.
 #include "Source/EBGeometry_Tape.hpp"
 
+// EBGeometry_DeviceTape.hpp is inert (empty after preprocessing) unless the TU is translated by an
+// offload compiler (CUDA), so it is always safe to include here.
+#include "Source/EBGeometry_DeviceTape.hpp"
+
 /**
  * @brief Namespace containing all of EBGeometry's functionality.
  * @details EBGeometry is a header-only C++17 library for implicit functions, signed distance

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 > partially-ported state, and public interfaces may change without deprecation
 > aliases (clean breaks). Pin a tagged release if you need stability while the port
 > lands.
+> *Status: Tiers 0-7 landed — device-eligible tapes now upload and evaluate on CUDA
+> devices (`DeviceTape<T>`); remaining tiers cover HIP/SYCL backends and
+> async/performance work.*
 
 ## EBGeometry - a header-only C++ library for signed distance fields
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@
 > partially-ported state, and public interfaces may change without deprecation
 > aliases (clean breaks). Pin a tagged release if you need stability while the port
 > lands.
-> *Status: Tiers 0-7 landed — device-eligible tapes now upload and evaluate on CUDA
-> devices (`DeviceTape<T>`); remaining tiers cover HIP/SYCL backends and
-> async/performance work.*
+> *Status: Tiers 0-7 landed — device-eligible tapes upload to CUDA devices
+> (`DeviceTape<T>`) with a kernel golden test wired into ctest, pending behavioral
+> validation on real GPU hardware (CI compiles but cannot run CUDA); remaining tiers
+> cover HIP/SYCL backends and async/performance work.*
 
 ## EBGeometry - a header-only C++ library for signed distance fields
 

--- a/Source/EBGeometry_DeviceTape.hpp
+++ b/Source/EBGeometry_DeviceTape.hpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_DeviceTape.hpp
+ * @brief  Declaration of DeviceTape: an RAII owner of one Tape uploaded to CUDA device memory.
+ * @details DeviceTape copies a device-eligible @ref EBGeometry::Tape into a single pooled device
+ * allocation and hands out a trivially-copyable @ref EBGeometry::TapeView whose pointers are
+ * device pointers, ready to pass by value as a kernel argument. Everything in this header is
+ * guarded on @c EBGEOMETRY_CUDA (nvcc translating the current TU), so the header is inert -- and
+ * @c EBGeometry.hpp can include it unconditionally -- on a plain host compiler. Consequently, in
+ * this tier DeviceTape is usable only from @c .cu translation units; host-compiler consumption
+ * against @c libcudart is a possible later extension.
+ * @author Robert Marskar
+ */
+
+#ifndef EBGEOMETRY_DEVICETAPE_HPP
+#define EBGEOMETRY_DEVICETAPE_HPP
+
+// Our includes
+#include "EBGeometry_GPU.hpp"
+#include "EBGeometry_Tape.hpp"
+
+#if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_DOXYGEN)
+
+// Std includes
+#include <cstdio>
+#include <cstdlib>
+#include <type_traits>
+
+// CUDA runtime API (cudaMalloc/cudaMemcpy/cudaFree). nvcc pre-includes this, but spelling it out
+// keeps the dependency explicit.
+#include <cuda_runtime.h>
+
+// Our includes
+#include "EBGeometry_Macros.hpp"
+
+/**
+ * @brief Always-on CUDA runtime API error check: prints the failing call and aborts.
+ * @details Host-side only. Deliberately NOT gated on EBGEOMETRY_ENABLE_ASSERTIONS (unlike
+ * EBGEOMETRY_EXPECT): a failed allocation or copy leaves DeviceTape's view pointing at garbage,
+ * which a release build must not silently evaluate. Abort (rather than an exception) matches the
+ * library's no-exceptions convention.
+ * @param x CUDA runtime API call (or any expression) yielding a cudaError_t.
+ */
+#define EBGEOMETRY_CUDA_CHECK(x)                                                      \
+  do {                                                                                \
+    const cudaError_t ebgeometry_cuda_err = (x);                                      \
+    if (ebgeometry_cuda_err != cudaSuccess) {                                         \
+      std::fprintf(stderr,                                                            \
+                   "EBGeometry CUDA error: %s\n  call: %s\n  file: %s\n  line: %d\n", \
+                   cudaGetErrorString(ebgeometry_cuda_err),                           \
+                   #x,                                                                \
+                   __FILE__,                                                          \
+                   __LINE__);                                                         \
+      std::abort();                                                                   \
+    }                                                                                 \
+  } while (0)
+
+namespace EBGeometry {
+
+/**
+ * @brief RAII owner of one @ref Tape uploaded to CUDA device memory.
+ * @details A single pooled @c cudaMalloc holds every tape array back to back; @ref view returns a
+ * trivially-copyable @ref TapeView whose pointers are DEVICE pointers -- pass it BY VALUE as a
+ * kernel argument and call @c view.value(p, coordScratch, valueScratch) in the kernel. The source
+ * @ref Tape is fully copied at construction and need NOT stay alive afterwards (device-eligible
+ * tapes hold no host-node back-pointers by definition). Copies are synchronous on the default
+ * stream (async/stream support is a later tier). Move-only.
+ *
+ * See the golden test @c Tests/GPU/EBGeometry_GPUTape.cu for a complete upload-launch-compare
+ * usage example.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+class DeviceTape
+{
+  static_assert(std::is_floating_point_v<T>, "DeviceTape<T>: T must be a floating-point type");
+
+public:
+  /**
+   * @brief Deleted default constructor: a DeviceTape always wraps an uploaded Tape.
+   */
+  DeviceTape() = delete;
+
+  /**
+   * @brief Deleted copy constructor (move-only; the device pool has a single owner).
+   */
+  DeviceTape(const DeviceTape&) = delete;
+
+  /**
+   * @brief Deleted copy assignment (move-only; the device pool has a single owner).
+   */
+  DeviceTape&
+  operator=(const DeviceTape&) = delete;
+
+  /**
+   * @brief Upload @p a_tape to the current CUDA device.
+   * @details Aborts (always-on, independent of EBGEOMETRY_ENABLE_ASSERTIONS) if the tape is not
+   * device-eligible or any CUDA API call fails.
+   * @param[in] a_tape Compiled tape to upload; must satisfy Tape::isDeviceEligible.
+   */
+  EBGEOMETRY_HOST explicit DeviceTape(const Tape<T>& a_tape);
+
+  /**
+   * @brief Move constructor. Steals the device pool and view; the source is left empty.
+   * @param[in, out] a_other Tape to move from.
+   */
+  EBGEOMETRY_HOST
+  DeviceTape(DeviceTape&& a_other) noexcept;
+
+  /**
+   * @brief Move assignment. Frees this tape's pool, then steals from @p a_other.
+   * @param[in, out] a_other Tape to move from.
+   * @return This DeviceTape.
+   */
+  EBGEOMETRY_HOST DeviceTape&
+  operator=(DeviceTape&& a_other) noexcept;
+
+  /**
+   * @brief Destructor. Frees the device pool (the result of cudaFree is deliberately discarded in
+   * a destructor).
+   */
+  EBGEOMETRY_HOST ~DeviceTape() noexcept;
+
+  /**
+   * @brief Get the device-pointer view of the uploaded tape.
+   * @details The view's pointers are device pointers into this DeviceTape's pool and stay valid
+   * exactly as long as this DeviceTape is alive. Pass the view by value to kernels.
+   * @return A @ref TapeView whose array pointers are device pointers.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST TapeView<T>
+                                view() const noexcept
+  {
+    return m_view;
+  }
+
+  /**
+   * @brief Get the total number of bytes held by the device pool (diagnostics).
+   * @return Pool size in bytes.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST size_t
+  getNumBytes() const noexcept
+  {
+    return m_numBytes;
+  }
+
+private:
+  /**
+   * @brief Single device allocation holding every uploaded tape array.
+   */
+  void* m_pool = nullptr;
+
+  /**
+   * @brief Total pool size in bytes.
+   */
+  size_t m_numBytes = 0;
+
+  /**
+   * @brief View with device pointers plus the counts copied from the source tape.
+   */
+  TapeView<T> m_view{};
+};
+
+} // namespace EBGeometry
+
+#include "EBGeometry_DeviceTapeImplem.hpp"
+
+#endif // EBGEOMETRY_CUDA || EBGEOMETRY_DOXYGEN
+
+#endif // EBGEOMETRY_DEVICETAPE_HPP

--- a/Source/EBGeometry_DeviceTapeImplem.hpp
+++ b/Source/EBGeometry_DeviceTapeImplem.hpp
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_DeviceTapeImplem.hpp
+ * @brief  Implementation of EBGeometry_DeviceTape.hpp.
+ * @details Holds the out-of-line DeviceTape definitions: the pooled-upload constructor (a sizing
+ * pass and a copy pass, both driven by the EBGEOMETRY_TAPE_PARAM_SOA X-macro registry), the move
+ * operations, and the destructor. Included last from EBGeometry_DeviceTape.hpp, inside the same
+ * EBGEOMETRY_CUDA guard, so it is inert on a plain host compiler.
+ * @author Robert Marskar
+ */
+
+#ifndef EBGEOMETRY_DEVICETAPEIMPLEM_HPP
+#define EBGEOMETRY_DEVICETAPEIMPLEM_HPP
+
+// Our includes
+#include "EBGeometry_GPU.hpp"
+
+#if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_DOXYGEN)
+
+// Std includes
+#include <cstdio>
+#include <cstdlib>
+#include <type_traits>
+#include <vector>
+
+// CUDA runtime API.
+#include <cuda_runtime.h>
+
+// Our includes
+#include "EBGeometry_DeviceTape.hpp"
+#include "EBGeometry_Macros.hpp"
+#include "EBGeometry_Tape.hpp"
+
+namespace EBGeometry {
+
+namespace DeviceTapeDetail {
+
+/**
+ * @brief Byte alignment of every sub-array section inside the DeviceTape pool.
+ * @details 256 bytes is at least the natural alignment of every stored type and matches the base
+ * alignment cudaMalloc itself guarantees, so base + paddedOffset preserves it for every section.
+ */
+inline constexpr size_t DeviceTapeAlign = 256;
+
+/**
+ * @brief Round a byte count up to the next multiple of @ref DeviceTapeAlign.
+ * @param[in] a_bytes Unpadded byte count.
+ * @return Padded byte count.
+ */
+[[nodiscard]] EBGEOMETRY_HOST inline size_t
+padUp(size_t a_bytes) noexcept
+{
+  return (a_bytes + (DeviceTapeAlign - 1)) & ~(DeviceTapeAlign - 1);
+}
+
+/**
+ * @brief Padded byte footprint of one host vector in the DeviceTape pool.
+ * @details An empty vector reserves no section at all (zero bytes), consistently with
+ * @ref uploadArray handing out a null device pointer for it.
+ * @tparam U Element type.
+ * @param[in] a_host Host array.
+ * @return Padded byte count (zero for an empty vector).
+ */
+template <class U>
+[[nodiscard]] EBGEOMETRY_HOST size_t
+paddedBytes(const std::vector<U>& a_host) noexcept
+{
+  return a_host.empty() ? size_t(0) : padUp(a_host.size() * sizeof(U));
+}
+
+/**
+ * @brief Copy one host vector into the device pool at @p a_offset, advance @p a_offset by the
+ * padded section size, and return the typed device pointer to the copied section.
+ * @details An empty vector yields no copy, no offset advance, and a null pointer -- mirroring what
+ * Tape::view() hands out for an empty std::vector (whose .data() may be null), and matching the
+ * interpreter contract that an array no clause references is never dereferenced.
+ * @tparam U Element type (must be trivially copyable).
+ * @param[in]      a_base   Device base address of the pool.
+ * @param[in, out] a_offset Current byte offset into the pool; advanced by the padded section size.
+ * @param[in]      a_host   Host array to upload.
+ * @return Device pointer to the section holding the copied array (null for an empty array).
+ */
+template <class U>
+[[nodiscard]] EBGEOMETRY_HOST const U*
+uploadArray(unsigned char* a_base, size_t& a_offset, const std::vector<U>& a_host)
+{
+  static_assert(std::is_trivially_copyable_v<U>, "DeviceTape: uploaded element must be trivially copyable");
+
+  if (a_host.empty()) {
+    return nullptr;
+  }
+
+  const size_t numBytes = a_host.size() * sizeof(U);
+
+  EBGEOMETRY_CUDA_CHECK(cudaMemcpy(a_base + a_offset, a_host.data(), numBytes, cudaMemcpyHostToDevice));
+
+  const U* devicePtr = reinterpret_cast<const U*>(a_base + a_offset);
+
+  a_offset += padUp(numBytes);
+
+  return devicePtr;
+}
+
+} // namespace DeviceTapeDetail
+
+template <class T>
+DeviceTape<T>::DeviceTape(const Tape<T>& a_tape)
+{
+  // Always-on eligibility gate: in release the interpreter's device HOST_CALLBACK branch is a
+  // no-op (EBGeometry_TapeImplem.hpp), so evaluating a non-eligible tape on device would silently
+  // leave value slots unwritten. The EXPECT gives debug builds the standard diagnostic first.
+  EBGEOMETRY_EXPECT(a_tape.isDeviceEligible());
+
+  if (!a_tape.isDeviceEligible()) {
+    std::fprintf(stderr, "EBGeometry::DeviceTape: tape contains HOST_CALLBACK clauses and cannot run on device\n");
+    std::abort();
+  }
+
+  using namespace DeviceTapeDetail;
+
+  // ── Pass 1: size the pool ───────────────────────────────────────────────────
+  size_t numBytes = 0;
+
+  numBytes += paddedBytes(a_tape.m_clauses);
+
+#define EBGEOMETRY_TAPE_DEVICE_BYTES(OP, MEMBER) numBytes += paddedBytes(a_tape.m_##MEMBER);
+  EBGEOMETRY_TAPE_PARAM_SOA(EBGEOMETRY_TAPE_DEVICE_BYTES)
+#undef EBGEOMETRY_TAPE_DEVICE_BYTES
+
+  numBytes += paddedBytes(a_tape.m_scalarParams);
+  numBytes += paddedBytes(a_tape.m_bvhNodes);
+  numBytes += paddedBytes(a_tape.m_bvhChildren);
+  numBytes += paddedBytes(a_tape.m_bvhLeaves);
+  numBytes += paddedBytes(a_tape.m_bvhBlocks);
+  // m_hostNodes is empty by device-eligibility (asserted above) -- never uploaded.
+
+  m_numBytes = numBytes;
+
+  if (numBytes > 0) {
+    EBGEOMETRY_CUDA_CHECK(cudaMalloc(&m_pool, numBytes));
+  }
+
+  // ── Pass 2: copy each array and assemble the device view ────────────────────
+  unsigned char* base   = static_cast<unsigned char*>(m_pool);
+  size_t         offset = 0;
+
+  m_view.clauses    = uploadArray(base, offset, a_tape.m_clauses);
+  m_view.numClauses = static_cast<uint32_t>(a_tape.m_clauses.size());
+
+#define EBGEOMETRY_TAPE_DEVICE_UPLOAD(OP, MEMBER) m_view.MEMBER = uploadArray(base, offset, a_tape.m_##MEMBER);
+  EBGEOMETRY_TAPE_PARAM_SOA(EBGEOMETRY_TAPE_DEVICE_UPLOAD)
+#undef EBGEOMETRY_TAPE_DEVICE_UPLOAD
+
+  m_view.scalarParams = uploadArray(base, offset, a_tape.m_scalarParams);
+  m_view.hostNodes    = nullptr;
+
+  m_view.bvhNodes    = uploadArray(base, offset, a_tape.m_bvhNodes);
+  m_view.bvhChildren = uploadArray(base, offset, a_tape.m_bvhChildren);
+  m_view.bvhLeaves   = uploadArray(base, offset, a_tape.m_bvhLeaves);
+  m_view.bvhBlocks   = uploadArray(base, offset, a_tape.m_bvhBlocks);
+
+  m_view.numMainClauses = a_tape.m_numMainClauses;
+  m_view.numCoordSlots  = a_tape.m_numCoordSlots;
+  m_view.numValueSlots  = a_tape.m_numValueSlots;
+  m_view.rootValueSlot  = a_tape.m_rootValueSlot;
+  m_view.deviceEligible = true;
+
+  EBGEOMETRY_EXPECT(offset == m_numBytes);
+}
+
+template <class T>
+DeviceTape<T>::DeviceTape(DeviceTape&& a_other) noexcept
+  : m_pool(a_other.m_pool), m_numBytes(a_other.m_numBytes), m_view(a_other.m_view)
+{
+  a_other.m_pool     = nullptr;
+  a_other.m_numBytes = 0;
+  a_other.m_view     = TapeView<T>();
+}
+
+template <class T>
+DeviceTape<T>&
+DeviceTape<T>::operator=(DeviceTape&& a_other) noexcept
+{
+  if (this != &a_other) {
+    if (m_pool != nullptr) {
+      (void)cudaFree(m_pool);
+    }
+
+    m_pool     = a_other.m_pool;
+    m_numBytes = a_other.m_numBytes;
+    m_view     = a_other.m_view;
+
+    a_other.m_pool     = nullptr;
+    a_other.m_numBytes = 0;
+    a_other.m_view     = TapeView<T>();
+  }
+
+  return *this;
+}
+
+template <class T>
+DeviceTape<T>::~DeviceTape() noexcept
+{
+  if (m_pool != nullptr) {
+    (void)cudaFree(m_pool);
+  }
+}
+
+} // namespace EBGeometry
+
+#endif // EBGEOMETRY_CUDA || EBGEOMETRY_DOXYGEN
+
+#endif // EBGEOMETRY_DEVICETAPEIMPLEM_HPP

--- a/Source/EBGeometry_DeviceTapeImplem.hpp
+++ b/Source/EBGeometry_DeviceTapeImplem.hpp
@@ -119,6 +119,16 @@ DeviceTape<T>::DeviceTape(const Tape<T>& a_tape)
     std::abort();
   }
 
+  // A default-constructed Tape reports device-eligible but has zero clauses and zero slots;
+  // evaluating its view would write coordScratch[0] out of bounds with assertions off. Every tape
+  // produced by compile() has at least one clause, so this gate only rejects misuse.
+  EBGEOMETRY_EXPECT(!a_tape.getClauses().empty());
+
+  if (a_tape.getClauses().empty()) {
+    std::fprintf(stderr, "EBGeometry::DeviceTape: tape is empty (not produced by compile())\n");
+    std::abort();
+  }
+
   using namespace DeviceTapeDetail;
 
   // ── Pass 1: size the pool ───────────────────────────────────────────────────

--- a/Source/EBGeometry_Tape.hpp
+++ b/Source/EBGeometry_Tape.hpp
@@ -446,6 +446,15 @@ template <class T>
 class TapeBuilder;
 
 /**
+ * @brief Forward declaration of the CUDA device-side tape uploader (defined in
+ * EBGeometry_DeviceTape.hpp; friend of @ref Tape). The class is only defined when an offload
+ * compiler translates the TU, so this declaration is harmless on plain host compilers.
+ * @tparam T Floating-point precision.
+ */
+template <class T>
+class DeviceTape;
+
+/**
  * @brief Trivially-copyable, non-owning view of a @ref Tape suitable for passing to the interpreter
  * (and, in a later tier, to device code).
  * @details Holds raw pointers into a host-owned @ref Tape's arrays plus the slot counts and root
@@ -547,6 +556,11 @@ struct TapeView
   [[nodiscard]] EBGEOMETRY_HOST_DEVICE T
   value(const Vec3T<T>& a_point, Vec3T<T>* a_coordScratch, T* a_valueScratch) const noexcept;
 };
+
+// TapeView is passed BY VALUE as a device kernel argument (see EBGeometry_DeviceTape.hpp), so it
+// must stay trivially copyable for both precisions.
+static_assert(std::is_trivially_copyable_v<TapeView<float>>, "TapeView must be trivially copyable (kernel argument)");
+static_assert(std::is_trivially_copyable_v<TapeView<double>>, "TapeView must be trivially copyable (kernel argument)");
 
 /**
  * @brief Host-owned flat tape: the clause array plus every per-op parameter array.
@@ -691,6 +705,7 @@ public:
 
 private:
   friend class TapeBuilder<T>;
+  friend class DeviceTape<T>;
 
   /**
    * @brief The flat clause array, in single-forward-pass order.

--- a/Tests/GPU/EBGeometry_GPUTape.cu
+++ b/Tests/GPU/EBGeometry_GPUTape.cu
@@ -1,0 +1,415 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_GPUTape.cu
+ * @brief  CUDA golden test for DeviceTape: upload compiled tapes and evaluate them in a kernel.
+ * @details Tier 7 of the GPU port. For four representative device-eligible scenes (a deep mixed
+ * CSG tree, a nested transform chain, a 216-leaf BVH sharp union, and a BVH smooth union) this
+ * program compiles the tape on the host, uploads it with DeviceTape, evaluates it for every query
+ * point in a grid-stride kernel, and compares the device results against BOTH host references:
+ * the host-side tape interpreter (tape.value) and the recursive value() oracle (tree.value). Both
+ * float and double run unconditionally, making this binary the device-side analogue of
+ * Tests/InstantiateAll.cpp for Tape/DeviceTape (which the host-only object library cannot cover).
+ *
+ * The scene constructions and margins replicate Tests/TestTape.cpp line-for-line (origins cited at
+ * each helper) so host and device coverage stay in lockstep.
+ *
+ * This is a plain main() program (no Catch2): the CI CUDA lane configures without
+ * EBGEOMETRY_BUILD_TESTS, so Catch2 is never fetched there. Without a CUDA device the program
+ * exits with code 77, which the GPUTapeGolden ctest registration maps to "Skipped" via
+ * SKIP_RETURN_CODE.
+ *
+ * Scratch strategy: exact global scratch buffers of numPoints * numCoordSlots /
+ * numPoints * numValueSlots entries, sliced by point index, so any tape size works with no
+ * per-thread cap (fixed-size local scratch is the later performance-tier path).
+ * @author Robert Marskar
+ */
+
+#include "EBGeometry.hpp" // Pulls in Tape + DeviceTape (active: this TU is compiled by nvcc).
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+// ctest SKIP_RETURN_CODE (see the GPUTapeGolden test registration in CMakeLists.txt).
+constexpr int SKIP_EXIT_CODE = 77;
+
+using namespace EBGeometry;
+
+// ── Kernel ────────────────────────────────────────────────────────────────────
+
+/**
+ * @brief Grid-stride kernel: a_out[i] = a_view.value(a_points[i], per-point scratch slices).
+ * @param[in]  a_view         Device-pointer tape view (by value; trivially copyable).
+ * @param[in]  a_points       Query points (device, a_numPoints entries).
+ * @param[out] a_out          Results (device, a_numPoints entries).
+ * @param[in]  a_numPoints    Number of query points.
+ * @param[out] a_coordScratch Global scratch, a_numPoints * a_view.numCoordSlots entries (device).
+ * @param[out] a_valueScratch Global scratch, a_numPoints * a_view.numValueSlots entries (device).
+ */
+template <class T>
+EBGEOMETRY_GLOBAL void
+evaluateTape(
+  TapeView<T> a_view, const Vec3T<T>* a_points, T* a_out, int a_numPoints, Vec3T<T>* a_coordScratch, T* a_valueScratch)
+{
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < a_numPoints; i += gridDim.x * blockDim.x) {
+    a_out[i] = a_view.value(a_points[i],
+                            a_coordScratch + size_t(i) * a_view.numCoordSlots,
+                            a_valueScratch + size_t(i) * a_view.numValueSlots);
+  }
+}
+
+// ── Host-side helpers (replicated line-for-line from Tests/TestTape.cpp) ──────
+
+namespace {
+
+template <class T>
+using IF = ImplicitFunction<T>;
+
+// Margin helpers copied from Tests/TestTape.cpp (exactMargin/formulaMargin): two independent
+// traversals of the same trait statics should agree up to floating-point reordering only; smooth
+// blends get a slightly looser bound.
+template <class T>
+double
+exactMargin()
+{
+  return std::is_same_v<T, float> ? 1.0e-4 : 1.0e-12;
+}
+
+template <class T>
+double
+formulaMargin()
+{
+  return std::is_same_v<T, float> ? 1.0e-3 : 1.0e-9;
+}
+
+// A spread of inside/outside/surface-ish query points; copied from Tests/TestTape.cpp
+// (queryPoints).
+template <class T>
+std::vector<Vec3T<T>>
+queryPoints()
+{
+  return {Vec3T<T>::zeros(),
+          Vec3T<T>(0.5, 0, 0),
+          Vec3T<T>(1.5, 0, 0),
+          Vec3T<T>(-1.2, 0.7, 0.3),
+          Vec3T<T>(2, 2, 2),
+          Vec3T<T>(-3, 1, -2),
+          Vec3T<T>(0.1, -0.4, 0.9),
+          Vec3T<T>(3, 0, 0),
+          Vec3T<T>(0, 3, 0),
+          Vec3T<T>(-0.5, -0.5, -0.5)};
+}
+
+// A row of disjoint unit spheres, centers a_spacing apart, with tight AABBs; copied from
+// Tests/TestTape.cpp (makeSphereRow).
+template <class T>
+void
+makeSphereRow(int                                         a_numSpheres,
+              T                                           a_spacing,
+              std::vector<std::shared_ptr<SphereSDF<T>>>& a_spheres,
+              std::vector<BoundingVolumes::AABBT<T>>&     a_bvs)
+{
+  for (int i = 0; i < a_numSpheres; i++) {
+    const Vec3T<T> center(T(i) * a_spacing, 0, 0);
+
+    a_spheres.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
+    a_bvs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
+  }
+}
+
+// A 6x6x6 grid (216 entries) of mixed, transformed primitives -- spheres, rotated boxes, scaled
+// tori, offset capsules -- with conservative AABBs; copied from Tests/TestTape.cpp
+// (makeMixedScene). Every entry lowers natively, so the whole scene is device-eligible.
+template <class T>
+void
+makeMixedScene(std::vector<std::shared_ptr<IF<T>>>& a_primitives, std::vector<BoundingVolumes::AABBT<T>>& a_bvs)
+{
+  constexpr int n = 6;
+
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < n; j++) {
+      for (int k = 0; k < n; k++) {
+        const Vec3T<T> center(T(3 * i), T(3 * j), T(3 * k));
+
+        std::shared_ptr<IF<T>> primitive;
+
+        switch ((i + j + k) % 4) {
+        case 0: {
+          primitive = Translate<T>(std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(0.8)), center);
+
+          break;
+        }
+        case 1: {
+          primitive = Translate<T>(
+            Rotate<T>(std::make_shared<BoxSDF<T>>(Vec3T<T>(-0.7, -0.7, -0.7), Vec3T<T>(0.7, 0.7, 0.7)), T(30), 2),
+            center);
+
+          break;
+        }
+        case 2: {
+          primitive =
+            Translate<T>(Scale<T>(std::make_shared<TorusSDF<T>>(Vec3T<T>::zeros(), T(0.5), T(0.2)), T(1.5)), center);
+
+          break;
+        }
+        default: {
+          primitive = Translate<T>(
+            Offset<T>(std::make_shared<CapsuleSDF<T>>(Vec3T<T>(0, -0.4, 0), Vec3T<T>(0, 0.4, 0), T(0.3)), T(0.1)),
+            center);
+
+          break;
+        }
+        }
+
+        a_primitives.push_back(primitive);
+        a_bvs.emplace_back(center - Vec3T<T>(1.5, 1.5, 1.5), center + Vec3T<T>(1.5, 1.5, 1.5));
+      }
+    }
+  }
+}
+
+// A 16x16x16 uniform grid over [-3, 18]^3 -- spanning the mixed scene, whose centers run 0..15,
+// with inside/on-surface/far coverage -- plus the standard 10-point query spread (4106 points).
+template <class T>
+std::vector<Vec3T<T>>
+testPoints()
+{
+  std::vector<Vec3T<T>> points = queryPoints<T>();
+
+  constexpr int n = 16;
+
+  const T lo = T(-3);
+  const T hi = T(18);
+
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < n; j++) {
+      for (int k = 0; k < n; k++) {
+        const T x = lo + (hi - lo) * T(i) / T(n - 1);
+        const T y = lo + (hi - lo) * T(j) / T(n - 1);
+        const T z = lo + (hi - lo) * T(k) / T(n - 1);
+
+        points.emplace_back(x, y, z);
+      }
+    }
+  }
+
+  return points;
+}
+
+// ── Per-scene driver ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Compile a_tree, upload it, evaluate it on the device for every test point, and compare
+ * against both CPU references (host tape interpreter and recursive value() oracle).
+ * @param[in] a_name      Scene name for diagnostics.
+ * @param[in] a_precision Precision name for diagnostics.
+ * @param[in] a_tree      Source implicit-function tree (must be device-eligible).
+ * @param[in] a_margin    Absolute comparison margin.
+ * @return Zero on success, one on any mismatch (or a non-device-eligible tape, which is a test
+ * FAILURE here, not a skip).
+ */
+template <class T>
+int
+runScene(const char* a_name, const char* a_precision, const ImplicitFunction<T>& a_tree, double a_margin)
+{
+  const Tape<T> tape = compile<T>(a_tree);
+
+  if (!tape.isDeviceEligible()) {
+    std::printf("FAIL [%s, %s]: tape is not device-eligible\n", a_name, a_precision);
+
+    return 1;
+  }
+
+  const std::vector<Vec3T<T>> points    = testPoints<T>();
+  const int                   numPoints = static_cast<int>(points.size());
+
+  // CPU references: host tape interpreter and the recursive value() oracle.
+  std::vector<T> cpuTape(points.size());
+  std::vector<T> oracle(points.size());
+
+  for (size_t i = 0; i < points.size(); i++) {
+    cpuTape[i] = tape.value(points[i]);
+    oracle[i]  = a_tree.value(points[i]);
+  }
+
+  // Upload; move-construct once so the move path is exercised, then evaluate through the moved-to
+  // owner's view.
+  DeviceTape<T> deviceTape(tape);
+  DeviceTape<T> moved(std::move(deviceTape));
+
+  // Device buffers: points, results, and exact global scratch sliced per point.
+  Vec3T<T>* devicePoints       = nullptr;
+  T*        deviceOut          = nullptr;
+  Vec3T<T>* deviceCoordScratch = nullptr;
+  T*        deviceValueScratch = nullptr;
+
+  EBGEOMETRY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&devicePoints), points.size() * sizeof(Vec3T<T>)));
+  EBGEOMETRY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&deviceOut), points.size() * sizeof(T)));
+  EBGEOMETRY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&deviceCoordScratch),
+                                   points.size() * size_t(tape.getNumCoordSlots()) * sizeof(Vec3T<T>)));
+  EBGEOMETRY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&deviceValueScratch),
+                                   points.size() * size_t(tape.getNumValueSlots()) * sizeof(T)));
+
+  EBGEOMETRY_CUDA_CHECK(
+    cudaMemcpy(devicePoints, points.data(), points.size() * sizeof(Vec3T<T>), cudaMemcpyHostToDevice));
+
+  evaluateTape<T>
+    <<<256, 128>>>(moved.view(), devicePoints, deviceOut, numPoints, deviceCoordScratch, deviceValueScratch);
+
+  EBGEOMETRY_CUDA_CHECK(cudaGetLastError());
+  EBGEOMETRY_CUDA_CHECK(cudaDeviceSynchronize());
+
+  std::vector<T> gpuOut(points.size());
+
+  EBGEOMETRY_CUDA_CHECK(cudaMemcpy(gpuOut.data(), deviceOut, points.size() * sizeof(T), cudaMemcpyDeviceToHost));
+
+  EBGEOMETRY_CUDA_CHECK(cudaFree(devicePoints));
+  EBGEOMETRY_CUDA_CHECK(cudaFree(deviceOut));
+  EBGEOMETRY_CUDA_CHECK(cudaFree(deviceCoordScratch));
+  EBGEOMETRY_CUDA_CHECK(cudaFree(deviceValueScratch));
+
+  // Compare against BOTH references with the same absolute-margin convention as
+  // Tests/TestTape.cpp (withinAbsT).
+  int numMismatches = 0;
+
+  for (size_t i = 0; i < points.size(); i++) {
+    const double gpu       = double(gpuOut[i]);
+    const double deltaTape = std::abs(gpu - double(cpuTape[i]));
+    const double deltaTree = std::abs(gpu - double(oracle[i]));
+
+    if (deltaTape > a_margin || deltaTree > a_margin) {
+      if (numMismatches < 5) {
+        std::printf("  mismatch [%s, %s] at point (%g, %g, %g): gpu=%.12g cpuTape=%.12g oracle=%.12g margin=%g\n",
+                    a_name,
+                    a_precision,
+                    double(points[i][0]),
+                    double(points[i][1]),
+                    double(points[i][2]),
+                    gpu,
+                    double(cpuTape[i]),
+                    double(oracle[i]),
+                    a_margin);
+      }
+
+      numMismatches++;
+    }
+  }
+
+  std::printf("%s [%s, %s]: %d points, %d mismatches (pool: %zu bytes)\n",
+              numMismatches == 0 ? "PASS" : "FAIL",
+              a_name,
+              a_precision,
+              numPoints,
+              numMismatches,
+              moved.getNumBytes());
+
+  return numMismatches == 0 ? 0 : 1;
+}
+
+/**
+ * @brief Run all four golden scenes for one precision.
+ * @param[in] a_precision Precision name for diagnostics.
+ * @return Number of failing scenes.
+ */
+template <class T>
+int
+runAllScenes(const char* a_precision)
+{
+  int failures = 0;
+
+  // (1) Deep mixed tree: Difference(SmoothUnion(Translate(Sphere), Box, s), Rotate(Cylinder));
+  // copied from Tests/TestTape.cpp ("deep mixed tree matches value()").
+  {
+    const auto sphere = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+    const auto box    = std::make_shared<BoxSDF<T>>(Vec3T<T>(-0.8, -0.8, -0.8), Vec3T<T>(0.8, 0.8, 0.8));
+    const auto cyl    = std::make_shared<CylinderSDF<T>>(Vec3T<T>(0, -1, 0), Vec3T<T>(0, 1, 0), T(0.5));
+
+    const T s = T(0.4);
+
+    const auto smoothUnion = SmoothUnion<T>(Translate<T>(sphere, Vec3T<T>(0.2, 0, 0)), box, s);
+    const auto tree        = Difference<T>(smoothUnion, Rotate<T>(cyl, T(25), 0));
+
+    failures += runScene<T>("deep mixed tree", a_precision, *tree, formulaMargin<T>());
+  }
+
+  // (2) Nested transform chain: Offset(Annular(Translate(Rotate(Scale(Box)))));
+  // copied from Tests/TestTape.cpp ("nested tape evaluation through a host callback is safe",
+  // inner tree).
+  {
+    const auto box  = std::make_shared<BoxSDF<T>>(Vec3T<T>(-1, -1, -1), Vec3T<T>(1, 1, 1));
+    const auto tree = Offset<T>(
+      Annular<T>(Translate<T>(Rotate<T>(Scale<T>(box, T(1.5)), T(20), 1), Vec3T<T>(0.5, 0, 0)), T(0.1)), T(0.2));
+
+    failures += runScene<T>("nested transform chain", a_precision, *tree, exactMargin<T>());
+  }
+
+  // (3) BVH sharp union over the 216-leaf mixed scene (K=4); copied from Tests/TestTape.cpp
+  // (requireBVHUnionGolden).
+  {
+    using BV = BoundingVolumes::AABBT<T>;
+
+    std::vector<std::shared_ptr<IF<T>>> primitives;
+    std::vector<BV>                     bvs;
+
+    makeMixedScene<T>(primitives, bvs);
+
+    const BVHUnionIF<T, IF<T>, BV, 4> bvhUnion(primitives, bvs);
+
+    failures += runScene<T>("BVH sharp union (216 leaves, K=4)", a_precision, bvhUnion, exactMargin<T>());
+  }
+
+  // (4) BVH smooth union over an 8-sphere row with the default SmoothMinOp blend; copied from
+  // Tests/TestTape.cpp ("BVH smooth union with the default SmoothMinOp blend lowers natively").
+  {
+    using BV = BoundingVolumes::AABBT<T>;
+
+    std::vector<std::shared_ptr<SphereSDF<T>>> spheres;
+    std::vector<BV>                            bvs;
+
+    makeSphereRow<T>(8, T(1.5), spheres, bvs);
+
+    const T smoothLen = T(0.25);
+
+    const BVHSmoothUnionIF<T, SphereSDF<T>, BV, 4> smooth(spheres, bvs, smoothLen);
+
+    failures += runScene<T>("BVH smooth union (8 spheres, K=4)", a_precision, smooth, formulaMargin<T>());
+  }
+
+  return failures;
+}
+
+} // namespace
+
+/**
+ * @brief Host entry point: skip (exit 77) without a CUDA device, otherwise run every golden scene
+ * for both precisions.
+ * @return Zero on success, one on any mismatch, 77 (SKIP_EXIT_CODE) when no CUDA device exists.
+ */
+int
+main()
+{
+  int deviceCount = 0;
+
+  const cudaError_t err = cudaGetDeviceCount(&deviceCount);
+
+  if (err != cudaSuccess || deviceCount == 0) {
+    std::printf("GPUTape: no CUDA device available (%s) -- skipping\n",
+                err == cudaSuccess ? "device count is zero" : cudaGetErrorString(err));
+
+    return SKIP_EXIT_CODE;
+  }
+
+  int failures = 0;
+
+  failures += runAllScenes<float>("float");
+  failures += runAllScenes<double>("double");
+
+  std::printf("GPUTape: %d scene(s) failed\n", failures);
+
+  return failures == 0 ? 0 : 1;
+}

--- a/Tests/GPU/EBGeometry_GPUTape.cu
+++ b/Tests/GPU/EBGeometry_GPUTape.cu
@@ -282,7 +282,9 @@ runScene(const char* a_name, const char* a_precision, const ImplicitFunction<T>&
     const double deltaTape = std::abs(gpu - double(cpuTape[i]));
     const double deltaTree = std::abs(gpu - double(oracle[i]));
 
-    if (deltaTape > a_margin || deltaTree > a_margin) {
+    // Negated conjunction so that a NaN device result fails loudly (NaN comparisons are false, so
+    // the naive delta > margin form would silently count a NaN as passing).
+    if (!(deltaTape <= a_margin && deltaTree <= a_margin)) {
       if (numMismatches < 5) {
         std::printf("  mismatch [%s, %s] at point (%g, %g, %g): gpu=%.12g cpuTape=%.12g oracle=%.12g margin=%g\n",
                     a_name,

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -111,6 +111,10 @@ using Meta = short;
   template struct ReflectOp<PREC>;                                          \
                                                                                \
   /* -- Flat tape + interpreter -------------------------------------------*/ \
+  /* DeviceTape<PREC> is deliberately absent: it is CUDA-only (inert without */ \
+  /* an offload compiler), so it cannot be instantiated in this host-only    */ \
+  /* TU. Its device-side analogue is Tests/GPU/EBGeometry_GPUTape.cu, which  */ \
+  /* instantiates and exercises it for both precisions under nvcc.           */ \
   template class Tape<PREC>;                                                 \
   template struct TapeView<PREC>;                                            \
   template class TapeBuilder<PREC>;                                          \


### PR DESCRIPTION
# Summary

### Background

Tier 7 of the GPU port (issue #115). Tiers 4–6 built a device-eligible tape and a `HOST_DEVICE` interpreter, but nothing had ever moved a tape into GPU memory or launched a kernel over it. This tier adds the device runtime and its validation harness. Constraint agreed with the maintainer: the CI CUDA lane stays compile-only (no GPU runners), so the on-GPU golden test is wired into ctest with a graceful skip and executed locally on a CUDA machine.

### Solution

**`DeviceTape<T>`** (`Source/EBGeometry_DeviceTape.hpp` + `Implem`, inert on host compilers via the `EBGEOMETRY_CUDA`/`EBGEOMETRY_DOXYGEN` guard): move-only RAII upload of a compiled tape into a **single pooled `cudaMalloc`** — every array (clauses, the 19 per-op parameter SoAs via the same X-macro registry that drives `Tape::view()`, scalar params, and the four BVH arrays) is copied to a 256-byte-padded offset, and a trivially-copyable `TapeView<T>` with device pointers is assembled for passing **by value** as a kernel argument. Construction aborts (always-on, independent of assertions) on tapes that are not device-eligible — the release-mode device interpreter would silently skip `HOST_CALLBACK` clauses — and on empty tapes not produced by `compile()`. A new always-on `EBGEOMETRY_CUDA_CHECK` macro guards every CUDA API call. Device-eligible tapes hold no host back-pointers, so the source `Tape` need not outlive the upload.

**Golden test** (`Tests/GPU/EBGeometry_GPUTape.cu`, plain `main()` — Catch2 is never fetched in the compile-only CI lane): four scenes replicated token-for-token from `TestTape.cpp` (deep mixed CSG tree, nested transform chain, 216-leaf BVH sharp union, BVH smooth union) evaluated over 4106 points by a grid-stride kernel with exact per-point global scratch, compared in float **and** double against both the host tape interpreter and the recursive `value()` oracle, using the host suite's margins. NaN device results fail loudly (negated-conjunction comparison). Without a CUDA device the binary exits 77, which ctest reports as **Skipped** (`SKIP_RETURN_CODE 77`) — never a false green or a false red.

**Wiring**: new `cuda` preset triplet (Release, CUDA ON, label-`gpu` test filter — existing `unit`-filtered presets untouched); the CI CUDA lane now compiles both `EBGeometry_GPUSmoke` and `EBGeometry_GPUTape` (still compile-only, `continue-on-error`); README banner and CLAUDE.md GPU section updated. `Tape<T>` gains a `DeviceTape` friend + forward declaration and `TapeView` trivially-copyable static_asserts.

Local validation on a CUDA machine:
```bash
cmake --preset cuda && cmake --build --preset cuda --parallel && ctest --preset cuda
```

### Side-effects

No nvcc exists in the development environment, so the CUDA code was verified three ways short of hardware: a host-compiler build against a stub runtime, an independent re-derivation through **clang 18's real CUDA frontend** (separate host and device passes, which parse `<<<>>>` launches and enforce host/device call legality — both clean, assertions ON and OFF), and CI's nvcc compile lane. **Behavioral GPU validation is pending the maintainer's local run** — stated in the README banner. Host behavior is unchanged (597/597 unit tests, ASan clean). `DeviceTape` is usable only from CUDA translation units in this tier.

### Alternative solutions

Per-array `cudaMalloc` (~26 allocations) was rejected for the pooled single allocation (leak-proof dtor/moves, fewer driver round-trips). Fixed-size per-thread scratch arrays and dynamic shared memory were rejected for the golden test in favor of exact global scratch sliced per point — no artificial tape-size cap, no launch-configuration coupling; the capped-local-array fast path belongs to the performance tier. A Catch2-based CUDA test was rejected because the compile-only CI lane configures without tests and never fetches Catch2.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation. 
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS

---
_Generated by [Claude Code](https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS)_