### PR TITLE
GPU port (Tier 8): HIP backend via a backend-neutral runtime layer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -453,6 +453,28 @@ jobs:
       - name: Build CUDA targets (compile-only)
         run: cmake --build build/cuda --target EBGeometry_GPUSmoke EBGeometry_GPUTape --parallel 2
 
+  GPU-HIP-Compile:
+    needs: [Formatting, Codespell, Reuse, Doxygen-check]
+    name: GPU HIP compile (device-portability smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Advisory while the GPU port is in progress: compiles the Tests/GPU/*.hip TUs with the HIP
+    # toolchain from the Ubuntu 24.04 archive (hipcc 5.7 -> clang-17 + rocm-device-libs;
+    # ~1-2 GB, no external apt repo, no multi-GB rocm/dev container). Compile-only -- no AMD GPU
+    # is needed. continue-on-error keeps it off the merge gate until confirmed green; promote it
+    # together with GPU-CUDA-Compile.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install HIP toolchain (Ubuntu archive)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hipcc libamdhip64-dev rocm-device-libs-17
+      - name: Configure (HIP smoke test)
+        run: cmake -S . -B build/hip -DEBGEOMETRY_ENABLE_HIP=ON -DCMAKE_HIP_COMPILER=hipcc
+      - name: Build HIP targets (compile-only)
+        run: cmake --build build/hip --target EBGeometry_GPUSmoke EBGeometry_GPUTape --parallel 2
+
   CI-passed:
     needs: [Formatting, Codespell, Reuse, Doxygen-check, Linux-GNU, Linux-Intel, Examples-GNUMake, Examples-CMake, Examples-FloatPrecision, Build-documentation, Unit-Tests, Release-Test, Sanitizers]
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -469,9 +469,12 @@ jobs:
       - name: Install HIP toolchain (Ubuntu archive)
         run: |
           sudo apt-get update
-          sudo apt-get install -y hipcc libamdhip64-dev rocm-device-libs-17
+          sudo apt-get install -y hipcc clang-17 libamdhip64-dev rocm-device-libs-17
       - name: Configure (HIP smoke test)
-        run: cmake -S . -B build/hip -DEBGEOMETRY_ENABLE_HIP=ON -DCMAKE_HIP_COMPILER=hipcc
+        # CMake >= 3.28 rejects the hipcc wrapper as CMAKE_HIP_COMPILER ("Use Clang directly, or let
+        # CMake pick a default"); drive the HIP language with the clang that Ubuntu hipcc 5.7 itself
+        # wraps (clang-17, matching rocm-device-libs-17).
+        run: cmake -S . -B build/hip -DEBGEOMETRY_ENABLE_HIP=ON -DCMAKE_HIP_COMPILER=clang++-17
       - name: Build HIP targets (compile-only)
         run: cmake --build build/hip --target EBGeometry_GPUSmoke EBGeometry_GPUTape --parallel 2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ cmake --build --preset debug --target TestBVH
 ./build/debug/Tests/TestBVH
 ```
 
-### GPU/CUDA
+### GPU (CUDA / HIP)
 
 The `cuda` preset builds the CUDA targets (requires nvcc; not part of `Scripts/run-all-checks.sh`):
 
@@ -132,13 +132,29 @@ cmake --build --preset cuda --parallel $(nproc)
 ctest --preset cuda                      # runs GPUTapeGolden; reports "Skipped" without a GPU
 ```
 
-- `Tests/GPU/*.cu` (the Tier 0 device-portability smoke test and the Tier 7 `EBGeometry_GPUTape`
-  golden test) are compiled only under `EBGEOMETRY_ENABLE_CUDA=ON`; no host preset ever touches
-  them.
+The `hip` preset is its exact mirror for AMD (requires a ROCm/HIP toolchain; CMake >= 3.21, or
+>= 3.28 to drive hipcc as the HIP compiler):
+
+```bash
+cmake --preset hip                       # optionally -DCMAKE_HIP_ARCHITECTURES=<gfx...> (e.g. gfx90a, the default) to match your GPU
+cmake --build --preset hip --parallel $(nproc)
+ctest --preset hip                       # runs GPUTapeGolden; reports "Skipped" without a GPU
+```
+
+- The GPU test bodies live in shared, backend-agnostic headers (`Tests/GPU/EBGeometry_GPUSmoke.hpp`
+  and `Tests/GPU/EBGeometry_GPUTape.hpp`, calling the backend-neutral `EBGeometry::GPU` wrappers
+  from `Source/EBGeometry_GPURuntime.hpp`); the `.cu` (CUDA) and `.hip` (HIP) files are thin
+  includer translation units. They compile only under `EBGEOMETRY_ENABLE_CUDA=ON` or
+  `EBGEOMETRY_ENABLE_HIP=ON` respectively — one backend per configure (the two options are
+  mutually exclusive), and no host preset ever touches them.
 - `GPUTapeGolden` self-skips with exit code 77 (mapped to a ctest "Skipped" via
-  `SKIP_RETURN_CODE`) when no CUDA device is present, so the preset is safe on GPU-less machines.
-- CI's `GPU-CUDA-Compile` lane is compile-only (`continue-on-error`); behavioral GPU validation
-  happens on a developer's CUDA machine.
+  `SKIP_RETURN_CODE`) when no GPU device is present, so both presets are safe on GPU-less
+  machines.
+- CI's `GPU-CUDA-Compile` and `GPU-HIP-Compile` lanes are compile-only (`continue-on-error`);
+  behavioral GPU validation happens on a developer's GPU machine.
+- On an NVIDIA box without AMD hardware, the HIP code path itself can be validated behaviorally
+  via HIP's NVIDIA platform: `cmake --preset hip -DCMAKE_HIP_PLATFORM=nvidia` (needs CMake >=
+  3.28, the CUDA toolkit, and the ROCm HIP headers).
 
 ## Documentation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ option(EBGEOMETRY_ENABLE_SANITIZERS
 option(EBGEOMETRY_ENABLE_CUDA
   "Compile the CUDA device-portability smoke test (requires a CUDA toolkit / nvcc)" OFF)
 
+option(EBGEOMETRY_ENABLE_HIP
+  "Compile the HIP device-portability smoke test (requires a ROCm/HIP toolchain)" OFF)
+
 set(EBGEOMETRY_SIMD "avx" CACHE STRING
   "SIMD level to compile against: avx512 | avx | sse41 | none")
 set_property(CACHE EBGEOMETRY_SIMD PROPERTY STRINGS avx512 avx sse41 none)
@@ -53,29 +56,54 @@ if(EBGEOMETRY_SIMD_FLAGS)
   target_compile_options(EBGeometry INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:${EBGEOMETRY_SIMD_FLAGS}>")
 endif()
 
-# ── Optional CUDA device-portability smoke test ───────────────────────────────
+# ── Optional GPU device-portability smoke test (CUDA or HIP) ──────────────────
 # Header-only EBGeometry compiles nothing itself, so the GPU port's host/device annotations are
-# exercised by building a tiny .cu translation unit with nvcc. This is a compile-only check: no GPU
-# is required to build it. Off by default so a plain host configure never needs a CUDA compiler.
-if(EBGEOMETRY_ENABLE_CUDA)
-  enable_language(CUDA)
-  set(CMAKE_CUDA_STANDARD 17)
-  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES 70)
+# exercised by building tiny offload translation units (thin .cu/.hip includers of the shared
+# Tests/GPU/*.hpp bodies) with the backend compiler. This is a compile-only check: no GPU is
+# required to build it. Off by default so a plain host configure never needs a GPU compiler.
+if(EBGEOMETRY_ENABLE_CUDA AND EBGEOMETRY_ENABLE_HIP)
+  message(FATAL_ERROR
+    "EBGEOMETRY_ENABLE_CUDA and EBGEOMETRY_ENABLE_HIP are mutually exclusive: configure one "
+    "GPU backend per build directory (each preset already has its own build/<preset> dir).")
+endif()
+
+if(EBGEOMETRY_ENABLE_CUDA OR EBGEOMETRY_ENABLE_HIP)
+  if(EBGEOMETRY_ENABLE_CUDA)
+    enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+      set(CMAKE_CUDA_ARCHITECTURES 70)
+    endif()
+    set(EBGEOMETRY_GPU_SOURCE_EXT cu)
+  else()
+    # enable_language(HIP) exists from CMake 3.21; driving it with hipcc needs 3.28. The
+    # project floor is 3.16 (host-only); make the HIP-specific floor explicit here.
+    if(CMAKE_VERSION VERSION_LESS 3.21)
+      message(FATAL_ERROR "EBGEOMETRY_ENABLE_HIP requires CMake >= 3.21 (>= 3.28 for hipcc)")
+    endif()
+    enable_language(HIP)
+    set(CMAKE_HIP_STANDARD 17)
+    set(CMAKE_HIP_STANDARD_REQUIRED ON)
+    if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
+      set(CMAKE_HIP_ARCHITECTURES gfx90a)
+    endif()
+    set(EBGEOMETRY_GPU_SOURCE_EXT hip)
   endif()
 
-  add_executable(EBGeometry_GPUSmoke Tests/GPU/EBGeometry_GPUSmoke.cu)
+  add_executable(EBGeometry_GPUSmoke Tests/GPU/EBGeometry_GPUSmoke.${EBGEOMETRY_GPU_SOURCE_EXT})
   target_link_libraries(EBGeometry_GPUSmoke PRIVATE EBGeometry::EBGeometry)
   # Vec/BoundingVolumes reach for constexpr std helpers (std::numeric_limits, std::min/max) inside
-  # __host__ __device__ code; --expt-relaxed-constexpr lets nvcc call those from device code.
+  # __host__ __device__ code; --expt-relaxed-constexpr lets nvcc call those from device code. The
+  # genex keeps the flag off HIP compiles, where clang's HIP semantics already allow calling
+  # constexpr functions from device code without any flag.
   target_compile_options(EBGeometry_GPUSmoke PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
 
   # Tier 7: device-runtime golden test (DeviceTape upload + kernel evaluation vs CPU references).
-  # Compiles without a GPU (the CI CUDA lane is compile-only); at runtime it exits with code 77
-  # (SKIP_RETURN_CODE below) when no CUDA device is present, so ctest reports it as "Skipped".
-  add_executable(EBGeometry_GPUTape Tests/GPU/EBGeometry_GPUTape.cu)
+  # Compiles without a GPU (the CI GPU lanes are compile-only); at runtime it exits with code 77
+  # (SKIP_RETURN_CODE below) when no GPU device is present, so ctest reports it as "Skipped".
+  add_executable(EBGeometry_GPUTape Tests/GPU/EBGeometry_GPUTape.${EBGEOMETRY_GPU_SOURCE_EXT})
   target_link_libraries(EBGeometry_GPUTape PRIVATE EBGeometry::EBGeometry)
   target_compile_options(EBGeometry_GPUTape PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,12 +69,15 @@ endif()
 
 if(EBGEOMETRY_ENABLE_CUDA OR EBGEOMETRY_ENABLE_HIP)
   if(EBGEOMETRY_ENABLE_CUDA)
-    enable_language(CUDA)
-    set(CMAKE_CUDA_STANDARD 17)
-    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    # The default architecture must be chosen BEFORE enable_language: CMake's compiler
+    # determination otherwise caches its own detected/toolchain default first, making a later
+    # if(NOT DEFINED ...) guard dead code.
     if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
       set(CMAKE_CUDA_ARCHITECTURES 70)
     endif()
+    enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
     set(EBGEOMETRY_GPU_SOURCE_EXT cu)
   else()
     # enable_language(HIP) exists from CMake 3.21; driving it with hipcc needs 3.28. The
@@ -82,12 +85,16 @@ if(EBGEOMETRY_ENABLE_CUDA OR EBGEOMETRY_ENABLE_HIP)
     if(CMAKE_VERSION VERSION_LESS 3.21)
       message(FATAL_ERROR "EBGEOMETRY_ENABLE_HIP requires CMake >= 3.21 (>= 3.28 for hipcc)")
     endif()
-    enable_language(HIP)
-    set(CMAKE_HIP_STANDARD 17)
-    set(CMAKE_HIP_STANDARD_REQUIRED ON)
+
+    # Set before enable_language for the same reason as the CUDA default above; without this the
+    # effective default is whatever rocm_agent_enumerator or the compiler reports (gfx906, a
+    # deprecated Vega part, on a GPU-less box with the Ubuntu-archive hipcc).
     if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
       set(CMAKE_HIP_ARCHITECTURES gfx90a)
     endif()
+    enable_language(HIP)
+    set(CMAKE_HIP_STANDARD 17)
+    set(CMAKE_HIP_STANDARD_REQUIRED ON)
     set(EBGEOMETRY_GPU_SOURCE_EXT hip)
   endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -66,6 +66,19 @@
         "EBGEOMETRY_SIMD": "none",
         "EBGEOMETRY_BUILD_EXAMPLES": "OFF"
       }
+    },
+    {
+      "name": "hip",
+      "inherits": "base",
+      "displayName": "HIP (tests + device golden test)",
+      "description": "Release-type build with the HIP device runtime and the GPU golden test. Requires a ROCm/HIP toolchain; the GPUTapeGolden test self-skips without a GPU.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "EBGEOMETRY_ENABLE_HIP": "ON",
+        "EBGEOMETRY_ENABLE_ASSERTIONS": "OFF",
+        "EBGEOMETRY_SIMD": "none",
+        "EBGEOMETRY_BUILD_EXAMPLES": "OFF"
+      }
     }
   ],
   "buildPresets": [
@@ -73,7 +86,8 @@
     { "name": "debug-san",    "configurePreset": "debug-san"    },
     { "name": "release",      "configurePreset": "release"      },
     { "name": "release-test", "configurePreset": "release-test" },
-    { "name": "cuda",         "configurePreset": "cuda"         }
+    { "name": "cuda",         "configurePreset": "cuda"         },
+    { "name": "hip",          "configurePreset": "hip"          }
   ],
   "testPresets": [
     {
@@ -111,6 +125,14 @@
       "name": "cuda",
       "displayName": "GPU golden test (CUDA)",
       "configurePreset": "cuda",
+      "output": { "outputOnFailure": true },
+      "filter": { "include": { "label": "gpu" } },
+      "execution": { "timeout": 120 }
+    },
+    {
+      "name": "hip",
+      "displayName": "GPU golden test (HIP)",
+      "configurePreset": "hip",
       "output": { "outputOnFailure": true },
       "filter": { "include": { "label": "gpu" } },
       "execution": { "timeout": 120 }

--- a/EBGeometry.hpp
+++ b/EBGeometry.hpp
@@ -20,6 +20,7 @@
 #include "Source/EBGeometry_DCEL_Mesh.hpp"
 #include "Source/EBGeometry_DCEL_Vertex.hpp"
 #include "Source/EBGeometry_GPU.hpp"
+#include "Source/EBGeometry_GPURuntime.hpp"
 #include "Source/EBGeometry_ImplicitFunction.hpp"
 #include "Source/EBGeometry_Macros.hpp"
 #include "Source/EBGeometry_MeshDistanceFunctions.hpp"
@@ -50,7 +51,7 @@
 #include "Source/EBGeometry_Tape.hpp"
 
 // EBGeometry_DeviceTape.hpp is inert (empty after preprocessing) unless the TU is translated by an
-// offload compiler (CUDA), so it is always safe to include here.
+// offload compiler (CUDA or HIP), so it is always safe to include here.
 #include "Source/EBGeometry_DeviceTape.hpp"
 
 /**

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@
 > partially-ported state, and public interfaces may change without deprecation
 > aliases (clean breaks). Pin a tagged release if you need stability while the port
 > lands.
-> *Status: Tiers 0-7 landed — device-eligible tapes upload to CUDA devices
-> (`DeviceTape<T>`) with a kernel golden test wired into ctest, pending behavioral
-> validation on real GPU hardware (CI compiles but cannot run CUDA); remaining tiers
-> cover HIP/SYCL backends and async/performance work.*
+> *Status: Tiers 0-7 landed plus the HIP backend — device-eligible tapes upload to
+> CUDA **or HIP** devices (`DeviceTape<T>`) through a backend-neutral runtime layer,
+> with the kernel golden test wired into ctest for both; **both backends are pending
+> behavioral validation on real GPU hardware** (CI compiles CUDA and HIP but cannot
+> run either); remaining tiers cover SYCL/OpenACC backends and async/performance
+> work.*
 
 ## EBGeometry - a header-only C++ library for signed distance fields
 

--- a/Source/EBGeometry_AnalyticDistanceFunctions.hpp
+++ b/Source/EBGeometry_AnalyticDistanceFunctions.hpp
@@ -788,7 +788,7 @@ struct CapsuleOp
     const Vec3T<T> v1 = a_point - a_params.center1;
     const Vec3T<T> v2 = a_params.center2 - a_params.center1;
 
-    const T h = std::clamp(dot(v1, v2) / dot(v2, v2), T(0.0), T(1.0));
+    const T h = clamp(dot(v1, v2) / dot(v2, v2), T(0.0), T(1.0));
     const T d = length(v1 - h * v2) - a_params.radius;
 
     return d;
@@ -990,8 +990,8 @@ struct ConeOp
 
     const Vec2T<T> q = a_params.height * Vec2T<T>(a_params.c.x / a_params.c.y, -1.0);
     const Vec2T<T> w = Vec2T<T>(dr, dz);
-    const Vec2T<T> a = w - std::clamp(dot(w, q) / dot(q, q), zero, one) * q;
-    const Vec2T<T> b = w - Vec2T<T>(q.x * std::clamp(w.x / q.x, zero, one), q.y);
+    const Vec2T<T> a = w - clamp(dot(w, q) / dot(q, q), zero, one) * q;
+    const Vec2T<T> b = w - Vec2T<T>(q.x * clamp(w.x / q.x, zero, one), q.y);
 
     auto sign = [](const T& x) -> int { return (x > zero) - (x < zero); };
 

--- a/Source/EBGeometry_CSGImplem.hpp
+++ b/Source/EBGeometry_CSGImplem.hpp
@@ -844,7 +844,7 @@ FiniteRepetitionIF<T>::value(const Vec3T<T>& a_point) const noexcept
   Vec3T<T> q;
 
   for (size_t i = 0; i < 3; i++) {
-    q[i] = a_point[i] - m_period[i] * std::round(std::clamp((a_point[i] / m_period[i]), -m_repeatLo[i], m_repeatHi[i]));
+    q[i] = a_point[i] - m_period[i] * std::round(clamp((a_point[i] / m_period[i]), -m_repeatLo[i], m_repeatHi[i]));
   }
 
   const T ret = m_implicitFunction->value(q);

--- a/Source/EBGeometry_DCEL_MeshImplem.hpp
+++ b/Source/EBGeometry_DCEL_MeshImplem.hpp
@@ -413,7 +413,7 @@ MeshT<T, Meta>::computeVertexNormalAngleWeighted(const DCELIndex a_vertexIdx)
     const Vec3& norm = m_faces[faceIdx].getNormal();
 
     // Clamp to [-1,1] to guard against std::acos(NaN) from floating-point rounding.
-    const T alpha = std::acos(std::clamp(v1.dot(v2), T(-1), T(1)));
+    const T alpha = std::acos(clamp(v1.dot(v2), T(-1), T(1)));
 
     normal += alpha * norm;
   }
@@ -685,7 +685,7 @@ MeshT<T, Meta>::unsignedDistance2ToEdge(const DCELIndex a_edgeIdx, const Vec3& a
 
   EBGEOMETRY_EXPECT(x2x1.dot(x2x1) > T(0));
 
-  const T t = std::clamp((a_x0 - x1).dot(x2x1) / x2x1.dot(x2x1), T(0.0), T(1.0));
+  const T t = clamp((a_x0 - x1).dot(x2x1) / x2x1.dot(x2x1), T(0.0), T(1.0));
 
   const Vec3 linePoint = x1 + t * x2x1;
   const Vec3 delta     = a_x0 - linePoint;

--- a/Source/EBGeometry_DeviceTape.hpp
+++ b/Source/EBGeometry_DeviceTape.hpp
@@ -4,14 +4,15 @@
 
 /**
  * @file   EBGeometry_DeviceTape.hpp
- * @brief  Declaration of DeviceTape: an RAII owner of one Tape uploaded to CUDA device memory.
+ * @brief  Declaration of DeviceTape: an RAII owner of one Tape uploaded to GPU device memory.
  * @details DeviceTape copies a device-eligible @ref EBGeometry::Tape into a single pooled device
  * allocation and hands out a trivially-copyable @ref EBGeometry::TapeView whose pointers are
  * device pointers, ready to pass by value as a kernel argument. Everything in this header is
- * guarded on @c EBGEOMETRY_CUDA (nvcc translating the current TU), so the header is inert -- and
- * @c EBGeometry.hpp can include it unconditionally -- on a plain host compiler. Consequently, in
- * this tier DeviceTape is usable only from @c .cu translation units; host-compiler consumption
- * against @c libcudart is a possible later extension.
+ * guarded on @c EBGEOMETRY_CUDA or @c EBGEOMETRY_HIP (an offload compiler -- nvcc or hipcc --
+ * translating the current TU), so the header is inert -- and @c EBGeometry.hpp can include it
+ * unconditionally -- on a plain host compiler. Consequently, in this tier DeviceTape is usable
+ * only from @c .cu / @c .hip translation units; host-compiler consumption against the backend
+ * runtime library is a possible later extension.
  * @author Robert Marskar
  */
 
@@ -22,55 +23,30 @@
 #include "EBGeometry_GPU.hpp"
 #include "EBGeometry_Tape.hpp"
 
-#if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_DOXYGEN)
+#if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_HIP) || defined(EBGEOMETRY_DOXYGEN)
 
 // Std includes
-#include <cstdio>
-#include <cstdlib>
 #include <type_traits>
 
-// CUDA runtime API (cudaMalloc/cudaMemcpy/cudaFree). nvcc pre-includes this, but spelling it out
-// keeps the dependency explicit.
-#include <cuda_runtime.h>
-
-// Our includes
+// Our includes. EBGeometry_GPURuntime.hpp supplies the backend runtime header plus the
+// backend-neutral EBGeometry::GPU wrappers and the EBGEOMETRY_GPU_CHECK macro.
+#include "EBGeometry_GPURuntime.hpp"
 #include "EBGeometry_Macros.hpp"
-
-/**
- * @brief Always-on CUDA runtime API error check: prints the failing call and aborts.
- * @details Host-side only. Deliberately NOT gated on EBGEOMETRY_ENABLE_ASSERTIONS (unlike
- * EBGEOMETRY_EXPECT): a failed allocation or copy leaves DeviceTape's view pointing at garbage,
- * which a release build must not silently evaluate. Abort (rather than an exception) matches the
- * library's no-exceptions convention.
- * @param x CUDA runtime API call (or any expression) yielding a cudaError_t.
- */
-#define EBGEOMETRY_CUDA_CHECK(x)                                                      \
-  do {                                                                                \
-    const cudaError_t ebgeometry_cuda_err = (x);                                      \
-    if (ebgeometry_cuda_err != cudaSuccess) {                                         \
-      std::fprintf(stderr,                                                            \
-                   "EBGeometry CUDA error: %s\n  call: %s\n  file: %s\n  line: %d\n", \
-                   cudaGetErrorString(ebgeometry_cuda_err),                           \
-                   #x,                                                                \
-                   __FILE__,                                                          \
-                   __LINE__);                                                         \
-      std::abort();                                                                   \
-    }                                                                                 \
-  } while (0)
 
 namespace EBGeometry {
 
 /**
- * @brief RAII owner of one @ref Tape uploaded to CUDA device memory.
- * @details A single pooled @c cudaMalloc holds every tape array back to back; @ref view returns a
- * trivially-copyable @ref TapeView whose pointers are DEVICE pointers -- pass it BY VALUE as a
- * kernel argument and call @c view.value(p, coordScratch, valueScratch) in the kernel. The source
- * @ref Tape is fully copied at construction and need NOT stay alive afterwards (device-eligible
- * tapes hold no host-node back-pointers by definition). Copies are synchronous on the default
- * stream (async/stream support is a later tier). Move-only.
+ * @brief RAII owner of one @ref Tape uploaded to GPU (CUDA or HIP) device memory.
+ * @details A single pooled device allocation (@ref GPU::memAlloc) holds every tape array back to
+ * back; @ref view returns a trivially-copyable @ref TapeView whose pointers are DEVICE pointers --
+ * pass it BY VALUE as a kernel argument and call @c view.value(p, coordScratch, valueScratch) in
+ * the kernel. The source @ref Tape is fully copied at construction and need NOT stay alive
+ * afterwards (device-eligible tapes hold no host-node back-pointers by definition). Copies are
+ * synchronous on the default stream (async/stream support is a later tier). Move-only.
  *
- * See the golden test @c Tests/GPU/EBGeometry_GPUTape.cu for a complete upload-launch-compare
- * usage example.
+ * See the golden test body @c Tests/GPU/EBGeometry_GPUTape.hpp for a complete
+ * upload-launch-compare usage example (compiled as CUDA via its @c .cu twin and as HIP via its
+ * @c .hip twin).
  * @tparam T Floating-point precision.
  */
 template <class T>
@@ -96,9 +72,9 @@ public:
   operator=(const DeviceTape&) = delete;
 
   /**
-   * @brief Upload @p a_tape to the current CUDA device.
+   * @brief Upload @p a_tape to the current GPU device.
    * @details Aborts (always-on, independent of EBGEOMETRY_ENABLE_ASSERTIONS) if the tape is not
-   * device-eligible or any CUDA API call fails.
+   * device-eligible or any GPU runtime API call fails.
    * @param[in] a_tape Compiled tape to upload; must satisfy Tape::isDeviceEligible.
    */
   EBGEOMETRY_HOST explicit DeviceTape(const Tape<T>& a_tape);
@@ -119,8 +95,8 @@ public:
   operator=(DeviceTape&& a_other) noexcept;
 
   /**
-   * @brief Destructor. Frees the device pool (the result of cudaFree is deliberately discarded in
-   * a destructor).
+   * @brief Destructor. Frees the device pool (the result of GPU::memFree is deliberately
+   * discarded in a destructor).
    */
   EBGEOMETRY_HOST ~DeviceTape() noexcept;
 
@@ -167,6 +143,6 @@ private:
 
 #include "EBGeometry_DeviceTapeImplem.hpp"
 
-#endif // EBGEOMETRY_CUDA || EBGEOMETRY_DOXYGEN
+#endif // EBGEOMETRY_CUDA || EBGEOMETRY_HIP || EBGEOMETRY_DOXYGEN
 
 #endif // EBGEOMETRY_DEVICETAPE_HPP

--- a/Source/EBGeometry_DeviceTapeImplem.hpp
+++ b/Source/EBGeometry_DeviceTapeImplem.hpp
@@ -8,7 +8,7 @@
  * @details Holds the out-of-line DeviceTape definitions: the pooled-upload constructor (a sizing
  * pass and a copy pass, both driven by the EBGEOMETRY_TAPE_PARAM_SOA X-macro registry), the move
  * operations, and the destructor. Included last from EBGeometry_DeviceTape.hpp, inside the same
- * EBGEOMETRY_CUDA guard, so it is inert on a plain host compiler.
+ * GPU-backend (CUDA or HIP) guard, so it is inert on a plain host compiler.
  * @author Robert Marskar
  */
 
@@ -18,7 +18,7 @@
 // Our includes
 #include "EBGeometry_GPU.hpp"
 
-#if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_DOXYGEN)
+#if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_HIP) || defined(EBGEOMETRY_DOXYGEN)
 
 // Std includes
 #include <cstdio>
@@ -26,11 +26,9 @@
 #include <type_traits>
 #include <vector>
 
-// CUDA runtime API.
-#include <cuda_runtime.h>
-
 // Our includes
 #include "EBGeometry_DeviceTape.hpp"
+#include "EBGeometry_GPURuntime.hpp"
 #include "EBGeometry_Macros.hpp"
 #include "EBGeometry_Tape.hpp"
 
@@ -41,7 +39,8 @@ namespace DeviceTapeDetail {
 /**
  * @brief Byte alignment of every sub-array section inside the DeviceTape pool.
  * @details 256 bytes is at least the natural alignment of every stored type and matches the base
- * alignment cudaMalloc itself guarantees, so base + paddedOffset preserves it for every section.
+ * alignment the device allocator (cudaMalloc/hipMalloc) itself guarantees, so base + paddedOffset
+ * preserves it for every section.
  */
 inline constexpr size_t DeviceTapeAlign = 256;
 
@@ -95,7 +94,7 @@ uploadArray(unsigned char* a_base, size_t& a_offset, const std::vector<U>& a_hos
 
   const size_t numBytes = a_host.size() * sizeof(U);
 
-  EBGEOMETRY_CUDA_CHECK(cudaMemcpy(a_base + a_offset, a_host.data(), numBytes, cudaMemcpyHostToDevice));
+  EBGEOMETRY_GPU_CHECK(GPU::memcpy(a_base + a_offset, a_host.data(), numBytes, GPU::MemcpyHostToDevice));
 
   const U* devicePtr = reinterpret_cast<const U*>(a_base + a_offset);
 
@@ -150,7 +149,7 @@ DeviceTape<T>::DeviceTape(const Tape<T>& a_tape)
   m_numBytes = numBytes;
 
   if (numBytes > 0) {
-    EBGEOMETRY_CUDA_CHECK(cudaMalloc(&m_pool, numBytes));
+    EBGEOMETRY_GPU_CHECK(GPU::memAlloc(&m_pool, numBytes));
   }
 
   // ── Pass 2: copy each array and assemble the device view ────────────────────
@@ -196,7 +195,7 @@ DeviceTape<T>::operator=(DeviceTape&& a_other) noexcept
 {
   if (this != &a_other) {
     if (m_pool != nullptr) {
-      (void)cudaFree(m_pool);
+      (void)GPU::memFree(m_pool);
     }
 
     m_pool     = a_other.m_pool;
@@ -215,12 +214,12 @@ template <class T>
 DeviceTape<T>::~DeviceTape() noexcept
 {
   if (m_pool != nullptr) {
-    (void)cudaFree(m_pool);
+    (void)GPU::memFree(m_pool);
   }
 }
 
 } // namespace EBGeometry
 
-#endif // EBGEOMETRY_CUDA || EBGEOMETRY_DOXYGEN
+#endif // EBGEOMETRY_CUDA || EBGEOMETRY_HIP || EBGEOMETRY_DOXYGEN
 
 #endif // EBGEOMETRY_DEVICETAPEIMPLEM_HPP

--- a/Source/EBGeometry_GPURuntime.hpp
+++ b/Source/EBGeometry_GPURuntime.hpp
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_GPURuntime.hpp
+ * @brief  Backend-neutral GPU runtime API layer (CUDA or HIP) plus the EBGEOMETRY_GPU_CHECK macro.
+ * @details Unlike EBGeometry_GPU.hpp -- which only detects the offload compiler and defines the
+ * decoration macros, pulling in no backend runtime headers -- this header IS the runtime-API
+ * layer: it includes the backend runtime header (<cuda_runtime.h> or <hip/hip_runtime.h>) and
+ * exposes the small memory-management/error surface EBGeometry needs through backend-neutral
+ * aliases and inline wrappers in the EBGeometry::GPU namespace, so DeviceTape and the GPU tests
+ * compile unchanged as CUDA (.cu) or HIP (.hip) translation units. On an ordinary host compiler
+ * the whole header is inert (empty after preprocessing), so the umbrella EBGeometry.hpp can
+ * include it unconditionally.
+ *
+ * HIP is checked before CUDA: hipcc on the NVIDIA platform defines both @c __HIPCC__ and
+ * @c __CUDACC__, and there the hip* entry points exist and forward to cuda*, so mapping to hip*
+ * whenever @c __HIPCC__ is defined is correct on both HIP platforms.
+ * @author Robert Marskar
+ */
+
+#ifndef EBGEOMETRY_GPURUNTIME_HPP
+#define EBGEOMETRY_GPURUNTIME_HPP
+
+// Our includes
+#include "EBGeometry_GPU.hpp"
+
+#if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_HIP) || defined(EBGEOMETRY_DOXYGEN)
+
+// Std includes (EBGEOMETRY_GPU_CHECK needs fprintf/abort; the wrappers need size_t).
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+
+// Backend runtime header. HIP is checked FIRST: hipcc on the NVIDIA platform defines both
+// __HIPCC__ and __CUDACC__, and there the hip* entry points exist and forward to cuda*, so
+// mapping to hip* whenever __HIPCC__ is defined is correct on both HIP platforms.
+#if defined(EBGEOMETRY_HIP)
+#include <hip/hip_runtime.h> // NOT pre-included by the compiler driver; must be explicit.
+#elif defined(EBGEOMETRY_CUDA)
+#include <cuda_runtime.h> // nvcc pre-includes this; spelled out for hygiene.
+#endif
+
+namespace EBGeometry {
+
+/**
+ * @brief Backend-neutral GPU runtime API surface (CUDA or HIP).
+ * @details Thin aliases and inline forwarders over the backend runtime (cuda* under CUDA, hip*
+ * under HIP) covering exactly the surface EBGeometry uses: memory allocation/copy/free, device
+ * enumeration, error retrieval, and synchronization. The two runtimes mirror each other's
+ * signatures 1:1 for this surface, so every wrapper is a one-line forwarder.
+ */
+namespace GPU {
+
+#if defined(EBGEOMETRY_DOXYGEN)
+
+/**
+ * @brief Backend runtime error code (@c cudaError_t under CUDA, @c hipError_t under HIP).
+ */
+using Error = int;
+
+/**
+ * @brief Memory-copy direction (@c cudaMemcpyKind under CUDA, @c hipMemcpyKind under HIP).
+ */
+using MemcpyKind = int;
+
+/**
+ * @brief Success value of @ref Error (@c cudaSuccess / @c hipSuccess).
+ */
+inline constexpr Error Success = 0;
+
+/**
+ * @brief Host-to-device copy direction (@c cudaMemcpyHostToDevice / @c hipMemcpyHostToDevice).
+ */
+inline constexpr MemcpyKind MemcpyHostToDevice = 1;
+
+/**
+ * @brief Device-to-host copy direction (@c cudaMemcpyDeviceToHost / @c hipMemcpyDeviceToHost).
+ */
+inline constexpr MemcpyKind MemcpyDeviceToHost = 2;
+
+/**
+ * @brief Allocate device memory (@c cudaMalloc / @c hipMalloc).
+ * @param[out] a_devicePtr Receives the device pointer to the allocation.
+ * @param[in]  a_numBytes  Number of bytes to allocate.
+ * @return Backend error code (@ref Success on success).
+ */
+[[nodiscard]] inline Error
+memAlloc(void** a_devicePtr, size_t a_numBytes) noexcept;
+
+/**
+ * @brief Free device memory allocated with @ref memAlloc (@c cudaFree / @c hipFree).
+ * @param[in] a_devicePtr Device pointer to free (null is a no-op).
+ * @return Backend error code (@ref Success on success).
+ */
+[[nodiscard]] inline Error
+memFree(void* a_devicePtr) noexcept;
+
+/**
+ * @brief Copy memory between host and device (@c cudaMemcpy / @c hipMemcpy). Synchronous.
+ * @param[out] a_dst      Destination pointer (host or device, per @p a_kind).
+ * @param[in]  a_src      Source pointer (host or device, per @p a_kind).
+ * @param[in]  a_numBytes Number of bytes to copy.
+ * @param[in]  a_kind     Copy direction.
+ * @return Backend error code (@ref Success on success).
+ */
+[[nodiscard]] inline Error
+memcpy(void* a_dst, const void* a_src, size_t a_numBytes, MemcpyKind a_kind) noexcept;
+
+/**
+ * @brief Get the number of available GPU devices (@c cudaGetDeviceCount / @c hipGetDeviceCount).
+ * @param[out] a_count Receives the device count.
+ * @return Backend error code (@ref Success on success).
+ */
+[[nodiscard]] inline Error
+getDeviceCount(int* a_count) noexcept;
+
+/**
+ * @brief Get and clear the last runtime error (@c cudaGetLastError / @c hipGetLastError).
+ * @return Backend error code (@ref Success if no error is pending).
+ */
+[[nodiscard]] inline Error
+getLastError() noexcept;
+
+/**
+ * @brief Block until the device has finished all preceding work (@c cudaDeviceSynchronize /
+ * @c hipDeviceSynchronize).
+ * @return Backend error code (@ref Success on success).
+ */
+[[nodiscard]] inline Error
+deviceSynchronize() noexcept;
+
+/**
+ * @brief Get the human-readable description of an error code (@c cudaGetErrorString /
+ * @c hipGetErrorString).
+ * @param[in] a_error Backend error code.
+ * @return Static string describing the error.
+ */
+[[nodiscard]] inline const char*
+getErrorString(Error a_error) noexcept;
+
+#elif defined(EBGEOMETRY_HIP)
+
+using Error      = hipError_t;
+using MemcpyKind = hipMemcpyKind;
+
+inline constexpr Error      Success            = hipSuccess;
+inline constexpr MemcpyKind MemcpyHostToDevice = hipMemcpyHostToDevice;
+inline constexpr MemcpyKind MemcpyDeviceToHost = hipMemcpyDeviceToHost;
+
+[[nodiscard]] inline Error
+memAlloc(void** a_devicePtr, size_t a_numBytes) noexcept
+{
+  return hipMalloc(a_devicePtr, a_numBytes);
+}
+
+[[nodiscard]] inline Error
+memFree(void* a_devicePtr) noexcept
+{
+  return hipFree(a_devicePtr);
+}
+
+[[nodiscard]] inline Error
+memcpy(void* a_dst, const void* a_src, size_t a_numBytes, MemcpyKind a_kind) noexcept
+{
+  return hipMemcpy(a_dst, a_src, a_numBytes, a_kind);
+}
+
+[[nodiscard]] inline Error
+getDeviceCount(int* a_count) noexcept
+{
+  return hipGetDeviceCount(a_count);
+}
+
+[[nodiscard]] inline Error
+getLastError() noexcept
+{
+  return hipGetLastError();
+}
+
+[[nodiscard]] inline Error
+deviceSynchronize() noexcept
+{
+  return hipDeviceSynchronize();
+}
+
+[[nodiscard]] inline const char*
+getErrorString(Error a_error) noexcept
+{
+  return hipGetErrorString(a_error);
+}
+
+#elif defined(EBGEOMETRY_CUDA)
+
+using Error      = cudaError_t;
+using MemcpyKind = cudaMemcpyKind;
+
+inline constexpr Error      Success            = cudaSuccess;
+inline constexpr MemcpyKind MemcpyHostToDevice = cudaMemcpyHostToDevice;
+inline constexpr MemcpyKind MemcpyDeviceToHost = cudaMemcpyDeviceToHost;
+
+[[nodiscard]] inline Error
+memAlloc(void** a_devicePtr, size_t a_numBytes) noexcept
+{
+  return cudaMalloc(a_devicePtr, a_numBytes);
+}
+
+[[nodiscard]] inline Error
+memFree(void* a_devicePtr) noexcept
+{
+  return cudaFree(a_devicePtr);
+}
+
+[[nodiscard]] inline Error
+memcpy(void* a_dst, const void* a_src, size_t a_numBytes, MemcpyKind a_kind) noexcept
+{
+  return cudaMemcpy(a_dst, a_src, a_numBytes, a_kind);
+}
+
+[[nodiscard]] inline Error
+getDeviceCount(int* a_count) noexcept
+{
+  return cudaGetDeviceCount(a_count);
+}
+
+[[nodiscard]] inline Error
+getLastError() noexcept
+{
+  return cudaGetLastError();
+}
+
+[[nodiscard]] inline Error
+deviceSynchronize() noexcept
+{
+  return cudaDeviceSynchronize();
+}
+
+[[nodiscard]] inline const char*
+getErrorString(Error a_error) noexcept
+{
+  return cudaGetErrorString(a_error);
+}
+
+#endif
+
+} // namespace GPU
+} // namespace EBGeometry
+
+/**
+ * @brief Always-on GPU runtime API error check: prints the failing call and aborts.
+ * @details Host-side only. Deliberately NOT gated on EBGEOMETRY_ENABLE_ASSERTIONS (unlike
+ * EBGEOMETRY_EXPECT): a failed allocation or copy leaves DeviceTape's view pointing at garbage,
+ * which a release build must not silently evaluate. Abort (rather than an exception) matches the
+ * library's no-exceptions convention.
+ * @param x GPU runtime API call (or any expression) yielding an EBGeometry::GPU::Error.
+ */
+#define EBGEOMETRY_GPU_CHECK(x)                                                      \
+  do {                                                                               \
+    const EBGeometry::GPU::Error ebgeometry_gpu_err = (x);                           \
+    if (ebgeometry_gpu_err != EBGeometry::GPU::Success) {                            \
+      std::fprintf(stderr,                                                           \
+                   "EBGeometry GPU error: %s\n  call: %s\n  file: %s\n  line: %d\n", \
+                   EBGeometry::GPU::getErrorString(ebgeometry_gpu_err),              \
+                   #x,                                                               \
+                   __FILE__,                                                         \
+                   __LINE__);                                                        \
+      std::abort();                                                                  \
+    }                                                                                \
+  } while (0)
+
+#endif // EBGEOMETRY_CUDA || EBGEOMETRY_HIP || EBGEOMETRY_DOXYGEN
+
+#endif // EBGEOMETRY_GPURUNTIME_HPP

--- a/Source/EBGeometry_Vec.hpp
+++ b/Source/EBGeometry_Vec.hpp
@@ -684,12 +684,27 @@ template <typename T>
 max(const Vec3T<T>& u, const Vec3T<T>& v) noexcept;
 
 /**
+ * @brief Scalar clamp of v to [lo, hi].
+ * @details EBGeometry-owned replacement for std::clamp in device-reachable code: libstdc++ 14's
+ * std::clamp contains a __glibcxx_assert whose failure handler is a host-only function, which the
+ * HIP/CUDA device compilation pass rejects when reached from EBGEOMETRY_HOST_DEVICE code.
+ * @tparam T Value type.
+ * @param[in] v  Value to be clamped.
+ * @param[in] lo Lower bound.
+ * @param[in] hi Upper bound.
+ * @return lo if v < lo, hi if hi < v, otherwise v.
+ */
+template <typename T>
+[[nodiscard]] EBGEOMETRY_HOST_DEVICE inline constexpr T
+clamp(const T& v, const T& lo, const T& hi) noexcept;
+
+/**
  * @brief Component-wise clamp of a 3D vector.
  * @tparam T Floating-point precision.
  * @param[in] v  Vector to be clamped.
  * @param[in] lo Component-wise lower bound.
  * @param[in] hi Component-wise upper bound.
- * @return New vector with X[i] = std::clamp(v[i], lo[i], hi[i]).
+ * @return New vector with X[i] = clamp(v[i], lo[i], hi[i]).
  */
 template <typename T>
 [[nodiscard]] EBGEOMETRY_HOST_DEVICE inline constexpr Vec3T<T>

--- a/Source/EBGeometry_VecImplem.hpp
+++ b/Source/EBGeometry_VecImplem.hpp
@@ -571,10 +571,17 @@ max(const Vec3T<T>& u, const Vec3T<T>& v) noexcept
 }
 
 template <typename T>
+EBGEOMETRY_HOST_DEVICE inline constexpr T
+clamp(const T& v, const T& lo, const T& hi) noexcept
+{
+  return (v < lo) ? lo : (hi < v) ? hi : v;
+}
+
+template <typename T>
 EBGEOMETRY_HOST_DEVICE inline constexpr Vec3T<T>
 clamp(const Vec3T<T>& v, const Vec3T<T>& lo, const Vec3T<T>& hi) noexcept
 {
-  return Vec3T<T>(std::clamp(v[0], lo[0], hi[0]), std::clamp(v[1], lo[1], hi[1]), std::clamp(v[2], lo[2], hi[2]));
+  return Vec3T<T>(clamp(v[0], lo[0], hi[0]), clamp(v[1], lo[1], hi[1]), clamp(v[2], lo[2], hi[2]));
 }
 
 template <typename T>

--- a/Tests/GPU/EBGeometry_GPUSmoke.hip
+++ b/Tests/GPU/EBGeometry_GPUSmoke.hip
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
- * @file   EBGeometry_GPUSmoke.cu
- * @brief  CUDA translation unit for the compile-only GPU smoke test.
+ * @file   EBGeometry_GPUSmoke.hip
+ * @brief  HIP translation unit for the compile-only GPU smoke test.
  * @details Thin includer: the backend-agnostic test body lives in EBGeometry_GPUSmoke.hpp and is
- * shared with the HIP twin EBGeometry_GPUSmoke.hip.
+ * shared with the CUDA twin EBGeometry_GPUSmoke.cu.
  * @author Robert Marskar
  */
 

--- a/Tests/GPU/EBGeometry_GPUSmoke.hpp
+++ b/Tests/GPU/EBGeometry_GPUSmoke.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_GPUSmoke.hpp
+ * @brief  Backend-agnostic body of the compile-only GPU smoke test for the device annotations.
+ * @details Tier 0 of the GPU port only annotates the value vocabulary (Vec2T/Vec3T and the
+ * bounding-volume types) with EBGEOMETRY_HOST_DEVICE. This body exercises exactly that surface
+ * from inside a kernel, so that building it with an offload compiler proves the annotated methods
+ * are callable from device code. It is a compile-only check -- no GPU is needed to build it --
+ * but it also runs correctly on a device when one is present. The body is shared between the two
+ * backend translation units EBGeometry_GPUSmoke.cu (CUDA) and EBGeometry_GPUSmoke.hip (HIP),
+ * which simply include this file; all runtime API calls go through the backend-neutral
+ * EBGeometry::GPU wrappers.
+ * @author Robert Marskar
+ */
+
+#ifndef EBGEOMETRY_GPUSMOKE_HPP
+#define EBGEOMETRY_GPUSMOKE_HPP
+
+#include "Source/EBGeometry_BoundingVolumes.hpp"
+#include "Source/EBGeometry_GPURuntime.hpp"
+#include "Source/EBGeometry_Vec.hpp"
+
+using T = double;
+
+using EBGeometry::Vec3T;
+using EBGeometry::BoundingVolumes::AABBT;
+using EBGeometry::BoundingVolumes::SphereT;
+
+namespace GPU = EBGeometry::GPU;
+
+/**
+ * @brief Kernel that exercises the host/device value vocabulary on the device.
+ * @param[out] a_out Single-element device buffer receiving a combined scalar result.
+ */
+EBGEOMETRY_GLOBAL void
+smokeKernel(T* a_out)
+{
+  const Vec3T<T> a(T(1), T(2), T(3));
+  const Vec3T<T> b(T(4), T(5), T(6));
+  const Vec3T<T> c = a + b;
+
+  const AABBT<T>   box(Vec3T<T>(T(0), T(0), T(0)), Vec3T<T>(T(1), T(1), T(1)));
+  const SphereT<T> sphere(Vec3T<T>(T(0), T(0), T(0)), T(1));
+
+  a_out[0] = EBGeometry::dot(c, c) + box.getDistance2(a) + sphere.getDistance(b) + c.length();
+}
+
+/**
+ * @brief Host entry point. Launches the kernel and reads back the result.
+ * @details The runtime API results are deliberately discarded: this program is a compile-only
+ * portability check that must also remain runnable (as a harmless no-op) on a machine without any
+ * GPU device.
+ * @return Zero on success.
+ */
+int
+main()
+{
+  T* deviceOut = nullptr;
+  (void)GPU::memAlloc(reinterpret_cast<void**>(&deviceOut), sizeof(T));
+
+  smokeKernel<<<1, 1>>>(deviceOut);
+  (void)GPU::deviceSynchronize();
+
+  T hostOut = T(0);
+  (void)GPU::memcpy(&hostOut, deviceOut, sizeof(T), GPU::MemcpyDeviceToHost);
+  (void)GPU::memFree(deviceOut);
+
+  return 0;
+}
+
+#endif // EBGEOMETRY_GPUSMOKE_HPP

--- a/Tests/GPU/EBGeometry_GPUTape.hip
+++ b/Tests/GPU/EBGeometry_GPUTape.hip
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
- * @file   EBGeometry_GPUTape.cu
- * @brief  CUDA translation unit for the DeviceTape golden test.
+ * @file   EBGeometry_GPUTape.hip
+ * @brief  HIP translation unit for the DeviceTape golden test.
  * @details Thin includer: the backend-agnostic test body lives in EBGeometry_GPUTape.hpp and is
- * shared with the HIP twin EBGeometry_GPUTape.hip.
+ * shared with the CUDA twin EBGeometry_GPUTape.cu.
  * @author Robert Marskar
  */
 

--- a/Tests/GPU/EBGeometry_GPUTape.hpp
+++ b/Tests/GPU/EBGeometry_GPUTape.hpp
@@ -1,0 +1,427 @@
+// SPDX-FileCopyrightText: 2026 Robert Marskar <robert.marskar@sintef.no>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file   EBGeometry_GPUTape.hpp
+ * @brief  Backend-agnostic body of the GPU golden test for DeviceTape: upload compiled tapes and
+ *         evaluate them in a kernel.
+ * @details Tier 7 of the GPU port. For four representative device-eligible scenes (a deep mixed
+ * CSG tree, a nested transform chain, a 216-leaf BVH sharp union, and a BVH smooth union) this
+ * program compiles the tape on the host, uploads it with DeviceTape, evaluates it for every query
+ * point in a grid-stride kernel, and compares the device results against BOTH host references:
+ * the host-side tape interpreter (tape.value) and the recursive value() oracle (tree.value). Both
+ * float and double run unconditionally, making this binary the device-side analogue of
+ * Tests/InstantiateAll.cpp for Tape/DeviceTape (which the host-only object library cannot cover).
+ *
+ * The body is shared between the two backend translation units EBGeometry_GPUTape.cu (CUDA) and
+ * EBGeometry_GPUTape.hip (HIP), which simply include this file; all runtime API calls go through
+ * the backend-neutral EBGeometry::GPU wrappers and EBGEOMETRY_GPU_CHECK.
+ *
+ * The scene constructions and margins replicate Tests/TestTape.cpp line-for-line (origins cited at
+ * each helper) so host and device coverage stay in lockstep.
+ *
+ * This is a plain main() program (no Catch2): the CI GPU lanes configure without
+ * EBGEOMETRY_BUILD_TESTS, so Catch2 is never fetched there. Without a GPU device the program
+ * exits with code 77, which the GPUTapeGolden ctest registration maps to "Skipped" via
+ * SKIP_RETURN_CODE.
+ *
+ * Scratch strategy: exact global scratch buffers of numPoints * numCoordSlots /
+ * numPoints * numValueSlots entries, sliced by point index, so any tape size works with no
+ * per-thread cap (fixed-size local scratch is the later performance-tier path).
+ * @author Robert Marskar
+ */
+
+#ifndef EBGEOMETRY_GPUTAPE_TEST_HPP
+#define EBGEOMETRY_GPUTAPE_TEST_HPP
+
+#include "EBGeometry.hpp" // Pulls in Tape + DeviceTape (active: this body is compiled by an offload compiler).
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+// ctest SKIP_RETURN_CODE (see the GPUTapeGolden test registration in CMakeLists.txt).
+constexpr int SKIP_EXIT_CODE = 77;
+
+using namespace EBGeometry;
+
+// ── Kernel ────────────────────────────────────────────────────────────────────
+
+/**
+ * @brief Grid-stride kernel: a_out[i] = a_view.value(a_points[i], per-point scratch slices).
+ * @param[in]  a_view         Device-pointer tape view (by value; trivially copyable).
+ * @param[in]  a_points       Query points (device, a_numPoints entries).
+ * @param[out] a_out          Results (device, a_numPoints entries).
+ * @param[in]  a_numPoints    Number of query points.
+ * @param[out] a_coordScratch Global scratch, a_numPoints * a_view.numCoordSlots entries (device).
+ * @param[out] a_valueScratch Global scratch, a_numPoints * a_view.numValueSlots entries (device).
+ */
+template <class T>
+EBGEOMETRY_GLOBAL void
+evaluateTape(
+  TapeView<T> a_view, const Vec3T<T>* a_points, T* a_out, int a_numPoints, Vec3T<T>* a_coordScratch, T* a_valueScratch)
+{
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < a_numPoints; i += gridDim.x * blockDim.x) {
+    a_out[i] = a_view.value(a_points[i],
+                            a_coordScratch + size_t(i) * a_view.numCoordSlots,
+                            a_valueScratch + size_t(i) * a_view.numValueSlots);
+  }
+}
+
+// ── Host-side helpers (replicated line-for-line from Tests/TestTape.cpp) ──────
+
+namespace {
+
+template <class T>
+using IF = ImplicitFunction<T>;
+
+// Margin helpers copied from Tests/TestTape.cpp (exactMargin/formulaMargin): two independent
+// traversals of the same trait statics should agree up to floating-point reordering only; smooth
+// blends get a slightly looser bound.
+template <class T>
+double
+exactMargin()
+{
+  return std::is_same_v<T, float> ? 1.0e-4 : 1.0e-12;
+}
+
+template <class T>
+double
+formulaMargin()
+{
+  return std::is_same_v<T, float> ? 1.0e-3 : 1.0e-9;
+}
+
+// A spread of inside/outside/surface-ish query points; copied from Tests/TestTape.cpp
+// (queryPoints).
+template <class T>
+std::vector<Vec3T<T>>
+queryPoints()
+{
+  return {Vec3T<T>::zeros(),
+          Vec3T<T>(0.5, 0, 0),
+          Vec3T<T>(1.5, 0, 0),
+          Vec3T<T>(-1.2, 0.7, 0.3),
+          Vec3T<T>(2, 2, 2),
+          Vec3T<T>(-3, 1, -2),
+          Vec3T<T>(0.1, -0.4, 0.9),
+          Vec3T<T>(3, 0, 0),
+          Vec3T<T>(0, 3, 0),
+          Vec3T<T>(-0.5, -0.5, -0.5)};
+}
+
+// A row of disjoint unit spheres, centers a_spacing apart, with tight AABBs; copied from
+// Tests/TestTape.cpp (makeSphereRow).
+template <class T>
+void
+makeSphereRow(int                                         a_numSpheres,
+              T                                           a_spacing,
+              std::vector<std::shared_ptr<SphereSDF<T>>>& a_spheres,
+              std::vector<BoundingVolumes::AABBT<T>>&     a_bvs)
+{
+  for (int i = 0; i < a_numSpheres; i++) {
+    const Vec3T<T> center(T(i) * a_spacing, 0, 0);
+
+    a_spheres.push_back(std::make_shared<SphereSDF<T>>(center, T(1)));
+    a_bvs.emplace_back(center - Vec3T<T>::ones(), center + Vec3T<T>::ones());
+  }
+}
+
+// A 6x6x6 grid (216 entries) of mixed, transformed primitives -- spheres, rotated boxes, scaled
+// tori, offset capsules -- with conservative AABBs; copied from Tests/TestTape.cpp
+// (makeMixedScene). Every entry lowers natively, so the whole scene is device-eligible.
+template <class T>
+void
+makeMixedScene(std::vector<std::shared_ptr<IF<T>>>& a_primitives, std::vector<BoundingVolumes::AABBT<T>>& a_bvs)
+{
+  constexpr int n = 6;
+
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < n; j++) {
+      for (int k = 0; k < n; k++) {
+        const Vec3T<T> center(T(3 * i), T(3 * j), T(3 * k));
+
+        std::shared_ptr<IF<T>> primitive;
+
+        switch ((i + j + k) % 4) {
+        case 0: {
+          primitive = Translate<T>(std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(0.8)), center);
+
+          break;
+        }
+        case 1: {
+          primitive = Translate<T>(
+            Rotate<T>(std::make_shared<BoxSDF<T>>(Vec3T<T>(-0.7, -0.7, -0.7), Vec3T<T>(0.7, 0.7, 0.7)), T(30), 2),
+            center);
+
+          break;
+        }
+        case 2: {
+          primitive =
+            Translate<T>(Scale<T>(std::make_shared<TorusSDF<T>>(Vec3T<T>::zeros(), T(0.5), T(0.2)), T(1.5)), center);
+
+          break;
+        }
+        default: {
+          primitive = Translate<T>(
+            Offset<T>(std::make_shared<CapsuleSDF<T>>(Vec3T<T>(0, -0.4, 0), Vec3T<T>(0, 0.4, 0), T(0.3)), T(0.1)),
+            center);
+
+          break;
+        }
+        }
+
+        a_primitives.push_back(primitive);
+        a_bvs.emplace_back(center - Vec3T<T>(1.5, 1.5, 1.5), center + Vec3T<T>(1.5, 1.5, 1.5));
+      }
+    }
+  }
+}
+
+// A 16x16x16 uniform grid over [-3, 18]^3 -- spanning the mixed scene, whose centers run 0..15,
+// with inside/on-surface/far coverage -- plus the standard 10-point query spread (4106 points).
+template <class T>
+std::vector<Vec3T<T>>
+testPoints()
+{
+  std::vector<Vec3T<T>> points = queryPoints<T>();
+
+  constexpr int n = 16;
+
+  const T lo = T(-3);
+  const T hi = T(18);
+
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < n; j++) {
+      for (int k = 0; k < n; k++) {
+        const T x = lo + (hi - lo) * T(i) / T(n - 1);
+        const T y = lo + (hi - lo) * T(j) / T(n - 1);
+        const T z = lo + (hi - lo) * T(k) / T(n - 1);
+
+        points.emplace_back(x, y, z);
+      }
+    }
+  }
+
+  return points;
+}
+
+// ── Per-scene driver ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Compile a_tree, upload it, evaluate it on the device for every test point, and compare
+ * against both CPU references (host tape interpreter and recursive value() oracle).
+ * @param[in] a_name      Scene name for diagnostics.
+ * @param[in] a_precision Precision name for diagnostics.
+ * @param[in] a_tree      Source implicit-function tree (must be device-eligible).
+ * @param[in] a_margin    Absolute comparison margin.
+ * @return Zero on success, one on any mismatch (or a non-device-eligible tape, which is a test
+ * FAILURE here, not a skip).
+ */
+template <class T>
+int
+runScene(const char* a_name, const char* a_precision, const ImplicitFunction<T>& a_tree, double a_margin)
+{
+  const Tape<T> tape = compile<T>(a_tree);
+
+  if (!tape.isDeviceEligible()) {
+    std::printf("FAIL [%s, %s]: tape is not device-eligible\n", a_name, a_precision);
+
+    return 1;
+  }
+
+  const std::vector<Vec3T<T>> points    = testPoints<T>();
+  const int                   numPoints = static_cast<int>(points.size());
+
+  // CPU references: host tape interpreter and the recursive value() oracle.
+  std::vector<T> cpuTape(points.size());
+  std::vector<T> oracle(points.size());
+
+  for (size_t i = 0; i < points.size(); i++) {
+    cpuTape[i] = tape.value(points[i]);
+    oracle[i]  = a_tree.value(points[i]);
+  }
+
+  // Upload; move-construct once so the move path is exercised, then evaluate through the moved-to
+  // owner's view.
+  DeviceTape<T> deviceTape(tape);
+  DeviceTape<T> moved(std::move(deviceTape));
+
+  // Device buffers: points, results, and exact global scratch sliced per point.
+  Vec3T<T>* devicePoints       = nullptr;
+  T*        deviceOut          = nullptr;
+  Vec3T<T>* deviceCoordScratch = nullptr;
+  T*        deviceValueScratch = nullptr;
+
+  EBGEOMETRY_GPU_CHECK(GPU::memAlloc(reinterpret_cast<void**>(&devicePoints), points.size() * sizeof(Vec3T<T>)));
+  EBGEOMETRY_GPU_CHECK(GPU::memAlloc(reinterpret_cast<void**>(&deviceOut), points.size() * sizeof(T)));
+  EBGEOMETRY_GPU_CHECK(GPU::memAlloc(reinterpret_cast<void**>(&deviceCoordScratch),
+                                     points.size() * size_t(tape.getNumCoordSlots()) * sizeof(Vec3T<T>)));
+  EBGEOMETRY_GPU_CHECK(GPU::memAlloc(reinterpret_cast<void**>(&deviceValueScratch),
+                                     points.size() * size_t(tape.getNumValueSlots()) * sizeof(T)));
+
+  EBGEOMETRY_GPU_CHECK(
+    GPU::memcpy(devicePoints, points.data(), points.size() * sizeof(Vec3T<T>), GPU::MemcpyHostToDevice));
+
+  evaluateTape<T>
+    <<<256, 128>>>(moved.view(), devicePoints, deviceOut, numPoints, deviceCoordScratch, deviceValueScratch);
+
+  EBGEOMETRY_GPU_CHECK(GPU::getLastError());
+  EBGEOMETRY_GPU_CHECK(GPU::deviceSynchronize());
+
+  std::vector<T> gpuOut(points.size());
+
+  EBGEOMETRY_GPU_CHECK(GPU::memcpy(gpuOut.data(), deviceOut, points.size() * sizeof(T), GPU::MemcpyDeviceToHost));
+
+  EBGEOMETRY_GPU_CHECK(GPU::memFree(devicePoints));
+  EBGEOMETRY_GPU_CHECK(GPU::memFree(deviceOut));
+  EBGEOMETRY_GPU_CHECK(GPU::memFree(deviceCoordScratch));
+  EBGEOMETRY_GPU_CHECK(GPU::memFree(deviceValueScratch));
+
+  // Compare against BOTH references with the same absolute-margin convention as
+  // Tests/TestTape.cpp (withinAbsT).
+  int numMismatches = 0;
+
+  for (size_t i = 0; i < points.size(); i++) {
+    const double gpu       = double(gpuOut[i]);
+    const double deltaTape = std::abs(gpu - double(cpuTape[i]));
+    const double deltaTree = std::abs(gpu - double(oracle[i]));
+
+    // Negated conjunction so that a NaN device result fails loudly (NaN comparisons are false, so
+    // the naive delta > margin form would silently count a NaN as passing).
+    if (!(deltaTape <= a_margin && deltaTree <= a_margin)) {
+      if (numMismatches < 5) {
+        std::printf("  mismatch [%s, %s] at point (%g, %g, %g): gpu=%.12g cpuTape=%.12g oracle=%.12g margin=%g\n",
+                    a_name,
+                    a_precision,
+                    double(points[i][0]),
+                    double(points[i][1]),
+                    double(points[i][2]),
+                    gpu,
+                    double(cpuTape[i]),
+                    double(oracle[i]),
+                    a_margin);
+      }
+
+      numMismatches++;
+    }
+  }
+
+  std::printf("%s [%s, %s]: %d points, %d mismatches (pool: %zu bytes)\n",
+              numMismatches == 0 ? "PASS" : "FAIL",
+              a_name,
+              a_precision,
+              numPoints,
+              numMismatches,
+              moved.getNumBytes());
+
+  return numMismatches == 0 ? 0 : 1;
+}
+
+/**
+ * @brief Run all four golden scenes for one precision.
+ * @param[in] a_precision Precision name for diagnostics.
+ * @return Number of failing scenes.
+ */
+template <class T>
+int
+runAllScenes(const char* a_precision)
+{
+  int failures = 0;
+
+  // (1) Deep mixed tree: Difference(SmoothUnion(Translate(Sphere), Box, s), Rotate(Cylinder));
+  // copied from Tests/TestTape.cpp ("deep mixed tree matches value()").
+  {
+    const auto sphere = std::make_shared<SphereSDF<T>>(Vec3T<T>::zeros(), T(1));
+    const auto box    = std::make_shared<BoxSDF<T>>(Vec3T<T>(-0.8, -0.8, -0.8), Vec3T<T>(0.8, 0.8, 0.8));
+    const auto cyl    = std::make_shared<CylinderSDF<T>>(Vec3T<T>(0, -1, 0), Vec3T<T>(0, 1, 0), T(0.5));
+
+    const T s = T(0.4);
+
+    const auto smoothUnion = SmoothUnion<T>(Translate<T>(sphere, Vec3T<T>(0.2, 0, 0)), box, s);
+    const auto tree        = Difference<T>(smoothUnion, Rotate<T>(cyl, T(25), 0));
+
+    failures += runScene<T>("deep mixed tree", a_precision, *tree, formulaMargin<T>());
+  }
+
+  // (2) Nested transform chain: Offset(Annular(Translate(Rotate(Scale(Box)))));
+  // copied from Tests/TestTape.cpp ("nested tape evaluation through a host callback is safe",
+  // inner tree).
+  {
+    const auto box  = std::make_shared<BoxSDF<T>>(Vec3T<T>(-1, -1, -1), Vec3T<T>(1, 1, 1));
+    const auto tree = Offset<T>(
+      Annular<T>(Translate<T>(Rotate<T>(Scale<T>(box, T(1.5)), T(20), 1), Vec3T<T>(0.5, 0, 0)), T(0.1)), T(0.2));
+
+    failures += runScene<T>("nested transform chain", a_precision, *tree, exactMargin<T>());
+  }
+
+  // (3) BVH sharp union over the 216-leaf mixed scene (K=4); copied from Tests/TestTape.cpp
+  // (requireBVHUnionGolden).
+  {
+    using BV = BoundingVolumes::AABBT<T>;
+
+    std::vector<std::shared_ptr<IF<T>>> primitives;
+    std::vector<BV>                     bvs;
+
+    makeMixedScene<T>(primitives, bvs);
+
+    const BVHUnionIF<T, IF<T>, BV, 4> bvhUnion(primitives, bvs);
+
+    failures += runScene<T>("BVH sharp union (216 leaves, K=4)", a_precision, bvhUnion, exactMargin<T>());
+  }
+
+  // (4) BVH smooth union over an 8-sphere row with the default SmoothMinOp blend; copied from
+  // Tests/TestTape.cpp ("BVH smooth union with the default SmoothMinOp blend lowers natively").
+  {
+    using BV = BoundingVolumes::AABBT<T>;
+
+    std::vector<std::shared_ptr<SphereSDF<T>>> spheres;
+    std::vector<BV>                            bvs;
+
+    makeSphereRow<T>(8, T(1.5), spheres, bvs);
+
+    const T smoothLen = T(0.25);
+
+    const BVHSmoothUnionIF<T, SphereSDF<T>, BV, 4> smooth(spheres, bvs, smoothLen);
+
+    failures += runScene<T>("BVH smooth union (8 spheres, K=4)", a_precision, smooth, formulaMargin<T>());
+  }
+
+  return failures;
+}
+
+} // namespace
+
+/**
+ * @brief Host entry point: skip (exit 77) without a GPU device, otherwise run every golden scene
+ * for both precisions.
+ * @return Zero on success, one on any mismatch, 77 (SKIP_EXIT_CODE) when no GPU device exists.
+ */
+int
+main()
+{
+  int deviceCount = 0;
+
+  const GPU::Error err = GPU::getDeviceCount(&deviceCount);
+
+  if (err != GPU::Success || deviceCount == 0) {
+    std::printf("GPUTape: no GPU device available (%s) -- skipping\n",
+                err == GPU::Success ? "device count is zero" : GPU::getErrorString(err));
+
+    return SKIP_EXIT_CODE;
+  }
+
+  int failures = 0;
+
+  failures += runAllScenes<float>("float");
+  failures += runAllScenes<double>("double");
+
+  std::printf("GPUTape: %d scene(s) failed\n", failures);
+
+  return failures == 0 ? 0 : 1;
+}
+
+#endif // EBGEOMETRY_GPUTAPE_TEST_HPP

--- a/Tests/GPU/EBGeometry_GPUTape.hpp
+++ b/Tests/GPU/EBGeometry_GPUTape.hpp
@@ -32,8 +32,8 @@
  * @author Robert Marskar
  */
 
-#ifndef EBGEOMETRY_GPUTAPE_TEST_HPP
-#define EBGEOMETRY_GPUTAPE_TEST_HPP
+#ifndef EBGEOMETRY_GPUTAPE_HPP
+#define EBGEOMETRY_GPUTAPE_HPP
 
 #include "EBGeometry.hpp" // Pulls in Tape + DeviceTape (active: this body is compiled by an offload compiler).
 
@@ -424,4 +424,4 @@ main()
   return failures == 0 ? 0 : 1;
 }
 
-#endif // EBGEOMETRY_GPUTAPE_TEST_HPP
+#endif // EBGEOMETRY_GPUTAPE_HPP

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -111,10 +111,11 @@ using Meta = short;
   template struct ReflectOp<PREC>;                                          \
                                                                                \
   /* -- Flat tape + interpreter -------------------------------------------*/ \
-  /* DeviceTape<PREC> is deliberately absent: it is CUDA-only (inert without */ \
+  /* DeviceTape<PREC> is deliberately absent: it is GPU-only (inert without  */ \
   /* an offload compiler), so it cannot be instantiated in this host-only    */ \
-  /* TU. Its device-side analogue is Tests/GPU/EBGeometry_GPUTape.cu, which  */ \
-  /* instantiates and exercises it for both precisions under nvcc.           */ \
+  /* TU. Its device-side analogue is Tests/GPU/EBGeometry_GPUTape.hpp, which */ \
+  /* instantiates and exercises it for both precisions under nvcc (via the   */ \
+  /* .cu twin) or hipcc (via the .hip twin).                                 */ \
   template class Tape<PREC>;                                                 \
   template struct TapeView<PREC>;                                            \
   template class TapeBuilder<PREC>;                                          \


### PR DESCRIPTION
# Summary

### Background

Issue #115's device-execution tier calls for "HIP, then SYCL, then OpenACC via the wrappers; broaden CI." After Tier 7, the device runtime (`DeviceTape`, kernel golden test) was CUDA-only, with direct `cuda*` API calls. Tier 0's macro layer already anticipated HIP (`EBGEOMETRY_HIP`, device-pass detection), so this PR makes the runtime backend-neutral and adds the HIP build + CI lane. Proceeding was approved with GPU hardware validation still pending (the maintainer is currently away from a CUDA machine).

### Solution

**Backend-neutral runtime layer** (`Source/EBGeometry_GPURuntime.hpp`, new): `namespace EBGeometry::GPU` with inline `[[nodiscard]]` wrappers and type/constant aliases over the 11-symbol runtime surface (`memAlloc`, `memFree`, `memcpy`, `getDeviceCount`, `getLastError`, `deviceSynchronize`, `getErrorString`; `Error`, `MemcpyKind`, `Success`, `MemcpyHostToDevice`, `MemcpyDeviceToHost`), mapped 1:1 to `hip*` under `__HIPCC__` — checked first, since hip-on-NVIDIA defines both compiler macros — and `cuda*` under `__CUDACC__`. Namespaced functions rather than macros so nothing leaks into consumer code. `EBGEOMETRY_CUDA_CHECK` is renamed **`EBGEOMETRY_GPU_CHECK`** (clean break, zero survivors repo-wide). The header is fully inert on host compilers (preprocesses to nothing) and safe to include first or twice under either offload frontend.

**`DeviceTape` generalized**: guards widen to `CUDA || HIP || DOXYGEN`; every API call goes through the aliases. No structural change — HIP's runtime mirrors CUDA's exactly for this surface.

**Shared test sources**: the smoke and golden-test bodies move to `Tests/GPU/EBGeometry_GPU{Smoke,Tape}.hpp`, included by thin `.cu` (existing targets unchanged) and new `.hip` translation units. Kernel syntax is identical across backends; an adversarial diff confirmed the bodies are token-identical to the Tier 7 originals modulo the mechanical renames.

**Build + CI**: `EBGEOMETRY_ENABLE_HIP` option (mutually exclusive with CUDA per build directory), HIP language wiring with a `gfx90a` default architecture, the same `GPUTapeGolden` ctest registration (exit-77 skip) for either backend, and a `hip` preset triplet mirroring `cuda`. New compile-only `GPU-HIP-Compile` CI lane using Ubuntu 24.04's own `hipcc` packages (~1–2 GB, no multi-gigabyte ROCm container), `continue-on-error` like the CUDA lane. Review found and this PR fixes a subtle CMake defect: architecture defaults must be set *before* `enable_language`, else CMake's own detection caches first and the documented defaults are dead code (the CUDA `70` default had the same pre-existing flaw, also fixed).

**Verification without a GPU toolchain**: clang 18 — which *is* the upstream HIP compiler — ran dual-pass (host + `gfx908` device) syntax/semantics proofs on all four translation units in both assertion modes, plus CUDA-regression proofs of the refactor; the real `nvcc` and new `hipcc` CI lanes check both on push. Host behavior is unchanged: 597/597 unit tests (both precisions), Doxygen clean with the new `GPU` namespace documented, REUSE/format/codespell clean.

Local validation on a ROCm box:
```bash
cmake --preset hip -DCMAKE_HIP_ARCHITECTURES=<your gfx arch>   # gfx90a default
cmake --build --preset hip --parallel $(nproc)
ctest --preset hip
```

### Side-effects

`EBGEOMETRY_CUDA_CHECK` no longer exists (clean break). One GPU backend per build directory (enforced with a `FATAL_ERROR`; each preset has its own build dir, so presets are unaffected). Behavioral GPU validation remains pending real hardware for **both** backends — stated in the README banner. `Examples/GpuCsg` from the plan is deliberately deferred: a GPU example cannot compile under the three-build-system Examples contract that CI enforces, and the golden test already demonstrates the full upload→launch→compare flow.

### Alternative solutions

Object-like `gpuMalloc` macros (the common HPC pattern) were rejected because a header-only library would rewrite consumer identifiers. A `rocm/dev` container CI lane (~20 GB) was rejected for the Ubuntu-archive toolchain. Duplicating the test sources per backend was rejected for the shared-body layout.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation. 
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS

---
_Generated by [Claude Code](https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS)_