### PR TITLE
Migrate DCEL topology from weak_ptr to uint32_t indices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,16 +287,22 @@ does not follow this template, edit the PR body to conform to it.
   `debug-san`, OFF in `release`/`release-test`) and are the primary way internal invariant
   violations (e.g. a dangling half-edge, a malformed mesh) surface during development; they compile
   to nothing in Release.
-- **DCEL topology uses `weak_ptr` for back-references** (edge→pair edge, edge→face, vertex→
-  outgoing edge, etc.) with the `DCEL::MeshT`'s own vertex/edge/face vectors as the sole
-  `shared_ptr` owners. Introducing a *new* back-reference field as a `shared_ptr` will very likely
-  create a reference cycle that leaks (invisible without a leak-checking sanitizer, since nothing
-  crashes) — always use `weak_ptr` + `.lock()` for anything that points "backward" in the mesh
-  graph.
+- **DCEL topology is index-based, not pointer-based.** Every cross-reference (edge→pair edge,
+  edge→face, vertex→outgoing edge, face→half-edge, etc.) is a plain `uint32_t` index into the
+  owning `DCEL::MeshT`'s own vertex/edge/face arrays, sentinel `UINT32_MAX` for "unset" — never a
+  `weak_ptr`/`shared_ptr`. This is what makes `VertexT`/`EdgeT`/`FaceT` trivially copyable
+  (`static_assert`-checked in their headers), a prerequisite for the GPU port's `memcpy`-based
+  mirroring. Any member function that needs to resolve one of these indices back into an actual
+  vertex/edge/face therefore takes the owning `MeshT` as an explicit parameter (e.g.
+  `edge.getVertex(mesh)`, `face.signedDistance(point, mesh)`) — introducing a *new* back-reference
+  field should follow the same pattern (an index member, resolved via an explicit mesh parameter),
+  not a cached pointer, which would only be valid in the address space it was set in and would
+  need re-patching after every host-to-device mirror.
 - **`MeshSDF` retains its source `DCEL::MeshT`, not just the packed BVH.** If you write a similar
   wrapper around a DCEL mesh, remember that a `PackedBVH` of faces holds `shared_ptr<const
-  DCEL::FaceT>`s that transitively `weak_ptr`-reference the mesh's edges/vertices — nothing keeps
-  the mesh itself alive unless something holds an explicit `shared_ptr<DCEL::MeshT>`.
+  DCEL::FaceT>`s whose half-edge index is only meaningful together with the mesh it was resolved
+  against — nothing keeps the mesh itself alive unless something holds an explicit
+  `shared_ptr<DCEL::MeshT>`.
 - **Every CMake preset gets its own `build/<preset-name>/` directory** (see `CMakePresets.json`'s
   `binaryDir`) specifically so switching presets can't silently reuse a stale `CMakeCache.txt` from
   a different configuration.

--- a/Docs/Sphinx/source/ImplemDCEL.rst
+++ b/Docs/Sphinx/source/ImplemDCEL.rst
@@ -22,31 +22,45 @@ The main DCEL functionality (vertices, edges, faces) is provided by classes temp
 floating-point precision ``T`` and a user-defined meta-data type ``Meta`` attached to each
 instance:
 
-*  ``VertexT<T, Meta>`` stores the vertex position, its (outward) normal vector, and the outgoing
-   half-edge from the vertex, plus pointers to every polygon face sharing that vertex. It also has
+*  ``VertexT<T, Meta>`` stores the vertex position, its (outward) normal vector, and the index of
+   an outgoing half-edge from the vertex (into the owning ``MeshT``'s edge array). It also has
    member functions for computing the vertex pseudonormal, see :ref:`Chap:NormalDCEL`. For the
    full API, see the Doxygen reference for
    `VertexT <doxygen/html/classEBGeometry_1_1DCEL_1_1VertexT.html>`__.
 
-*  ``EdgeT<T, Meta>`` represents a half-edge: it stores a reference to its owning face, and
-   pointers to the next edge, its pair edge, and its starting vertex. For the full API, see the
-   Doxygen reference for `EdgeT <doxygen/html/classEBGeometry_1_1DCEL_1_1EdgeT.html>`__.
+*  ``EdgeT<T, Meta>`` represents a half-edge: it stores the indices of its owning face, the next
+   edge, its pair edge, and its starting vertex -- each an index into the owning ``MeshT``'s
+   corresponding array, not a pointer. For the full API, see the Doxygen reference for
+   `EdgeT <doxygen/html/classEBGeometry_1_1DCEL_1_1EdgeT.html>`__.
 
-*  ``FaceT<T, Meta>`` represents a polygon face. Besides its half-edge, it also stores the face
-   normal vector, a 2D embedding of the polygon, and its centroid position: the normal and 2D
-   embedding exist because the signed distance computation needs them, and the centroid exists
-   because BVH partitioners use it when partitioning the surface mesh. For the full API, see the
-   Doxygen reference for `FaceT <doxygen/html/classEBGeometry_1_1DCEL_1_1FaceT.html>`__.
+*  ``FaceT<T, Meta>`` represents a polygon face. Besides the index of its half-edge, it also
+   stores the face normal vector, a 2D embedding of the polygon, and its centroid position: the
+   normal and 2D embedding exist because the signed distance computation needs them, and the
+   centroid exists because BVH partitioners use it when partitioning the surface mesh. For the
+   full API, see the Doxygen reference for
+   `FaceT <doxygen/html/classEBGeometry_1_1DCEL_1_1FaceT.html>`__.
+
+.. note::
+
+   ``VertexT``, ``EdgeT``, and ``FaceT`` cross-reference each other exclusively by index into the
+   owning ``MeshT``'s own vertex/edge/face arrays -- never by pointer. Every member function that
+   needs to resolve one of these indices back into an actual vertex/edge/face (``signedDistance()``,
+   ``reconcile()``, the point-in-face test, ...) therefore takes that owning ``MeshT`` as an
+   explicit argument. Since every member is consequently a plain value (``Vec3T<T>``, ``T``,
+   ``uint32_t``, an enum, or ``Meta``), all three classes are trivially copyable whenever ``T`` and
+   ``Meta`` are -- they can be ``memcpy``'d or mirrored to a different address space with no pointer
+   patching, as long as they are interpreted against the same mesh's arrays on the other side.
 
 *  ``MeshT<T, Meta>`` stores an entire DCEL mesh -- all of its vertices, half-edges, and faces --
    and provides brute-force (:math:`\mathcal{O}(N)`) distance queries, ``signedDistance()`` and
    ``unsignedDistance2()``, that scan every face directly. It is not itself a
    ``SignedDistanceFunction<T>``: for anything beyond small meshes, one instead wraps a
    ``MeshT<T, Meta>`` in one of the BVH-accelerated classes described in
-   :ref:`Chap:MeshSDFClasses`, which hold a ``shared_ptr<MeshT<T, Meta>>`` internally and only fall
-   back to it for topology (not for the accelerated distance queries themselves). A mesh is
-   typically never constructed by hand -- it is built by a file parser reading vertices and faces
-   from disk, see :ref:`Chap:Parsers`. For the full API, see the Doxygen reference for
+   :ref:`Chap:MeshSDFClasses`, which hold a ``shared_ptr<MeshT<T, Meta>>`` internally and pass it to
+   every packed face's ``signedDistance()``/``unsignedDistance2()`` call, since a face's half-edge
+   index is only meaningful together with the mesh it was built from. A mesh is typically never
+   constructed by hand -- it is built by a file parser reading vertices and faces from disk, see
+   :ref:`Chap:Parsers`. For the full API, see the Doxygen reference for
    `MeshT <doxygen/html/classEBGeometry_1_1DCEL_1_1MeshT.html>`__.
 
 Meta-data can be attached to the DCEL primitives by selecting an appropriate type for ``Meta`` above.
@@ -69,8 +83,8 @@ and handing the resulting list to a ``TreeBVH``. Concretely,
 ``MeshSDF`` and ``TriMeshSDF``'s construction) does this by:
 
 #. Building each face's bounding volume ``BV`` directly from its vertex coordinates
-   (``FaceT::getAllVertexCoordinates()``) -- this is why ``FaceT`` stores its vertices' positions
-   accessibly, rather than requiring a caller to walk its half-edges to collect them.
+   (``FaceT::getAllVertexCoordinates(mesh)``, which walks the face's half-edge loop and resolves
+   each vertex index against the owning mesh).
 #. Constructing a ``TreeBVH<T, FaceT<T, Meta>, BV, K>`` from the resulting
    ``(face, bounding volume)`` pairs.
 #. Partitioning that tree according to the requested ``BVH::Build`` strategy (``TopDown``,

--- a/Docs/Sphinx/source/Implementation.rst
+++ b/Docs/Sphinx/source/Implementation.rst
@@ -26,14 +26,14 @@ components). A handful of design choices recur throughout the implementation:
   same bounding volume hierarchy machinery, reducing an :math:`\mathcal{O}(N)` linear scan to an
   :math:`\mathcal{O}(\log N)` tree traversal in either case. See :ref:`Chap:ImplemBVH`.
 
-* **Value types where topology permits it.** A DCEL mesh needs pointer-based topology (a
-  half-edge, its pair, and its owning face are genuinely different objects referencing each
-  other), so it uses ``weak_ptr`` back-references to avoid reference cycles. Where no topology is
-  needed, however, EBGeometry prefers small, self-contained value types instead -- a triangle
-  with no half-edge structure, or a bounding-volume-hierarchy node stored by index offset rather
-  than by pointer -- since these can be packed tightly in memory and, where the data layout
-  allows it, evaluated with SIMD instructions. See :ref:`Chap:ImplemDCEL` and
-  :ref:`Chap:ImplemBVH`.
+* **Value types, even where topology is needed.** A DCEL mesh's half-edges, their pairs, and
+  their owning faces are genuinely different objects referencing each other -- but rather than
+  pointers or reference-counted back-references, every such cross-reference is a plain
+  ``uint32_t`` index into the owning mesh's own vertex/edge/face arrays. This makes
+  ``VertexT``/``EdgeT``/``FaceT`` themselves trivially copyable value types, the same as a
+  bounding-volume-hierarchy node stored by index offset rather than by pointer, so both can be
+  packed tightly in memory and, where the data layout allows it, evaluated with SIMD instructions.
+  See :ref:`Chap:ImplemDCEL` and :ref:`Chap:ImplemBVH`.
 
 * **SIMD as an opt-in, compile-time-detected layer.** SIMD acceleration is implemented with
   hand-written compiler intrinsics in exactly two places, selected at compile time from the

--- a/Integrations/AMReX/PaintEB/main.cpp
+++ b/Integrations/AMReX/PaintEB/main.cpp
@@ -40,7 +40,7 @@ public:
     // Set the meta-data for all facets to their "index", i.e. position in the list of facets
     auto& faces = mesh->getFaces();
     for (size_t i = 0; i < faces.size(); i++) {
-      faces[i]->getMetaData() = 1.0 * i;
+      faces[i].getMetaData() = 1.0 * i;
     }
 
     m_sdf = std::make_shared<EBGeometry::MeshSDF<T, Meta, K>>(mesh, EBGeometry::BVH::Build::SAH);

--- a/Source/EBGeometry_DCEL_Edge.hpp
+++ b/Source/EBGeometry_DCEL_Edge.hpp
@@ -13,8 +13,7 @@
 #define EBGEOMETRY_DCEL_EDGE_HPP
 
 // Std includes
-#include <cstddef>
-#include <memory>
+#include <cstdint>
 #include <type_traits>
 
 // Our includes
@@ -36,13 +35,20 @@ namespace DCEL {
  * circulate the interior of the face. The EdgeT object is such a half-edge; it
  * represents the outgoing half-edge from a vertex, located such that it can be
  * logically represented as a half edge on the "inside" of a polygon face. It
- * contains pointers to the polygon face, vertex, and next half edge It also contains
- * a pointer to the "pair" half edge, i.e. the
- * corresponding half-edge on the other face that shares this edge. Since this
- * class is used with DCEL functionality and signed distance fields, this class
- * also has a signed distance function and thus a "normal vector".
+ * stores the indices of the polygon face, vertex, and next half edge in the
+ * owning mesh's arrays. It also stores the index of the "pair" half edge, i.e.
+ * the corresponding half-edge on the other face that shares this edge. Since
+ * this class is used with DCEL functionality and signed distance fields, this
+ * class also has a signed distance function and thus a "normal vector".
  * @note The normal vector is outgoing, i.e. a point x is "outside" if the dot
  * product between n and (x - x0) is positive.
+ * @note All topology indices below (m_vertex, m_pairEdge, m_nextEdge, m_face) are
+ * indices into the owning DCEL::MeshT's own vertex/edge/face arrays, resolved by
+ * passing that mesh to the accessors below. Using indices rather than pointers
+ * (the previous weak_ptr/shared_ptr scheme) keeps EdgeT a plain, relocatable
+ * value: the owning mesh's arrays are the sole storage, and every
+ * cross-reference is a position within them, not an address -- so an EdgeT is
+ * meaningful under a memcpy or a host-to-device mirror with no pointer patching.
  * @tparam T    Floating-point precision.
  * @tparam Meta Meta-data type stored per edge.
  */
@@ -73,48 +79,32 @@ public:
   using Face = FaceT<T, Meta>;
 
   /**
-   * @brief Alias for vertex pointer type
+   * @brief Alias for mesh type
    */
-  using VertexPtr = std::shared_ptr<Vertex>;
+  using Mesh = MeshT<T, Meta>;
 
   /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
-
-  /**
-   * @brief Default constructor. Sets all pointers to zero and vectors to zero
-   * vectors
+   * @brief Default constructor. Sets all topology indices to the unset sentinel and vectors to
+   * zero vectors.
    */
   EdgeT() noexcept = default;
 
   /**
    * @brief Copy constructor.
-   * @details Copies the normal vector and all four topology pointers (vertex, pair edge, next
-   * edge, face) from the other half-edge. Meta-data (m_metaData) is deliberately NOT copied --
-   * it default-constructs instead; use setMetaData() afterwards if it needs to be populated.
-   * Rationale: same as VertexT's copy constructor -- these pointers are back-references into a
-   * specific mesh's topology (the objects they point to still reference the original edge, not
-   * this copy), so copying them wholesale is not topologically meaningful in general, but is
-   * occasionally useful (e.g. duplicating an edge's geometric/adjacency snapshot).
-   * operator=(const Edge&) has identical semantics.
+   * @details Defaulted memberwise copy of every member -- the normal vector, all four topology
+   * indices (vertex, pair edge, next edge, face), and meta-data. Copying every member (rather than
+   * the narrow, metadata-excluding copy this used to have) is what lets EdgeT be trivially
+   * copyable: `std::is_trivially_copyable` requires the copy constructor to be the implicit/defaulted
+   * one, so a user-provided body -- even one that does nothing but a plain memberwise copy --
+   * would disqualify it. operator=(const Edge&) has identical semantics.
    * @param[in] a_otherEdge Other edge.
    */
-  EdgeT(const Edge& a_otherEdge) noexcept;
+  EdgeT(const Edge& a_otherEdge) = default;
 
   /**
    * @brief Move constructor.
-   * @details Unlike the copy constructor, this transfers the entire state (including m_metaData)
-   * from a_otherEdge, since moving relocates a single object's identity. Defaulted (memberwise
-   * move) rather than hand-written: explicitly defaulting is required here since the presence of a
-   * user-declared copy constructor would otherwise suppress the implicitly-generated move
-   * constructor. Not marked noexcept since Meta is an unconstrained template parameter whose move
-   * constructor is not guaranteed to be noexcept.
+   * @details Defaulted memberwise move; equivalent to the copy constructor since every member is a
+   * plain value.
    * @param[in, out] a_otherEdge Other edge.
    */
   EdgeT(Edge&& a_otherEdge) = default;
@@ -122,9 +112,9 @@ public:
   /**
    * @brief Partial constructor. Calls the default constructor but sets the
    * starting vertex.
-   * @param[in] a_vertex Starting vertex.
+   * @param[in] a_vertexIndex Index of the starting vertex in the owning mesh's vertex array.
    */
-  EdgeT(const VertexPtr& a_vertex) noexcept;
+  EdgeT(const uint32_t a_vertexIndex) noexcept;
 
   /**
    * @brief Destructor (does nothing)
@@ -133,14 +123,12 @@ public:
 
   /**
    * @brief Copy assignment operator.
-   * @details Has the same semantics as the copy constructor (including that m_metaData is not
-   * copied; use setMetaData() afterwards if it needs to be populated). See the copy constructor's
-   * documentation for details.
+   * @details Defaulted memberwise copy; see the copy constructor's documentation.
    * @param[in] a_otherEdge Other edge.
    * @return Reference to (*this).
    */
   Edge&
-  operator=(const Edge& a_otherEdge) noexcept;
+  operator=(const Edge& a_otherEdge) = default;
 
   /**
    * @brief Move assignment operator.
@@ -160,20 +148,23 @@ public:
   size() const noexcept;
 
   /**
-   * @brief Define function. Sets the starting vertex, edges, and normal vectors
-   * @param[in] a_vertex       Starting vertex
-   * @param[in] a_pairEdge     Pair half-edge
-   * @param[in] a_nextEdge     Next half-edge
+   * @brief Define function. Sets the starting vertex, pair/next edge indices.
+   * @param[in] a_vertexIndex   Index of the starting vertex in the owning mesh's vertex array.
+   * @param[in] a_pairEdgeIndex Index of the pair half-edge in the owning mesh's edge array, or
+   * UINT32_MAX if unset.
+   * @param[in] a_nextEdgeIndex Index of the next half-edge in the owning mesh's edge array, or
+   * UINT32_MAX if unset.
    */
   inline void
-  define(const VertexPtr& a_vertex, const EdgePtr& a_pairEdge, const EdgePtr& a_nextEdge) noexcept;
+  define(const uint32_t a_vertexIndex, const uint32_t a_pairEdgeIndex, const uint32_t a_nextEdgeIndex) noexcept;
 
   /**
    * @brief Reconcile internal logic
-   * @details Computes normal.
+   * @details Computes the normal vector.
+   * @param[in] a_mesh Owning mesh, used to resolve the face/pair-edge indices.
    */
   inline void
-  reconcile() noexcept;
+  reconcile(const Mesh& a_mesh) noexcept;
 
   /**
    * @brief Flip surface normal
@@ -182,32 +173,35 @@ public:
   flipNormal() noexcept;
 
   /**
-   * @brief Set the starting vertex
-   * @param[in] a_vertex Starting vertex
+   * @brief Set the index of the starting vertex
+   * @param[in] a_vertexIndex Index of the starting vertex in the owning mesh's vertex array.
    */
   inline void
-  setVertex(const VertexPtr& a_vertex) noexcept;
+  setVertex(const uint32_t a_vertexIndex) noexcept;
 
   /**
-   * @brief Set the pair edge
-   * @param[in] a_pairEdge Pair edge
+   * @brief Set the index of the pair edge
+   * @param[in] a_pairEdgeIndex Index of the pair edge in the owning mesh's edge array, or
+   * UINT32_MAX to mark it unset.
    */
   inline void
-  setPairEdge(const EdgePtr& a_pairEdge) noexcept;
+  setPairEdge(const uint32_t a_pairEdgeIndex) noexcept;
 
   /**
-   * @brief Set the next edge
-   * @param[in] a_nextEdge Next edge
+   * @brief Set the index of the next edge
+   * @param[in] a_nextEdgeIndex Index of the next edge in the owning mesh's edge array, or
+   * UINT32_MAX to mark it unset.
    */
   inline void
-  setNextEdge(const EdgePtr& a_nextEdge) noexcept;
+  setNextEdge(const uint32_t a_nextEdgeIndex) noexcept;
 
   /**
-   * @brief Set the pointer to this half-edge's face.
-   * @param[in] a_face Face to associate with this half-edge.
+   * @brief Set the index of this half-edge's face.
+   * @param[in] a_faceIndex Index of the face in the owning mesh's face array, or UINT32_MAX to
+   * mark it unset.
    */
   inline void
-  setFace(const FacePtr& a_face) noexcept;
+  setFace(const uint32_t a_faceIndex) noexcept;
 
   /**
    * @brief Set the meta-data.
@@ -217,71 +211,106 @@ public:
   setMetaData(const Meta& a_metaData) noexcept;
 
   /**
-   * @brief Get the starting vertex.
-   * @details Returns a shared_ptr obtained by locking the internal weak_ptr (see the class-level
-   * @details note on ownership). Returns nullptr if the vertex has been destroyed, which should
-   * not happen while the owning mesh is alive.
-   * @return Starting vertex, or nullptr.
+   * @brief Get the index of the starting vertex.
+   * @return Index of the starting vertex in the owning mesh's vertex array, or UINT32_MAX if
+   * unset.
    */
-  [[nodiscard]] inline VertexPtr
-  getVertex() noexcept;
+  [[nodiscard]] inline uint32_t
+  getVertexIndex() const noexcept;
+
+  /**
+   * @brief Get the index of the pair edge.
+   * @return Index of the pair edge in the owning mesh's edge array, or UINT32_MAX if unset.
+   */
+  [[nodiscard]] inline uint32_t
+  getPairEdgeIndex() const noexcept;
+
+  /**
+   * @brief Get the index of the next edge.
+   * @return Index of the next edge in the owning mesh's edge array, or UINT32_MAX if unset.
+   */
+  [[nodiscard]] inline uint32_t
+  getNextEdgeIndex() const noexcept;
+
+  /**
+   * @brief Get the index of this half-edge's face.
+   * @return Index of the face in the owning mesh's face array, or UINT32_MAX if unset.
+   */
+  [[nodiscard]] inline uint32_t
+  getFaceIndex() const noexcept;
+
+  /**
+   * @brief Get the starting vertex.
+   * @param[in] a_mesh Owning mesh, used to resolve the vertex index.
+   * @return Reference to the starting vertex. m_vertex must be set (see getVertexIndex()).
+   */
+  [[nodiscard]] inline Vertex&
+  getVertex(Mesh& a_mesh) noexcept;
 
   /**
    * @brief Get the starting vertex (const overload).
-   * @return Starting vertex, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the vertex index.
+   * @return Const reference to the starting vertex. m_vertex must be set (see getVertexIndex()).
    */
-  [[nodiscard]] inline VertexPtr
-  getVertex() const noexcept;
+  [[nodiscard]] inline const Vertex&
+  getVertex(const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get the end vertex.
-   * @return The next half-edge's starting vertex, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the next-edge and vertex indices.
+   * @return Reference to the next half-edge's starting vertex. m_nextEdge must be set.
    */
-  [[nodiscard]] inline VertexPtr
-  getOtherVertex() noexcept;
+  [[nodiscard]] inline Vertex&
+  getOtherVertex(Mesh& a_mesh) noexcept;
 
   /**
    * @brief Get the end vertex (const overload).
-   * @return The next half-edge's starting vertex, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the next-edge and vertex indices.
+   * @return Const reference to the next half-edge's starting vertex. m_nextEdge must be set.
    */
-  [[nodiscard]] inline VertexPtr
-  getOtherVertex() const noexcept;
+  [[nodiscard]] inline const Vertex&
+  getOtherVertex(const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get the pair edge.
-   * @return Pair edge, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the pair-edge index.
+   * @return Reference to the pair edge. m_pairEdge must be set (see getPairEdgeIndex()).
    */
-  [[nodiscard]] inline EdgePtr
-  getPairEdge() noexcept;
+  [[nodiscard]] inline Edge&
+  getPairEdge(Mesh& a_mesh) noexcept;
 
   /**
    * @brief Get the pair edge (const overload).
-   * @return Pair edge, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the pair-edge index.
+   * @return Const reference to the pair edge. m_pairEdge must be set (see getPairEdgeIndex()).
    */
-  [[nodiscard]] inline EdgePtr
-  getPairEdge() const noexcept;
+  [[nodiscard]] inline const Edge&
+  getPairEdge(const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get the next edge.
-   * @return Next edge, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the next-edge index.
+   * @return Reference to the next edge. m_nextEdge must be set (see getNextEdgeIndex()).
    */
-  [[nodiscard]] inline EdgePtr
-  getNextEdge() noexcept;
+  [[nodiscard]] inline Edge&
+  getNextEdge(Mesh& a_mesh) noexcept;
 
   /**
    * @brief Get the next edge (const overload).
-   * @return Next edge, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the next-edge index.
+   * @return Const reference to the next edge. m_nextEdge must be set (see getNextEdgeIndex()).
    */
-  [[nodiscard]] inline EdgePtr
-  getNextEdge() const noexcept;
+  [[nodiscard]] inline const Edge&
+  getNextEdge(const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Compute the normal vector as the average of the face normals on
    * both sides of this edge.
+   * @param[in] a_mesh Owning mesh, used to resolve the face/pair-edge indices.
    * @return Unit normal vector for this edge.
    */
   [[nodiscard]] inline Vec3T<T>
-  computeNormal() const noexcept;
+  computeNormal(const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get modifiable normal vector.
@@ -299,17 +328,19 @@ public:
 
   /**
    * @brief Get this half-edge's face.
-   * @return Owning face, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the face index.
+   * @return Reference to the owning face. m_face must be set (see getFaceIndex()).
    */
-  [[nodiscard]] inline FacePtr
-  getFace() noexcept;
+  [[nodiscard]] inline Face&
+  getFace(Mesh& a_mesh) noexcept;
 
   /**
    * @brief Get this half-edge's face (const overload).
-   * @return Owning face, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the face index.
+   * @return Const reference to the owning face. m_face must be set (see getFaceIndex()).
    */
-  [[nodiscard]] inline FacePtr
-  getFace() const noexcept;
+  [[nodiscard]] inline const Face&
+  getFace(const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get meta-data
@@ -330,22 +361,24 @@ public:
    * @details Checks whether a_x0 projects onto the edge segment or past one of
    * the end vertices. If it projects to a vertex, the signed distance to that
    * vertex is returned. Otherwise the sign is determined from the edge normal.
-   * @param[in] a_x0 Query point.
+   * @param[in] a_x0   Query point.
+   * @param[in] a_mesh Owning mesh, used to resolve the vertex indices.
    * @return Signed distance; positive on the normal side of the edge.
    */
   [[nodiscard]] inline T
-  signedDistance(const Vec3& a_x0) const noexcept;
+  signedDistance(const Vec3& a_x0, const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get the squared unsigned distance from a_x0 to this half-edge.
    * @details Clamps the projection parameter to [0,1] so the closest point is
    * always on the segment, then returns the squared distance. Faster than
    * signedDistance().
-   * @param[in] a_x0 Query point.
+   * @param[in] a_x0   Query point.
+   * @param[in] a_mesh Owning mesh, used to resolve the vertex indices.
    * @return Squared Euclidean distance to the closest point on the edge.
    */
   [[nodiscard]] inline T
-  unsignedDistance2(const Vec3& a_x0) const noexcept;
+  unsignedDistance2(const Vec3& a_x0, const Mesh& a_mesh) const noexcept;
 
 protected:
   /**
@@ -354,28 +387,26 @@ protected:
   Vec3 m_normal = Vec3::zeros();
 
   /**
-   * @brief Starting vertex.
-   * @details Stored as a weak_ptr: the vertex is owned by the mesh's own vertex list, and a
-   * plain shared_ptr here (mirrored by the sibling m_pairEdge/m_nextEdge/m_face links, and by
-   * FaceT::m_halfEdge and VertexT::m_outgoingEdge) would form a reference cycle across the
-   * half-edge/face/vertex graph that shared_ptr's reference counting can never collect.
+   * @brief Index of the starting vertex.
+   * @details Index into the owning DCEL::MeshT's vertex array, or UINT32_MAX if unset.
    */
-  std::weak_ptr<Vertex> m_vertex;
+  uint32_t m_vertex = UINT32_MAX;
 
   /**
-   * @brief Pair edge. See m_vertex for why this is a weak_ptr.
+   * @brief Index of the pair edge. See m_vertex for the indexing convention.
    */
-  std::weak_ptr<Edge> m_pairEdge;
+  uint32_t m_pairEdge = UINT32_MAX;
 
   /**
-   * @brief Next edge. See m_vertex for why this is a weak_ptr.
+   * @brief Index of the next edge. See m_vertex for the indexing convention.
    */
-  std::weak_ptr<Edge> m_nextEdge;
+  uint32_t m_nextEdge = UINT32_MAX;
 
   /**
-   * @brief Enclosing polygon face. See m_vertex for why this is a weak_ptr.
+   * @brief Index of the enclosing polygon face, into the owning mesh's face array, or
+   * UINT32_MAX if unset.
    */
-  std::weak_ptr<Face> m_face;
+  uint32_t m_face = UINT32_MAX;
 
   /**
    * @brief Meta-data attached to this edge
@@ -390,20 +421,28 @@ protected:
    * @details Parametrizes the edge as x(t) = x1 + (x2-x1)*t and computes t
    * such that x(t) is the closest point to a_x0. Returns t in (-inf, +inf);
    * the point is on the segment when t in [0,1].
-   * @param[in] a_x0 Query point.
+   * @param[in] a_x0   Query point.
+   * @param[in] a_mesh Owning mesh, used to resolve the vertex indices.
    * @return Projection parameter t.
    */
   [[nodiscard]] inline T
-  projectPointToEdge(const Vec3& a_x0) const noexcept;
+  projectPointToEdge(const Vec3& a_x0, const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get the vector pointing along this edge (from start to end vertex).
-   * @return x2 - x1, where x1 = getVertex()->getPosition() and x2 =
-   * getOtherVertex()->getPosition().
+   * @param[in] a_mesh Owning mesh, used to resolve the vertex indices.
+   * @return x2 - x1, where x1 = getVertex(a_mesh).getPosition() and x2 =
+   * getOtherVertex(a_mesh).getPosition().
    */
   [[nodiscard]] inline Vec3T<T>
-  getX2X1() const noexcept;
+  getX2X1(const Mesh& a_mesh) const noexcept;
 };
+
+static_assert(std::is_trivially_copyable_v<EdgeT<float, DefaultMetaData>>,
+              "EdgeT<float,DefaultMetaData> must be trivially copyable");
+static_assert(std::is_trivially_copyable_v<EdgeT<double, DefaultMetaData>>,
+              "EdgeT<double,DefaultMetaData> must be trivially copyable");
+
 } // namespace DCEL
 
 } // namespace EBGeometry

--- a/Source/EBGeometry_DCEL_EdgeImplem.hpp
+++ b/Source/EBGeometry_DCEL_EdgeImplem.hpp
@@ -6,7 +6,6 @@
  * @file   EBGeometry_DCEL_EdgeImplem.hpp
  * @brief  Implementation of EBGeometry_DCEL_Edge.hpp
  * @author Robert Marskar
- * @todo   Include m_face in constructors
  */
 
 #ifndef EBGEOMETRY_DCEL_EDGEIMPLEM_HPP
@@ -17,7 +16,6 @@
 #include <cmath>
 #include <cstddef>
 #include <limits>
-#include <memory>
 
 // Our includes
 #include "EBGeometry_DCEL_Edge.hpp"
@@ -30,34 +28,9 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline EdgeT<T, Meta>::EdgeT(const VertexPtr& a_vertex) noexcept
+inline EdgeT<T, Meta>::EdgeT(const uint32_t a_vertexIndex) noexcept
 {
-  m_vertex = a_vertex;
-}
-
-template <class T, class Meta>
-inline EdgeT<T, Meta>::EdgeT(const Edge& a_otherEdge) noexcept
-{
-  m_normal   = a_otherEdge.m_normal;
-  m_face     = a_otherEdge.m_face;
-  m_vertex   = a_otherEdge.m_vertex;
-  m_pairEdge = a_otherEdge.m_pairEdge;
-  m_nextEdge = a_otherEdge.m_nextEdge;
-}
-
-template <class T, class Meta>
-inline EdgeT<T, Meta>&
-EdgeT<T, Meta>::operator=(const Edge& a_otherEdge) noexcept
-{
-  if (this != &a_otherEdge) {
-    m_normal   = a_otherEdge.m_normal;
-    m_face     = a_otherEdge.m_face;
-    m_vertex   = a_otherEdge.m_vertex;
-    m_pairEdge = a_otherEdge.m_pairEdge;
-    m_nextEdge = a_otherEdge.m_nextEdge;
-  }
-
-  return *this;
+  m_vertex = a_vertexIndex;
 }
 
 template <class T, class Meta>
@@ -69,11 +42,13 @@ EdgeT<T, Meta>::size() const noexcept
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::define(const VertexPtr& a_vertex, const EdgePtr& a_pairEdge, const EdgePtr& a_nextEdge) noexcept
+EdgeT<T, Meta>::define(const uint32_t a_vertexIndex,
+                       const uint32_t a_pairEdgeIndex,
+                       const uint32_t a_nextEdgeIndex) noexcept
 {
-  m_vertex   = a_vertex;
-  m_pairEdge = a_pairEdge;
-  m_nextEdge = a_nextEdge;
+  m_vertex   = a_vertexIndex;
+  m_pairEdge = a_pairEdgeIndex;
+  m_nextEdge = a_nextEdgeIndex;
 }
 
 template <class T, class Meta>
@@ -85,37 +60,37 @@ EdgeT<T, Meta>::flipNormal() noexcept
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::reconcile() noexcept
+EdgeT<T, Meta>::reconcile(const Mesh& a_mesh) noexcept
 {
-  m_normal = this->computeNormal();
+  m_normal = this->computeNormal(a_mesh);
 }
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::setVertex(const VertexPtr& a_vertex) noexcept
+EdgeT<T, Meta>::setVertex(const uint32_t a_vertexIndex) noexcept
 {
-  m_vertex = a_vertex;
+  m_vertex = a_vertexIndex;
 }
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::setPairEdge(const EdgePtr& a_pairEdge) noexcept
+EdgeT<T, Meta>::setPairEdge(const uint32_t a_pairEdgeIndex) noexcept
 {
-  m_pairEdge = a_pairEdge;
+  m_pairEdge = a_pairEdgeIndex;
 }
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::setNextEdge(const EdgePtr& a_nextEdge) noexcept
+EdgeT<T, Meta>::setNextEdge(const uint32_t a_nextEdgeIndex) noexcept
 {
-  m_nextEdge = a_nextEdge;
+  m_nextEdge = a_nextEdgeIndex;
 }
 
 template <class T, class Meta>
 inline void
-EdgeT<T, Meta>::setFace(const FacePtr& a_face) noexcept
+EdgeT<T, Meta>::setFace(const uint32_t a_faceIndex) noexcept
 {
-  m_face = a_face;
+  m_face = a_faceIndex;
 }
 
 template <class T, class Meta>
@@ -126,28 +101,58 @@ EdgeT<T, Meta>::setMetaData(const Meta& a_metaData) noexcept
 }
 
 template <class T, class Meta>
+inline uint32_t
+EdgeT<T, Meta>::getVertexIndex() const noexcept
+{
+  return m_vertex;
+}
+
+template <class T, class Meta>
+inline uint32_t
+EdgeT<T, Meta>::getPairEdgeIndex() const noexcept
+{
+  return m_pairEdge;
+}
+
+template <class T, class Meta>
+inline uint32_t
+EdgeT<T, Meta>::getNextEdgeIndex() const noexcept
+{
+  return m_nextEdge;
+}
+
+template <class T, class Meta>
+inline uint32_t
+EdgeT<T, Meta>::getFaceIndex() const noexcept
+{
+  return m_face;
+}
+
+template <class T, class Meta>
 inline Vec3T<T>
-EdgeT<T, Meta>::computeNormal() const noexcept
+EdgeT<T, Meta>::computeNormal(const Mesh& a_mesh) const noexcept
 {
   // Every half-edge belongs to exactly one face by DCEL invariant, so m_face must be set. The pair
-  // edge (and its face) may legitimately be null for a boundary edge on an open mesh -- that case
+  // edge (and its face) may legitimately be unset for a boundary edge on an open mesh -- that case
   // is handled gracefully below rather than asserted against.
-  EBGEOMETRY_EXPECT(!m_face.expired());
+  EBGEOMETRY_EXPECT(m_face != UINT32_MAX);
 
   Vec3T<T> normal = Vec3T<T>::zeros();
 
-  if (const auto face = m_face.lock()) {
-    const Vec3T<T>& faceNormal = face->getNormal();
+  const Vec3T<T>& faceNormal = this->getFace(a_mesh).getNormal();
 
-    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[0]));
-    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[1]));
-    EBGEOMETRY_EXPECT(std::isfinite(faceNormal[2]));
+  EBGEOMETRY_EXPECT(std::isfinite(faceNormal[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(faceNormal[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(faceNormal[2]));
 
-    normal += faceNormal;
-  }
-  if (const auto pairEdge = m_pairEdge.lock()) {
-    if (const auto pairFace = pairEdge->getFace()) {
-      const Vec3T<T>& pairFaceNormal = pairFace->getNormal();
+  normal += faceNormal;
+
+  if (m_pairEdge != UINT32_MAX) {
+    const Edge&    pairEdge      = this->getPairEdge(a_mesh);
+    const uint32_t pairFaceIndex = pairEdge.getFaceIndex();
+
+    if (pairFaceIndex != UINT32_MAX) {
+      const Vec3T<T>& pairFaceNormal = pairEdge.getFace(a_mesh).getNormal();
 
       EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[0]));
       EBGEOMETRY_EXPECT(std::isfinite(pairFaceNormal[1]));
@@ -179,89 +184,105 @@ EdgeT<T, Meta>::getNormal() const noexcept
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
-EdgeT<T, Meta>::getVertex() noexcept
+inline VertexT<T, Meta>&
+EdgeT<T, Meta>::getVertex(Mesh& a_mesh) noexcept
 {
-  return m_vertex.lock();
+  EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
+
+  return a_mesh.getVertices()[m_vertex];
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
-EdgeT<T, Meta>::getVertex() const noexcept
+inline const VertexT<T, Meta>&
+EdgeT<T, Meta>::getVertex(const Mesh& a_mesh) const noexcept
 {
-  return m_vertex.lock();
+  EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
+
+  return a_mesh.getVertices()[m_vertex];
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
-EdgeT<T, Meta>::getOtherVertex() noexcept
+inline VertexT<T, Meta>&
+EdgeT<T, Meta>::getOtherVertex(Mesh& a_mesh) noexcept
 {
-  EBGEOMETRY_EXPECT(!m_nextEdge.expired());
+  EBGEOMETRY_EXPECT(m_nextEdge != UINT32_MAX);
 
-  return m_nextEdge.lock()->getVertex();
+  return this->getNextEdge(a_mesh).getVertex(a_mesh);
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<VertexT<T, Meta>>
-EdgeT<T, Meta>::getOtherVertex() const noexcept
+inline const VertexT<T, Meta>&
+EdgeT<T, Meta>::getOtherVertex(const Mesh& a_mesh) const noexcept
 {
-  EBGEOMETRY_EXPECT(!m_nextEdge.expired());
+  EBGEOMETRY_EXPECT(m_nextEdge != UINT32_MAX);
 
-  return m_nextEdge.lock()->getVertex();
+  return this->getNextEdge(a_mesh).getVertex(a_mesh);
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-EdgeT<T, Meta>::getPairEdge() noexcept
+inline EdgeT<T, Meta>&
+EdgeT<T, Meta>::getPairEdge(Mesh& a_mesh) noexcept
 {
-  return m_pairEdge.lock();
+  EBGEOMETRY_EXPECT(m_pairEdge != UINT32_MAX);
+
+  return a_mesh.getEdges()[m_pairEdge];
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-EdgeT<T, Meta>::getPairEdge() const noexcept
+inline const EdgeT<T, Meta>&
+EdgeT<T, Meta>::getPairEdge(const Mesh& a_mesh) const noexcept
 {
-  return m_pairEdge.lock();
+  EBGEOMETRY_EXPECT(m_pairEdge != UINT32_MAX);
+
+  return a_mesh.getEdges()[m_pairEdge];
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-EdgeT<T, Meta>::getNextEdge() noexcept
+inline EdgeT<T, Meta>&
+EdgeT<T, Meta>::getNextEdge(Mesh& a_mesh) noexcept
 {
-  return m_nextEdge.lock();
+  EBGEOMETRY_EXPECT(m_nextEdge != UINT32_MAX);
+
+  return a_mesh.getEdges()[m_nextEdge];
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-EdgeT<T, Meta>::getNextEdge() const noexcept
+inline const EdgeT<T, Meta>&
+EdgeT<T, Meta>::getNextEdge(const Mesh& a_mesh) const noexcept
 {
-  return m_nextEdge.lock();
+  EBGEOMETRY_EXPECT(m_nextEdge != UINT32_MAX);
+
+  return a_mesh.getEdges()[m_nextEdge];
 }
 
 template <class T, class Meta>
 inline Vec3T<T>
-EdgeT<T, Meta>::getX2X1() const noexcept
+EdgeT<T, Meta>::getX2X1(const Mesh& a_mesh) const noexcept
 {
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
+  EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
 
-  const auto& x1 = this->getVertex()->getPosition();
-  const auto& x2 = this->getOtherVertex()->getPosition();
+  const auto& x1 = this->getVertex(a_mesh).getPosition();
+  const auto& x2 = this->getOtherVertex(a_mesh).getPosition();
 
   return x2 - x1;
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<FaceT<T, Meta>>
-EdgeT<T, Meta>::getFace() noexcept
+inline FaceT<T, Meta>&
+EdgeT<T, Meta>::getFace(Mesh& a_mesh) noexcept
 {
-  return m_face.lock();
+  EBGEOMETRY_EXPECT(m_face != UINT32_MAX);
+
+  return a_mesh.getFaces()[m_face];
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<FaceT<T, Meta>>
-EdgeT<T, Meta>::getFace() const noexcept
+inline const FaceT<T, Meta>&
+EdgeT<T, Meta>::getFace(const Mesh& a_mesh) const noexcept
 {
-  return m_face.lock();
+  EBGEOMETRY_EXPECT(m_face != UINT32_MAX);
+
+  return a_mesh.getFaces()[m_face];
 }
 
 template <class T, class Meta>
@@ -280,15 +301,15 @@ EdgeT<T, Meta>::getMetaData() const noexcept
 
 template <class T, class Meta>
 inline T
-EdgeT<T, Meta>::projectPointToEdge(const Vec3& a_x0) const noexcept
+EdgeT<T, Meta>::projectPointToEdge(const Vec3& a_x0, const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
+  EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
 
-  const auto p    = a_x0 - m_vertex.lock()->getPosition();
-  const auto x2x1 = this->getX2X1();
+  const auto p    = a_x0 - this->getVertex(a_mesh).getPosition();
+  const auto x2x1 = this->getX2X1(a_mesh);
 
   EBGEOMETRY_EXPECT(x2x1.dot(x2x1) > T(0));
 
@@ -297,30 +318,30 @@ EdgeT<T, Meta>::projectPointToEdge(const Vec3& a_x0) const noexcept
 
 template <class T, class Meta>
 inline T
-EdgeT<T, Meta>::signedDistance(const Vec3& a_x0) const noexcept
+EdgeT<T, Meta>::signedDistance(const Vec3& a_x0, const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
+  EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
 
   T retval = std::numeric_limits<T>::max();
 
   // Project point to edge.
-  const T t = this->projectPointToEdge(a_x0);
+  const T t = this->projectPointToEdge(a_x0, a_mesh);
 
   if (t <= T(0.0)) {
     // Closest point is the starting vertex
-    retval = this->getVertex()->signedDistance(a_x0);
+    retval = this->getVertex(a_mesh).signedDistance(a_x0);
   }
   else if (t >= T(1.0)) {
     // Closest point is the end vertex
-    retval = this->getOtherVertex()->signedDistance(a_x0);
+    retval = this->getOtherVertex(a_mesh).signedDistance(a_x0);
   }
   else {
     // Closest point is the edge itself.
-    const Vec3 x2x1      = this->getX2X1();
-    const Vec3 linePoint = m_vertex.lock()->getPosition() + t * x2x1;
+    const Vec3 x2x1      = this->getX2X1(a_mesh);
+    const Vec3 linePoint = this->getVertex(a_mesh).getPosition() + t * x2x1;
     const Vec3 delta     = a_x0 - linePoint;
     const T    dot       = m_normal.dot(delta);
 
@@ -334,22 +355,22 @@ EdgeT<T, Meta>::signedDistance(const Vec3& a_x0) const noexcept
 
 template <class T, class Meta>
 inline T
-EdgeT<T, Meta>::unsignedDistance2(const Vec3& a_x0) const noexcept
+EdgeT<T, Meta>::unsignedDistance2(const Vec3& a_x0, const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_vertex.expired());
+  EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
 
   constexpr T zero = 0.0;
   constexpr T one  = 1.0;
 
   // Project point to edge and restrict to edge length.
-  const auto t = std::clamp(this->projectPointToEdge(a_x0), zero, one);
+  const auto t = std::clamp(this->projectPointToEdge(a_x0, a_mesh), zero, one);
 
   // Compute distance to this edge.
-  const Vec3T<T> x2x1      = this->getX2X1();
-  const Vec3T<T> linePoint = m_vertex.lock()->getPosition() + t * x2x1;
+  const Vec3T<T> x2x1      = this->getX2X1(a_mesh);
+  const Vec3T<T> linePoint = this->getVertex(a_mesh).getPosition() + t * x2x1;
   const Vec3T<T> delta     = a_x0 - linePoint;
 
   return delta.dot(delta);

--- a/Source/EBGeometry_DCEL_Face.hpp
+++ b/Source/EBGeometry_DCEL_Face.hpp
@@ -15,7 +15,6 @@
 // Std includes
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <type_traits>
 #include <vector>
 
@@ -32,20 +31,25 @@ namespace DCEL {
 /**
  * @brief Class which represents a polygon face in a double-edge connected list
  * (DCEL).
- * @details This class is a polygon face in a DCEL mesh. It contains pointer
- * storage to one of the half-edges that circulate the inside of the polygon
- * face, as well as having a normal vector, a centroid, and an area. This class
- * supports signed distance computations. These computations require algorithms
- * that compute e.g. the winding number of the polygon, or the number of times a
- * ray cast passes through it. Thus, one of its central features is that it can
- * be embedded in 2D by projecting it along the cardinal direction of its normal
- * vector. To be fully consistent with a DCEL structure the class stores a
- * reference to one of its half edges, but for performance reasons it also stores
- * references to the other half edges.
+ * @details This class is a polygon face in a DCEL mesh. It stores the index of
+ * one of the half-edges that circulate the inside of the polygon face, as well
+ * as having a normal vector, a centroid, and an area. This class supports
+ * signed distance computations. These computations require algorithms that
+ * compute e.g. the winding number of the polygon, or the number of times a ray
+ * cast passes through it. Thus, one of its central features is that it can be
+ * embedded in 2D by projecting it along the cardinal direction of its normal
+ * vector.
  * @note To compute the distance from a point to the face one must determine if
  * the point projects "inside" or "outside" the polygon. There are several
  * algorithms for this, and by default this class uses a crossing number
  * algorithm.
+ * @note m_halfEdge is an index into the owning DCEL::MeshT's own edge array,
+ * resolved by passing that mesh to the accessors below (see EdgeT for why
+ * indices rather than pointers are used). Every other member is a plain value
+ * (Vec3, T, uint32_t, an enum, and Meta), so as long as Meta and T are
+ * trivially copyable, FaceT itself is trivially copyable -- it can be memcpy'd
+ * or mirrored to a different address space with no pointer patching, as long
+ * as it is interpreted against the same mesh's arrays on the other side.
  * @tparam T    Floating-point precision type.
  * @tparam Meta User-defined metadata type.
  */
@@ -76,19 +80,9 @@ public:
   using Face = FaceT<T, Meta>;
 
   /**
-   * @brief Alias for vertex pointer type
+   * @brief Alias for mesh type
    */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
+  using Mesh = MeshT<T, Meta>;
 
   /**
    * @brief Alias for edge iterator
@@ -96,7 +90,7 @@ public:
   using EdgeIterator = EdgeIteratorT<T, Meta>;
 
   /**
-   * @brief Default constructor. Sets the half-edge to zero and the
+   * @brief Default constructor. Sets the half-edge index to the unset sentinel and the
    * inside/outside algorithm to crossing number algorithm
    */
   FaceT() = default;
@@ -104,25 +98,23 @@ public:
   /**
    * @brief Partial constructor. Calls default constructor but associates a
    * half-edge
-   * @param[in] a_edge Half-edge
+   * @param[in] a_edgeIndex Index of the half-edge in the owning mesh's edge array.
    */
-  FaceT(const EdgePtr& a_edge);
+  FaceT(const uint32_t a_edgeIndex);
 
   /**
    * @brief Copy constructor.
-   * @details Copies every member -- the normal vector, half-edge pointer, centroid, area,
-   * 2D-projection axes (m_xDir, m_yDir), inside/outside algorithm, and meta-data (m_metaData) -- so
-   * the copy is immediately usable for a point-in-face test and carries the same meta-data as the
-   * source face. operator=(const Face&) has identical semantics.
+   * @details Defaulted memberwise copy: every member is a plain value (see the class-level note),
+   * so the copy is immediately usable for a point-in-face test against the same mesh the source
+   * face belonged to, and carries the same meta-data as the source face.
    * @param[in] a_otherFace Other face to copy from.
    */
-  FaceT(const Face& a_otherFace);
+  FaceT(const Face& a_otherFace) = default;
 
   /**
    * @brief Move constructor.
-   * @details Transfers every member (memberwise move) from a_otherFace. Explicitly defaulted because
-   * the user-declared copy constructor would otherwise suppress it. Not marked noexcept since Meta is
-   * an unconstrained template parameter whose move constructor is not guaranteed to be noexcept.
+   * @details Defaulted memberwise move; equivalent to the copy constructor since every member is a
+   * plain value.
    * @param[in, out] a_otherFace Other face.
    */
   FaceT(Face&& a_otherFace) = default;
@@ -134,17 +126,17 @@ public:
 
   /**
    * @brief Copy assignment operator.
-   * @details Has the same semantics as the copy constructor; see its documentation.
+   * @details Defaulted memberwise copy; see the copy constructor's documentation.
    * @param[in] a_otherFace Other face.
    * @return Reference to (*this).
    */
   Face&
-  operator=(const Face& a_otherFace) noexcept;
+  operator=(const Face& a_otherFace) = default;
 
   /**
    * @brief Move assignment operator.
-   * @details Has the same full-state-transfer semantics as the move constructor (defaulted
-   * memberwise move; see its documentation for why this must be defaulted explicitly).
+   * @details Defaulted memberwise move; equivalent to copy assignment since every member is a
+   * plain value.
    * @param[in, out] a_otherFace Other face.
    * @return Reference to (*this).
    */
@@ -152,21 +144,22 @@ public:
   operator=(Face&& a_otherFace) = default;
 
   /**
-   * @brief Define function which sets the normal vector and half-edge
-   * @param[in] a_normal Normal vector
-   * @param[in] a_edge   Half edge
+   * @brief Define function which sets the normal vector and half-edge index
+   * @param[in] a_normal    Normal vector
+   * @param[in] a_edgeIndex Index of the half-edge in the owning mesh's edge array.
    */
   inline void
-  define(const Vec3& a_normal, const EdgePtr& a_edge) noexcept;
+  define(const Vec3& a_normal, const uint32_t a_edgeIndex) noexcept;
 
   /**
    * @brief Reconcile face. This will compute the normal vector, area, centroid,
    * and the 2D embedding of the polygon
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    * @note "Everything" must be set before doing this, i.e. the face must be
    * complete with half edges and there can be no dangling edges.
    */
   inline void
-  reconcile();
+  reconcile(const Mesh& a_mesh);
 
   /**
    * @brief Compute the 2D embedding of this polygon from the current normal vector and topology,
@@ -175,10 +168,9 @@ public:
    * after manually restoring a normal vector (e.g. when deep-copying a face and preserving whatever
    * normal it had, including one set via flipNormal()) without having that normal silently
    * overwritten by a geometrically-derived one.
-   * @note The face must be complete with half edges and there can be no dangling edges.
    */
   inline void
-  computeProjectionDirections();
+  computeProjectionDirections() noexcept;
 
   /**
    * @brief Flip the normal vector
@@ -187,11 +179,12 @@ public:
   flipNormal() noexcept;
 
   /**
-   * @brief Set the half edge
-   * @param[in] a_halfEdge Half edge
+   * @brief Set the half edge index
+   * @param[in] a_halfEdgeIndex Index of the half-edge in the owning mesh's edge array, or
+   * UINT32_MAX to mark it unset.
    */
   inline void
-  setHalfEdge(const EdgePtr& a_halfEdge) noexcept;
+  setHalfEdge(const uint32_t a_halfEdgeIndex) noexcept;
 
   /**
    * @brief Set the meta-data.
@@ -209,21 +202,11 @@ public:
   setInsideOutsideAlgorithm(InsideOutsideAlgorithm a_algorithm) noexcept;
 
   /**
-   * @brief Get the starting half-edge.
-   * @details Returns a shared_ptr obtained by locking the internal weak_ptr (see the class-level
-   * note on ownership near m_halfEdge). Returns nullptr if the edge has been destroyed, which
-   * should not happen while the owning mesh is alive.
-   * @return Starting half-edge, or nullptr.
+   * @brief Get the index of the starting half-edge.
+   * @return Index of the half-edge in the owning mesh's edge array, or UINT32_MAX if unset.
    */
-  [[nodiscard]] inline EdgePtr
-  getHalfEdge() noexcept;
-
-  /**
-   * @brief Get the starting half-edge (const overload).
-   * @return Starting half-edge, or nullptr.
-   */
-  [[nodiscard]] inline EdgePtr
-  getHalfEdge() const noexcept;
+  [[nodiscard]] inline uint32_t
+  getHalfEdgeIndex() const noexcept;
 
   /**
    * @brief Get modifiable centroid
@@ -299,7 +282,8 @@ public:
 
   /**
    * @brief Compute the signed distance to a point.
-   * @param[in] a_x0 Point in space
+   * @param[in] a_x0   Point in space
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    * @details This algorithm operates by checking if the input point projects to
    * the inside of the polygon. If it does then the distance is just the
    * projected distance onto the polygon plane and the sign is well-defined.
@@ -307,11 +291,12 @@ public:
    * @return Signed distance to the face; sign determined by normal direction.
    */
   [[nodiscard]] inline T
-  signedDistance(const Vec3& a_x0) const noexcept;
+  signedDistance(const Vec3& a_x0, const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Compute the unsigned squared distance to a point.
-   * @param[in] a_x0 Point in space
+   * @param[in] a_x0   Point in space
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    * @details This algorithm operates by checking if the input point projects to
    * the inside of the polygon. If it does then the distance is just the
    * projected distance onto the polygon plane. Otherwise, we check the distance
@@ -319,53 +304,57 @@ public:
    * @return Squared unsigned distance to the face.
    */
   [[nodiscard]] inline T
-  unsignedDistance2(const Vec3& a_x0) const noexcept;
+  unsignedDistance2(const Vec3& a_x0, const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Return the coordinates of all the vertices on this polygon.
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    * @details This builds a list of all the vertex coordinates and returns it.
    * @return Vector of 3D coordinates of all vertices on this polygon.
    */
   [[nodiscard]] inline std::vector<Vec3T<T>>
-  getAllVertexCoordinates() const;
+  getAllVertexCoordinates(const Mesh& a_mesh) const;
 
   /**
-   * @brief Return all the vertices on this polygon
-   * @details This builds a list of all the vertices and returns it.
-   * @return Vector of shared pointers to all vertices on this polygon.
+   * @brief Return the indices of all the vertices on this polygon
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
+   * @details This builds a list of all the vertex indices and returns it.
+   * @return Vector of indices, into the owning mesh's vertex array, of all vertices on this polygon.
    */
-  [[nodiscard]] inline std::vector<VertexPtr>
-  gatherVertices() const;
+  [[nodiscard]] inline std::vector<uint32_t>
+  gatherVertexIndices(const Mesh& a_mesh) const;
 
   /**
-   * @brief Return all the half-edges on this polygon
-   * @details This builds a list of all the edges and returns it.
-   * @return Vector of shared pointers to all half-edges on this polygon.
+   * @brief Return the indices of all the half-edges on this polygon
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
+   * @details This builds a list of all the edge indices and returns it.
+   * @return Vector of indices, into the owning mesh's edge array, of all half-edges on this polygon.
    */
-  [[nodiscard]] inline std::vector<EdgePtr>
-  gatherEdges() const;
+  [[nodiscard]] inline std::vector<uint32_t>
+  gatherEdgeIndices(const Mesh& a_mesh) const;
 
   /**
    * @brief Get the lower-left-most coordinate of this polygon face
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    * @return Lower-left-most coordinate of this polygon face.
    */
   [[nodiscard]] inline Vec3T<T>
-  getSmallestCoordinate() const;
+  getSmallestCoordinate(const Mesh& a_mesh) const;
 
   /**
    * @brief Get the upper-right-most coordinate of this polygon face
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    * @return Upper-right-most coordinate of this polygon face.
    */
   [[nodiscard]] inline Vec3T<T>
-  getHighestCoordinate() const;
+  getHighestCoordinate(const Mesh& a_mesh) const;
 
 protected:
   /**
-   * @brief This polygon's half-edge. A valid face will always have this set.
-   * @details Stored as a weak_ptr because the mesh's edge list owns the edge, not this face; an
-   * owning shared_ptr here would form a reference cycle that could never be collected.
+   * @brief This polygon's half-edge index. A valid face will always have this set.
+   * @details Index into the owning DCEL::MeshT's edge array, or UINT32_MAX if unset.
    */
-  std::weak_ptr<Edge> m_halfEdge;
+  uint32_t m_halfEdge = UINT32_MAX;
 
   /**
    * @brief Polygon face normal vector
@@ -414,21 +403,24 @@ protected:
 
   /**
    * @brief Compute the centroid position of this polygon
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    */
   inline void
-  computeCentroid();
+  computeCentroid(const Mesh& a_mesh);
 
   /**
    * @brief Compute the normal position of this polygon
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    */
   inline void
-  computeNormal();
+  computeNormal(const Mesh& a_mesh);
 
   /**
    * @brief Compute the area of this polygon and cache it in m_area.
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    */
   inline void
-  computeArea();
+  computeArea(const Mesh& a_mesh);
 
   /**
    * @brief Normalize the normal vector, ensuring it has a length of 1
@@ -446,12 +438,13 @@ protected:
 
   /**
    * @brief Check if a point projects to inside or outside the polygon face
-   * @param[in] a_p Point in space
+   * @param[in] a_p    Point in space
+   * @param[in] a_mesh Owning mesh, used to resolve the half-edge loop.
    * @return Returns true if a_p projects to inside the polygon and false
    * otherwise.
    */
   [[nodiscard]] inline bool
-  isPointInsideFace(const Vec3& a_p) const noexcept;
+  isPointInsideFace(const Vec3& a_p, const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Project a 3D point to this face's 2D embedding by dropping one coordinate.
@@ -465,29 +458,38 @@ protected:
    * @brief Compute the winding number of this polygon's boundary around a projected 2D point.
    * @details Walks the face's half-edge loop, projecting each vertex on the fly.
    * @param[in] a_point Projected 2D query point.
+   * @param[in] a_mesh  Owning mesh, used to resolve the half-edge loop.
    * @return The winding number.
    */
   [[nodiscard]] inline int
-  computeWindingNumber(const Vec2T<T>& a_point) const noexcept;
+  computeWindingNumber(const Vec2T<T>& a_point, const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Compute the crossing number of a +x ray from a projected 2D point with this polygon.
    * @details Walks the face's half-edge loop, projecting each vertex on the fly.
    * @param[in] a_point Projected 2D query point.
+   * @param[in] a_mesh  Owning mesh, used to resolve the half-edge loop.
    * @return The crossing number.
    */
   [[nodiscard]] inline size_t
-  computeCrossingNumber(const Vec2T<T>& a_point) const noexcept;
+  computeCrossingNumber(const Vec2T<T>& a_point, const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Compute the total subtended angle of this polygon's edges around a projected 2D point.
    * @details Walks the face's half-edge loop, projecting each vertex on the fly.
    * @param[in] a_point Projected 2D query point.
+   * @param[in] a_mesh  Owning mesh, used to resolve the half-edge loop.
    * @return The subtended angle (+-2*pi for an interior point, 0 for an exterior one).
    */
   [[nodiscard]] inline T
-  computeSubtendedAngle(const Vec2T<T>& a_point) const noexcept;
+  computeSubtendedAngle(const Vec2T<T>& a_point, const Mesh& a_mesh) const noexcept;
 };
+
+static_assert(std::is_trivially_copyable_v<FaceT<float, DefaultMetaData>>,
+              "FaceT<float,DefaultMetaData> must be trivially copyable");
+static_assert(std::is_trivially_copyable_v<FaceT<double, DefaultMetaData>>,
+              "FaceT<double,DefaultMetaData> must be trivially copyable");
+
 } // namespace DCEL
 
 } // namespace EBGeometry

--- a/Source/EBGeometry_DCEL_FaceImplem.hpp
+++ b/Source/EBGeometry_DCEL_FaceImplem.hpp
@@ -17,8 +17,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
-#include <memory>
-#include <vector>
 
 // Our includes
 #include "EBGeometry_Constants.hpp"
@@ -30,63 +28,32 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline FaceT<T, Meta>::FaceT(const EdgePtr& a_edge)
+inline FaceT<T, Meta>::FaceT(const uint32_t a_edgeIndex)
 {
-  m_halfEdge = a_edge;
-}
-
-template <class T, class Meta>
-inline FaceT<T, Meta>::FaceT(const Face& a_otherFace)
-{
-  m_normal                 = a_otherFace.m_normal;
-  m_halfEdge               = a_otherFace.m_halfEdge;
-  m_centroid               = a_otherFace.m_centroid;
-  m_area                   = a_otherFace.m_area;
-  m_xDir                   = a_otherFace.m_xDir;
-  m_yDir                   = a_otherFace.m_yDir;
-  m_insideOutsideAlgorithm = a_otherFace.m_insideOutsideAlgorithm;
-  m_metaData               = a_otherFace.m_metaData;
-}
-
-template <class T, class Meta>
-inline FaceT<T, Meta>&
-FaceT<T, Meta>::operator=(const Face& a_otherFace) noexcept
-{
-  if (this != &a_otherFace) {
-    m_normal                 = a_otherFace.m_normal;
-    m_halfEdge               = a_otherFace.m_halfEdge;
-    m_centroid               = a_otherFace.m_centroid;
-    m_area                   = a_otherFace.m_area;
-    m_xDir                   = a_otherFace.m_xDir;
-    m_yDir                   = a_otherFace.m_yDir;
-    m_insideOutsideAlgorithm = a_otherFace.m_insideOutsideAlgorithm;
-    m_metaData               = a_otherFace.m_metaData;
-  }
-
-  return *this;
+  m_halfEdge = a_edgeIndex;
 }
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::define(const Vec3& a_normal, const EdgePtr& a_edge) noexcept
+FaceT<T, Meta>::define(const Vec3& a_normal, const uint32_t a_edgeIndex) noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[2]));
 
-  // a_edge == nullptr is valid here (e.g. a freshly-created face not yet wired into the mesh).
+  // a_edgeIndex == UINT32_MAX is valid here (e.g. a freshly-created face not yet wired into a mesh).
   m_normal   = a_normal;
-  m_halfEdge = a_edge;
+  m_halfEdge = a_edgeIndex;
 }
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::reconcile()
+FaceT<T, Meta>::reconcile(const Mesh& a_mesh)
 {
-  this->computeNormal();
+  this->computeNormal(a_mesh);
   this->normalizeNormalVector();
-  this->computeCentroid();
-  this->computeArea();
+  this->computeCentroid(a_mesh);
+  this->computeArea(a_mesh);
   this->computeProjectionDirections();
 }
 
@@ -99,9 +66,9 @@ FaceT<T, Meta>::flipNormal() noexcept
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::setHalfEdge(const EdgePtr& a_halfEdge) noexcept
+FaceT<T, Meta>::setHalfEdge(const uint32_t a_halfEdgeIndex) noexcept
 {
-  m_halfEdge = a_halfEdge;
+  m_halfEdge = a_halfEdgeIndex;
 }
 
 template <class T, class Meta>
@@ -129,28 +96,28 @@ FaceT<T, Meta>::setInsideOutsideAlgorithm(InsideOutsideAlgorithm a_algorithm) no
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::computeCentroid()
+FaceT<T, Meta>::computeCentroid(const Mesh& a_mesh)
 {
   m_centroid = Vec3::zeros();
 
-  const auto vertices = this->gatherVertices();
+  const auto vertexIndices = this->gatherVertexIndices(a_mesh);
 
-  EBGEOMETRY_EXPECT(!vertices.empty());
+  EBGEOMETRY_EXPECT(!vertexIndices.empty());
 
-  for (const auto& v : vertices) {
-    m_centroid += v->getPosition();
+  for (const uint32_t v : vertexIndices) {
+    m_centroid += a_mesh.getVertices()[v].getPosition();
   }
 
-  m_centroid = m_centroid / vertices.size();
+  m_centroid = m_centroid / vertexIndices.size();
 }
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::computeNormal()
+FaceT<T, Meta>::computeNormal(const Mesh& a_mesh)
 {
-  const auto vertices = this->gatherVertices();
+  const auto vertexIndices = this->gatherVertexIndices(a_mesh);
 
-  const size_t N = vertices.size();
+  const size_t N = vertexIndices.size();
 
   // A polygon face needs at least 3 vertices to span a plane.
   EBGEOMETRY_EXPECT(N >= 3);
@@ -158,9 +125,9 @@ FaceT<T, Meta>::computeNormal()
   // To compute the normal vector we find three vertices in this polygon face.
   // They span a plane, and we just compute the normal vector of that plane.
   for (size_t i = 0; i < N; i++) {
-    const auto& x0 = vertices[i]->getPosition();
-    const auto& x1 = vertices[(i + 1) % N]->getPosition();
-    const auto& x2 = vertices[(i + 2) % N]->getPosition();
+    const auto& x0 = a_mesh.getVertices()[vertexIndices[i]].getPosition();
+    const auto& x1 = a_mesh.getVertices()[vertexIndices[(i + 1) % N]].getPosition();
+    const auto& x2 = a_mesh.getVertices()[vertexIndices[(i + 2) % N]].getPosition();
 
     m_normal = (x2 - x0).cross(x2 - x1);
 
@@ -178,7 +145,7 @@ FaceT<T, Meta>::computeNormal()
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::computeProjectionDirections()
+FaceT<T, Meta>::computeProjectionDirections() noexcept
 {
   EBGEOMETRY_EXPECT(m_normal.length() > std::numeric_limits<T>::epsilon());
 
@@ -209,13 +176,13 @@ FaceT<T, Meta>::computeProjectionDirections()
 
 template <class T, class Meta>
 inline void
-FaceT<T, Meta>::computeArea()
+FaceT<T, Meta>::computeArea(const Mesh& a_mesh)
 {
   T area = 0.0;
 
   // This computes the area of any N-side polygon.
-  const auto   vertices = this->gatherVertices();
-  const size_t N        = vertices.size();
+  const auto   vertexIndices = this->gatherVertexIndices(a_mesh);
+  const size_t N             = vertexIndices.size();
 
   EBGEOMETRY_EXPECT(N >= 3);
 
@@ -224,8 +191,8 @@ FaceT<T, Meta>::computeArea()
   // the origin, and omitting the wraparound edge silently produces a wrong (generally too large or
   // too small) area for any polygon that doesn't happen to pass through the origin.
   for (size_t i = 0; i < N; i++) {
-    const auto& v1 = vertices[i]->getPosition();
-    const auto& v2 = vertices[(i + 1) % N]->getPosition();
+    const auto& v1 = a_mesh.getVertices()[vertexIndices[i]].getPosition();
+    const auto& v2 = a_mesh.getVertices()[vertexIndices[(i + 1) % N]].getPosition();
 
     area += m_normal.dot(v2.cross(v1));
   }
@@ -290,17 +257,10 @@ FaceT<T, Meta>::getNormal() const noexcept
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-FaceT<T, Meta>::getHalfEdge() noexcept
+inline uint32_t
+FaceT<T, Meta>::getHalfEdgeIndex() const noexcept
 {
-  return m_halfEdge.lock();
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-FaceT<T, Meta>::getHalfEdge() const noexcept
-{
-  return m_halfEdge.lock();
+  return m_halfEdge;
 }
 
 template <class T, class Meta>
@@ -318,47 +278,42 @@ FaceT<T, Meta>::getMetaData() const noexcept
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<VertexT<T, Meta>>>
-FaceT<T, Meta>::gatherVertices() const
+inline std::vector<uint32_t>
+FaceT<T, Meta>::gatherVertexIndices(const Mesh& a_mesh) const
 {
-  std::vector<VertexPtr> vertices;
-  vertices.reserve(3);
+  std::vector<uint32_t> vertexIndices;
+  vertexIndices.reserve(3);
 
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-    vertices.emplace_back(edge->getVertex());
+  for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+    vertexIndices.emplace_back(a_mesh.getEdges()[iter()].getVertexIndex());
   }
 
-  return vertices;
+  return vertexIndices;
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<EdgeT<T, Meta>>>
-FaceT<T, Meta>::gatherEdges() const
+inline std::vector<uint32_t>
+FaceT<T, Meta>::gatherEdgeIndices(const Mesh& a_mesh) const
 {
-  std::vector<EdgePtr> edges;
-  edges.reserve(3);
+  std::vector<uint32_t> edgeIndices;
+  edgeIndices.reserve(3);
 
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-
-    edges.emplace_back(edge);
+  for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+    edgeIndices.emplace_back(iter());
   }
 
-  return edges;
+  return edgeIndices;
 }
 
 template <class T, class Meta>
 inline std::vector<Vec3T<T>>
-FaceT<T, Meta>::getAllVertexCoordinates() const
+FaceT<T, Meta>::getAllVertexCoordinates(const Mesh& a_mesh) const
 {
   std::vector<Vec3> ret;
   ret.reserve(3);
 
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-
-    ret.emplace_back(edge->getVertex()->getPosition());
+  for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+    ret.emplace_back(a_mesh.getEdges()[iter()].getVertex(a_mesh).getPosition());
   }
 
   return ret;
@@ -366,9 +321,9 @@ FaceT<T, Meta>::getAllVertexCoordinates() const
 
 template <class T, class Meta>
 inline Vec3T<T>
-FaceT<T, Meta>::getSmallestCoordinate() const
+FaceT<T, Meta>::getSmallestCoordinate(const Mesh& a_mesh) const
 {
-  const auto coords = this->getAllVertexCoordinates();
+  const auto coords = this->getAllVertexCoordinates(a_mesh);
 
   EBGEOMETRY_EXPECT(!coords.empty());
 
@@ -383,9 +338,9 @@ FaceT<T, Meta>::getSmallestCoordinate() const
 
 template <class T, class Meta>
 inline Vec3T<T>
-FaceT<T, Meta>::getHighestCoordinate() const
+FaceT<T, Meta>::getHighestCoordinate(const Mesh& a_mesh) const
 {
-  const auto coords = this->getAllVertexCoordinates();
+  const auto coords = this->getAllVertexCoordinates(a_mesh);
 
   EBGEOMETRY_EXPECT(!coords.empty());
 
@@ -421,7 +376,7 @@ FaceT<T, Meta>::projectPoint(const Vec3& a_point) const noexcept
 
 template <class T, class Meta>
 inline int
-FaceT<T, Meta>::computeWindingNumber(const Vec2T<T>& a_point) const noexcept
+FaceT<T, Meta>::computeWindingNumber(const Vec2T<T>& a_point, const Mesh& a_mesh) const noexcept
 {
   int wn = 0;
 
@@ -429,10 +384,10 @@ FaceT<T, Meta>::computeWindingNumber(const Vec2T<T>& a_point) const noexcept
     return (P1.x - P0.x) * (P2.y - P0.y) - (P2.x - P0.x) * (P1.y - P0.y);
   };
 
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-    const Vec2T<T> P1   = this->projectPoint(edge->getVertex()->getPosition());
-    const Vec2T<T> P2   = this->projectPoint(edge->getNextEdge()->getVertex()->getPosition());
+  for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+    const Edge&    edge = a_mesh.getEdges()[iter()];
+    const Vec2T<T> P1   = this->projectPoint(edge.getVertex(a_mesh).getPosition());
+    const Vec2T<T> P2   = this->projectPoint(edge.getNextEdge(a_mesh).getVertex(a_mesh).getPosition());
     const T        res  = isLeft(P1, P2, a_point);
 
     if (P1.y <= a_point.y) {
@@ -456,14 +411,14 @@ FaceT<T, Meta>::computeWindingNumber(const Vec2T<T>& a_point) const noexcept
 
 template <class T, class Meta>
 inline size_t
-FaceT<T, Meta>::computeCrossingNumber(const Vec2T<T>& a_point) const noexcept
+FaceT<T, Meta>::computeCrossingNumber(const Vec2T<T>& a_point, const Mesh& a_mesh) const noexcept
 {
   size_t cn = 0;
 
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-    const Vec2T<T> P1   = this->projectPoint(edge->getVertex()->getPosition());
-    const Vec2T<T> P2   = this->projectPoint(edge->getNextEdge()->getVertex()->getPosition());
+  for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+    const Edge&    edge = a_mesh.getEdges()[iter()];
+    const Vec2T<T> P1   = this->projectPoint(edge.getVertex(a_mesh).getPosition());
+    const Vec2T<T> P2   = this->projectPoint(edge.getNextEdge(a_mesh).getVertex(a_mesh).getPosition());
 
     // clang-format off
     const bool upwardCrossing   = (P1.y <= a_point.y) && (P2.y >  a_point.y);
@@ -487,16 +442,16 @@ FaceT<T, Meta>::computeCrossingNumber(const Vec2T<T>& a_point) const noexcept
 
 template <class T, class Meta>
 inline T
-FaceT<T, Meta>::computeSubtendedAngle(const Vec2T<T>& a_point) const noexcept
+FaceT<T, Meta>::computeSubtendedAngle(const Vec2T<T>& a_point, const Mesh& a_mesh) const noexcept
 {
   constexpr T pi = EBGeometry::pi<T>;
 
   T sumTheta = T(0);
 
-  for (EdgeIterator iter(*this); iter.ok(); ++iter) {
-    const EdgePtr& edge = iter();
-    const Vec2T<T> p1   = this->projectPoint(edge->getVertex()->getPosition()) - a_point;
-    const Vec2T<T> p2   = this->projectPoint(edge->getNextEdge()->getVertex()->getPosition()) - a_point;
+  for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+    const Edge&    edge = a_mesh.getEdges()[iter()];
+    const Vec2T<T> p1   = this->projectPoint(edge.getVertex(a_mesh).getPosition()) - a_point;
+    const Vec2T<T> p2   = this->projectPoint(edge.getNextEdge(a_mesh).getVertex(a_mesh).getPosition()) - a_point;
 
     const T theta1 = std::atan2(p1.y, p1.x);
     const T theta2 = std::atan2(p2.y, p2.x);
@@ -519,7 +474,7 @@ FaceT<T, Meta>::computeSubtendedAngle(const Vec2T<T>& a_point) const noexcept
 
 template <class T, class Meta>
 inline bool
-FaceT<T, Meta>::isPointInsideFace(const Vec3& a_p) const noexcept
+FaceT<T, Meta>::isPointInsideFace(const Vec3& a_p, const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(m_xDir < 3);
   EBGEOMETRY_EXPECT(m_yDir < 3);
@@ -529,15 +484,15 @@ FaceT<T, Meta>::isPointInsideFace(const Vec3& a_p) const noexcept
 
   switch (m_insideOutsideAlgorithm) {
   case InsideOutsideAlgorithm::WindingNumber: {
-    return this->computeWindingNumber(p2D) != 0;
+    return this->computeWindingNumber(p2D, a_mesh) != 0;
   }
   case InsideOutsideAlgorithm::CrossingNumber: {
-    return (this->computeCrossingNumber(p2D) % 2) == 1;
+    return (this->computeCrossingNumber(p2D, a_mesh) % 2) == 1;
   }
   case InsideOutsideAlgorithm::SubtendedAngle: {
     constexpr T pi = EBGeometry::pi<T>;
 
-    const T sumTheta = std::abs(this->computeSubtendedAngle(p2D)) / (T(2) * pi);
+    const T sumTheta = std::abs(this->computeSubtendedAngle(p2D, a_mesh)) / (T(2) * pi);
 
     return std::abs(sumTheta - T(1)) < T(0.5);
   }
@@ -548,34 +503,27 @@ FaceT<T, Meta>::isPointInsideFace(const Vec3& a_p) const noexcept
 
 template <class T, class Meta>
 inline T
-FaceT<T, Meta>::signedDistance(const Vec3& a_x0) const noexcept
+FaceT<T, Meta>::signedDistance(const Vec3& a_x0, const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_halfEdge.expired());
+  EBGEOMETRY_EXPECT(m_halfEdge != UINT32_MAX);
 
   T retval = std::numeric_limits<T>::infinity();
 
-  const bool inside = this->isPointInsideFace(a_x0);
+  const bool inside = this->isPointInsideFace(a_x0, a_mesh);
 
   if (inside) {
     retval = m_normal.dot(a_x0 - m_centroid);
   }
   else {
-    const EdgePtr startEdge = m_halfEdge.lock();
-    EdgePtr       cur       = startEdge;
+    for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+      const Edge& cur = a_mesh.getEdges()[iter()];
 
-    while (true) {
-      const T curDist = cur->signedDistance(a_x0);
+      const T curDist = cur.signedDistance(a_x0, a_mesh);
 
       retval = (std::abs(curDist) < std::abs(retval)) ? curDist : retval;
-
-      cur = cur->getNextEdge();
-
-      if (cur == nullptr || cur == startEdge) {
-        break;
-      }
     }
   }
 
@@ -584,16 +532,16 @@ FaceT<T, Meta>::signedDistance(const Vec3& a_x0) const noexcept
 
 template <class T, class Meta>
 inline T
-FaceT<T, Meta>::unsignedDistance2(const Vec3& a_x0) const noexcept
+FaceT<T, Meta>::unsignedDistance2(const Vec3& a_x0, const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_x0[2]));
-  EBGEOMETRY_EXPECT(!m_halfEdge.expired());
+  EBGEOMETRY_EXPECT(m_halfEdge != UINT32_MAX);
 
   T retval = std::numeric_limits<T>::infinity();
 
-  const bool inside = this->isPointInsideFace(a_x0);
+  const bool inside = this->isPointInsideFace(a_x0, a_mesh);
 
   if (inside) {
     const T normDist = m_normal.dot(a_x0 - m_centroid);
@@ -601,19 +549,12 @@ FaceT<T, Meta>::unsignedDistance2(const Vec3& a_x0) const noexcept
     retval = normDist * normDist;
   }
   else {
-    const EdgePtr startEdge = m_halfEdge.lock();
-    EdgePtr       cur       = startEdge;
+    for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
+      const Edge& cur = a_mesh.getEdges()[iter()];
 
-    while (true) {
-      const T curDist2 = cur->unsignedDistance2(a_x0);
+      const T curDist2 = cur.unsignedDistance2(a_x0, a_mesh);
 
       retval = (curDist2 < retval) ? curDist2 : retval;
-
-      cur = cur->getNextEdge();
-
-      if (cur == nullptr || cur == startEdge) {
-        break;
-      }
     }
   }
 

--- a/Source/EBGeometry_DCEL_Iterator.hpp
+++ b/Source/EBGeometry_DCEL_Iterator.hpp
@@ -12,7 +12,7 @@
 #define EBGEOMETRY_DCEL_ITERATOR_HPP
 
 // Std includes
-#include <memory>
+#include <cstdint>
 #include <type_traits>
 
 // Our includes
@@ -25,13 +25,15 @@ namespace DCEL {
 /**
  * @brief Class which makes it easier to iterate through DCEL edges
  * @details Iterates the half-edge loop bounding a polygon face (or starting from an arbitrary
- * half-edge), following EdgeT::getNextEdge() until either the loop returns to its starting edge
- * (a well-formed, closed face) or a null next-edge is reached (an incomplete/open half-edge chain).
- * Typical usage:
+ * half-edge index), following EdgeT::getNextEdgeIndex() until either the loop returns to its
+ * starting edge (a well-formed, closed face) or an unset next-edge index is reached (an
+ * incomplete/open half-edge chain). Resolves indices against the mesh passed at construction, so
+ * the iterator itself is a lightweight, short-lived (stack-only) helper -- it is not stored inside
+ * any DCEL object and does not need to be trivially copyable or portable. Typical usage:
  * @code{.cpp}
- * for (EdgeIterator it(someFace); it.ok(); ++it) {
- *   const EdgePtr& edge = it();
- *   // ... use edge ...
+ * for (EdgeIterator it(mesh, someFace); it.ok(); ++it) {
+ *   const uint32_t edgeIndex = it();
+ *   // ... use mesh.getEdges()[edgeIndex] ...
  * }
  * @endcode
  * @tparam T    Floating-point precision type.
@@ -59,19 +61,9 @@ public:
   using Face = FaceT<T, Meta>;
 
   /**
-   * @brief Alias for vertex pointer
+   * @brief Alias for DCEL mesh type
    */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer
-   */
-  using FacePtr = std::shared_ptr<Face>;
+  using Mesh = MeshT<T, Meta>;
 
   /**
    * @brief Default construction is not allowed. Use one of the full constructors
@@ -79,31 +71,23 @@ public:
   EdgeIteratorT() = delete;
 
   /**
-   * @brief Constructor, taking a face as argument. The iterator begins at the
-   * half-edge pointer contained in the face
+   * @brief Constructor, taking a mesh and a face as argument. The iterator begins at the
+   * half-edge index contained in the face.
+   * @param[in] a_mesh Owning mesh, used to resolve edge indices.
    * @param[in] a_face DCEL polygon face
-   * @note This constructor will will iterate through the half-edges in the
-   * polygon face.
+   * @note This constructor will iterate through the half-edges in the polygon face.
    */
-  EdgeIteratorT(Face& a_face) noexcept;
+  EdgeIteratorT(const Mesh& a_mesh, const Face& a_face) noexcept;
 
   /**
-   * @brief Constructor, taking a face as argument. The iterator begins at the
-   * half-edge pointer contained in the face
-   * @param[in] a_face DCEL polygon face
-   * @note This constructor will will iterate through the half-edges in the
-   * polygon face.
+   * @brief Constructor, taking a mesh and an arbitrary starting half-edge index directly (rather
+   * than a face's own half-edge). Useful for iterating a half-edge loop when only an edge index --
+   * not its face -- is available.
+   * @param[in] a_mesh          Owning mesh, used to resolve edge indices.
+   * @param[in] a_startEdgeIndex Starting half-edge index. May be UINT32_MAX (ok() will then
+   * immediately return false).
    */
-  EdgeIteratorT(const Face& a_face) noexcept;
-
-  /**
-   * @brief Constructor, taking an arbitrary starting half-edge directly (rather than a face's own
-   * half-edge). Useful for iterating a half-edge loop when only an edge -- not its face -- is
-   * available.
-   * @param[in] a_startEdge Starting half-edge. May be nullptr (ok() will then immediately return
-   * false).
-   */
-  EdgeIteratorT(const EdgePtr& a_startEdge) noexcept;
+  EdgeIteratorT(const Mesh& a_mesh, const uint32_t a_startEdgeIndex) noexcept;
 
   /**
    * @brief Copy constructor.
@@ -139,17 +123,10 @@ public:
   operator=(EdgeIteratorT&& a_other) noexcept = default;
 
   /**
-   * @brief Operator returning a pointer to the current half-edge
-   * @return Reference to the shared pointer to the current half-edge.
+   * @brief Operator returning the index of the current half-edge
+   * @return Index of the current half-edge in the owning mesh's edge array.
    */
-  [[nodiscard]] inline EdgePtr&
-  operator()() noexcept;
-
-  /**
-   * @brief Operator returning a pointer to the current half-edge (const overload)
-   * @return Const reference to the shared pointer to the current half-edge.
-   */
-  [[nodiscard]] inline const EdgePtr&
+  [[nodiscard]] inline uint32_t
   operator()() const noexcept;
 
   /**
@@ -167,26 +144,31 @@ public:
 
   /**
    * @brief Function which checks if the iteration can be continued.
-   * @return True if the iterator has not completed a full loop and the current edge is not null.
+   * @return True if the iterator has not completed a full loop and the current edge index is set.
    */
   [[nodiscard]] inline bool
   ok() const noexcept;
 
 protected:
   /**
+   * @brief Owning mesh, used to resolve edge indices. Non-owning; must outlive the iterator.
+   */
+  const Mesh* m_mesh = nullptr;
+
+  /**
    * @brief If true, a full loop has been made around the polygon face
    */
   bool m_fullLoop = false;
 
   /**
-   * @brief Starting half-edge
+   * @brief Starting half-edge index, or UINT32_MAX if unset.
    */
-  std::shared_ptr<Edge> m_startEdge = nullptr;
+  uint32_t m_startEdge = UINT32_MAX;
 
   /**
-   * @brief Current half-edge
+   * @brief Current half-edge index, or UINT32_MAX if unset.
    */
-  std::shared_ptr<Edge> m_curEdge = nullptr;
+  uint32_t m_curEdge = UINT32_MAX;
 };
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_IteratorImplem.hpp
+++ b/Source/EBGeometry_DCEL_IteratorImplem.hpp
@@ -11,9 +11,6 @@
 #ifndef EBGEOMETRY_DCEL_ITERATORIMPLEM_HPP
 #define EBGEOMETRY_DCEL_ITERATORIMPLEM_HPP
 
-// Std includes
-#include <memory>
-
 // Our includes
 #include "EBGeometry_DCEL_Edge.hpp"
 #include "EBGeometry_DCEL_Face.hpp"
@@ -26,35 +23,23 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline EdgeIteratorT<T, Meta>::EdgeIteratorT(Face& a_face) noexcept
+inline EdgeIteratorT<T, Meta>::EdgeIteratorT(const Mesh& a_mesh, const Face& a_face) noexcept
 {
-  m_startEdge = a_face.getHalfEdge();
+  m_mesh      = &a_mesh;
+  m_startEdge = a_face.getHalfEdgeIndex();
   m_curEdge   = m_startEdge;
 }
 
 template <class T, class Meta>
-inline EdgeIteratorT<T, Meta>::EdgeIteratorT(const Face& a_face) noexcept
+inline EdgeIteratorT<T, Meta>::EdgeIteratorT(const Mesh& a_mesh, const uint32_t a_startEdgeIndex) noexcept
 {
-  m_startEdge = a_face.getHalfEdge();
+  m_mesh      = &a_mesh;
+  m_startEdge = a_startEdgeIndex;
   m_curEdge   = m_startEdge;
 }
 
 template <class T, class Meta>
-inline EdgeIteratorT<T, Meta>::EdgeIteratorT(const EdgePtr& a_startEdge) noexcept
-{
-  m_startEdge = a_startEdge;
-  m_curEdge   = m_startEdge;
-}
-
-template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>&
-EdgeIteratorT<T, Meta>::operator()() noexcept
-{
-  return m_curEdge;
-}
-
-template <class T, class Meta>
-inline const std::shared_ptr<EdgeT<T, Meta>>&
+inline uint32_t
 EdgeIteratorT<T, Meta>::operator()() const noexcept
 {
   return m_curEdge;
@@ -72,9 +57,10 @@ template <class T, class Meta>
 inline void
 EdgeIteratorT<T, Meta>::operator++() noexcept
 {
-  EBGEOMETRY_EXPECT(m_curEdge != nullptr);
+  EBGEOMETRY_EXPECT(m_curEdge != UINT32_MAX);
+  EBGEOMETRY_EXPECT(m_mesh != nullptr);
 
-  m_curEdge  = m_curEdge->getNextEdge();
+  m_curEdge  = m_mesh->getEdges()[m_curEdge].getNextEdgeIndex();
   m_fullLoop = (m_curEdge == m_startEdge);
 }
 
@@ -82,7 +68,7 @@ template <class T, class Meta>
 inline bool
 EdgeIteratorT<T, Meta>::ok() const noexcept
 {
-  return !m_fullLoop && m_curEdge;
+  return !m_fullLoop && m_curEdge != UINT32_MAX;
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_Mesh.hpp
+++ b/Source/EBGeometry_DCEL_Mesh.hpp
@@ -22,6 +22,9 @@
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
+#include "EBGeometry_DCEL_Edge.hpp"
+#include "EBGeometry_DCEL_Face.hpp"
+#include "EBGeometry_DCEL_Vertex.hpp"
 
 namespace EBGeometry {
 
@@ -32,11 +35,14 @@ namespace DCEL {
  * functions)
  * @details This encapsulates a full DCEL mesh, and also includes DIRECT signed
  * distance functions. The mesh consists of a set of vertices, half-edges, and
- * polygon faces who each have references to other vertices, half-edges, and
- * polygon faces. The signed distance functions DIRECT, which means that they go
- * through ALL of the polygon faces and compute the signed distance to them. This
- * is extremely inefficient, which is why this class is almost always embedded
- * into a bounding volume hierarchy.
+ * polygon faces, stored by value in this class's own arrays; every
+ * cross-reference between them (vertex-to-outgoing-edge, edge-to-vertex/pair
+ * edge/next edge/face, face-to-half-edge) is an index into these arrays rather
+ * than a pointer -- see the class-level notes on VertexT/EdgeT/FaceT. The
+ * signed distance functions DIRECT, which means that they go through ALL of the
+ * polygon faces and compute the signed distance to them. This is extremely
+ * inefficient, which is why this class is almost always embedded into a
+ * bounding volume hierarchy.
  * @note This class is not for the light of heart -- it will almost always be
  * instantiated through a file parser which reads vertices and edges from file
  * and builds the mesh from that. Do not try to build a MeshT object yourself,
@@ -88,21 +94,6 @@ public:
   using Mesh = MeshT<T, Meta>;
 
   /**
-   * @brief Alias for vertex pointer type
-   */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
-
-  /**
    * @brief Default constructor.
    * @details Leaves the mesh empty (no vertices, edges, or faces) with the default search
    * algorithm; use define() or the mutable getVertices()/getEdges()/getFaces() to populate it.
@@ -111,11 +102,9 @@ public:
 
   /**
    * @brief Disallowed copy construction.
-   * @details Copying is deliberately disallowed: a shallow copy of m_vertices/m_edges/m_faces would
-   * share the same underlying vertex/edge/face objects as the original (they reference each other
-   * internally), so it would not behave like an independent mesh -- mutating the "copy" would also
-   * mutate the original. Use a file parser to build an independent mesh instead. Moving is allowed
-   * (see the move constructor), since that transfers ownership rather than aliasing it.
+   * @details Copying is deliberately disallowed to keep a single supported way to duplicate a mesh
+   * (deepCopy()) rather than two subtly-different ones. Moving is allowed (see the move
+   * constructor), since that transfers ownership rather than duplicating it.
    * @param[in] a_otherMesh Other mesh.
    */
   MeshT(const Mesh& a_otherMesh) = delete;
@@ -130,8 +119,8 @@ public:
    * @brief Full constructor. This provides the faces, edges, and vertices to the
    * mesh.
    * @details Copies the three vectors directly into m_faces/m_edges/m_vertices. This only
-   * associates pointer structures through the mesh; internal parameters like face area and normal
-   * are computed by reconcile().
+   * associates the index-based topology already recorded on the faces/edges/vertices; internal
+   * parameters like face area and normal are computed by reconcile().
    * @param[in] a_faces    Polygon faces
    * @param[in] a_edges    Half-edges
    * @param[in] a_vertices Vertices
@@ -139,7 +128,7 @@ public:
    * description. This is usually done through a file parser which reads a mesh
    * file format and creates the DCEL mesh structure
    */
-  MeshT(std::vector<FacePtr>& a_faces, std::vector<EdgePtr>& a_edges, std::vector<VertexPtr>& a_vertices) noexcept;
+  MeshT(std::vector<Face>& a_faces, std::vector<Edge>& a_edges, std::vector<Vertex>& a_vertices) noexcept;
 
   /**
    * @brief Destructor (does nothing)
@@ -166,13 +155,13 @@ public:
   /**
    * @brief Create an independent, fully-decoupled copy of this mesh.
    * @details Since copy construction/assignment are disallowed (see their documentation), this is
-   * the supported way to duplicate a mesh. Unlike a shallow copy, this creates brand new
-   * VertexT/EdgeT/FaceT objects and relinks all of their internal pointers (outgoing edge, pair
-   * edge, next edge, half edge, adjacent faces) so that the copy shares no vertex, edge, or face
-   * with the original -- mutating one mesh does not affect the other. Every field is preserved
-   * exactly (position, normal vector, centroid, area, meta-data, search algorithm) rather than
-   * recomputed, so a mesh that has had flipNormal()/flip() called on it and not yet been
-   * re-reconciled will be copied faithfully rather than silently "un-flipped".
+   * the supported way to duplicate a mesh. Because every VertexT/EdgeT/FaceT cross-reference is an
+   * index into this mesh's own arrays rather than a pointer, a plain copy of the three arrays is
+   * already a fully independent, correctly-linked mesh -- every index remains meaningful against
+   * the copied arrays with no relinking pass required. Every field is preserved exactly (position,
+   * normal vector, centroid, area, meta-data, search algorithm) rather than recomputed, so a mesh
+   * that has had flipNormal()/flip() called on it and not yet been re-reconciled is copied
+   * faithfully rather than silently "un-flipped".
    * @return A new mesh, independent of this one.
    */
   [[nodiscard]] inline std::shared_ptr<Mesh>
@@ -181,7 +170,7 @@ public:
   /**
    * @brief Perform a sanity check.
    * @details This will provide error messages if vertices are badly linked,
-   * faces are nullptr, and so on. These messages are logged by calling
+   * faces have no half-edge, and so on. These messages are logged by calling
    * incrementWarning() which identifies types of errors that can occur, and how
    * many of those errors have occurred.
    * @param[in] a_id Identifier when printing error messages (can be empty string).
@@ -230,14 +219,14 @@ public:
    * @brief Get modifiable vertices in this mesh
    * @return Reference to the vector of vertices.
    */
-  [[nodiscard]] inline std::vector<VertexPtr>&
+  [[nodiscard]] inline std::vector<Vertex>&
   getVertices() noexcept;
 
   /**
    * @brief Get immutable vertices in this mesh
    * @return Const reference to the vector of vertices.
    */
-  [[nodiscard]] inline const std::vector<VertexPtr>&
+  [[nodiscard]] inline const std::vector<Vertex>&
   getVertices() const noexcept;
 
   /**
@@ -251,28 +240,28 @@ public:
    * @brief Get modifiable half-edges in this mesh
    * @return Reference to the vector of half-edges.
    */
-  [[nodiscard]] inline std::vector<EdgePtr>&
+  [[nodiscard]] inline std::vector<Edge>&
   getEdges() noexcept;
 
   /**
    * @brief Get immutable half-edges in this mesh
    * @return Const reference to the vector of half-edges.
    */
-  [[nodiscard]] inline const std::vector<EdgePtr>&
+  [[nodiscard]] inline const std::vector<Edge>&
   getEdges() const noexcept;
 
   /**
    * @brief Get modifiable faces in this mesh
    * @return Reference to the vector of polygon faces.
    */
-  [[nodiscard]] inline std::vector<FacePtr>&
+  [[nodiscard]] inline std::vector<Face>&
   getFaces() noexcept;
 
   /**
    * @brief Get immutable faces in this mesh
    * @return Const reference to the vector of polygon faces.
    */
-  [[nodiscard]] inline const std::vector<FacePtr>&
+  [[nodiscard]] inline const std::vector<Face>&
   getFaces() const noexcept;
 
   /**
@@ -324,17 +313,17 @@ protected:
   /**
    * @brief Mesh vertices
    */
-  std::vector<VertexPtr> m_vertices;
+  std::vector<Vertex> m_vertices;
 
   /**
    * @brief Mesh half-edges
    */
-  std::vector<EdgePtr> m_edges;
+  std::vector<Edge> m_edges;
 
   /**
    * @brief Mesh faces
    */
-  std::vector<FacePtr> m_faces;
+  std::vector<Face> m_faces;
 
   /**
    * @brief Function which computes internal things for the polygon faces.

--- a/Source/EBGeometry_DCEL_MeshImplem.hpp
+++ b/Source/EBGeometry_DCEL_MeshImplem.hpp
@@ -15,12 +15,11 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <limits>
 #include <map>
-#include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 // Our includes
@@ -36,9 +35,9 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline MeshT<T, Meta>::MeshT(std::vector<FacePtr>&   a_faces,
-                             std::vector<EdgePtr>&   a_edges,
-                             std::vector<VertexPtr>& a_vertices) noexcept
+inline MeshT<T, Meta>::MeshT(std::vector<Face>&   a_faces,
+                             std::vector<Edge>&   a_edges,
+                             std::vector<Vertex>& a_vertices) noexcept
   : MeshT()
 {
   m_faces    = a_faces;
@@ -52,118 +51,15 @@ MeshT<T, Meta>::deepCopy() const
 {
   EBGEOMETRY_EXPECT(m_vertices.size() > 0 || m_edges.size() > 0 || m_faces.size() > 0);
 
-  // Pass 0: allocate a fresh, default-constructed object for every existing vertex/edge/face, and
-  // record the old->new correspondence. This must happen before any relinking below, since a
-  // vertex/edge/face's pointers can reference any other vertex/edge/face in the mesh.
-  std::vector<VertexPtr> newVertices(m_vertices.size());
-  std::vector<EdgePtr>   newEdges(m_edges.size());
-  std::vector<FacePtr>   newFaces(m_faces.size());
-
-  std::unordered_map<VertexPtr, VertexPtr> vertexMap;
-  std::unordered_map<EdgePtr, EdgePtr>     edgeMap;
-  std::unordered_map<FacePtr, FacePtr>     faceMap;
-
-  for (size_t i = 0; i < m_vertices.size(); i++) {
-    EBGEOMETRY_EXPECT(m_vertices[i] != nullptr);
-
-    newVertices[i]           = std::make_shared<Vertex>();
-    vertexMap[m_vertices[i]] = newVertices[i];
-  }
-  for (size_t i = 0; i < m_edges.size(); i++) {
-    EBGEOMETRY_EXPECT(m_edges[i] != nullptr);
-
-    newEdges[i]         = std::make_shared<Edge>();
-    edgeMap[m_edges[i]] = newEdges[i];
-  }
-  for (size_t i = 0; i < m_faces.size(); i++) {
-    EBGEOMETRY_EXPECT(m_faces[i] != nullptr);
-
-    newFaces[i]         = std::make_shared<Face>();
-    faceMap[m_faces[i]] = newFaces[i];
-  }
-
-  // Remap a possibly-null old pointer to its corresponding new one. A non-null pointer that is not
-  // in the map means it refers to a vertex/edge/face outside of this mesh's own vectors, which is a
-  // corrupted/inconsistent mesh (the same condition sanityCheck() is meant to catch beforehand).
-  auto remapVertex = [&](const VertexPtr& a_v) -> VertexPtr {
-    if (a_v == nullptr) {
-      return nullptr;
-    }
-    const auto it = vertexMap.find(a_v);
-    EBGEOMETRY_EXPECT(it != vertexMap.end());
-
-    return it->second;
-  };
-  auto remapEdge = [&](const EdgePtr& a_e) -> EdgePtr {
-    if (a_e == nullptr) {
-      return nullptr;
-    }
-    const auto it = edgeMap.find(a_e);
-    EBGEOMETRY_EXPECT(it != edgeMap.end());
-
-    return it->second;
-  };
-  auto remapFace = [&](const FacePtr& a_f) -> FacePtr {
-    if (a_f == nullptr) {
-      return nullptr;
-    }
-    const auto it = faceMap.find(a_f);
-    EBGEOMETRY_EXPECT(it != faceMap.end());
-
-    return it->second;
-  };
-
-  // Pass 1: vertices. Copy value data (position, normal, meta-data) exactly, and relink the
-  // outgoing edge and face list to the new objects.
-  for (size_t i = 0; i < m_vertices.size(); i++) {
-    const VertexPtr& oldV = m_vertices[i];
-    const VertexPtr& newV = newVertices[i];
-
-    newV->setPosition(oldV->getPosition());
-    newV->setNormal(oldV->getNormal());
-    newV->setMetaData(oldV->getMetaData());
-    newV->setEdge(remapEdge(oldV->getOutgoingEdge()));
-
-    for (const auto& f : oldV->getFaces()) {
-      newV->addFace(remapFace(f));
-    }
-  }
-
-  // Pass 2: edges. Copy the normal vector and meta-data exactly, and relink the vertex, pair edge,
-  // next edge, and face to the new objects.
-  for (size_t i = 0; i < m_edges.size(); i++) {
-    const EdgePtr& oldE = m_edges[i];
-    const EdgePtr& newE = newEdges[i];
-
-    newE->setVertex(remapVertex(oldE->getVertex()));
-    newE->setPairEdge(remapEdge(oldE->getPairEdge()));
-    newE->setNextEdge(remapEdge(oldE->getNextEdge()));
-    newE->setFace(remapFace(oldE->getFace()));
-    newE->getNormal() = oldE->getNormal();
-    newE->setMetaData(oldE->getMetaData());
-  }
-
-  // Pass 3: faces. Copy the normal vector, centroid, area, and meta-data exactly, relink the half
-  // edge to the new object, and rebuild the 2D embedding from the (already-relinked) topology and
-  // the (already-restored) normal vector. This deliberately does NOT call reconcile(), which would
-  // recompute the normal vector from vertex winding and silently discard a prior flipNormal().
-  for (size_t i = 0; i < m_faces.size(); i++) {
-    const FacePtr& oldF = m_faces[i];
-    const FacePtr& newF = newFaces[i];
-
-    newF->setHalfEdge(remapEdge(oldF->getHalfEdge()));
-    newF->getNormal()   = oldF->getNormal();
-    newF->getCentroid() = oldF->getCentroid();
-    newF->getArea()     = oldF->getArea();
-    newF->setMetaData(oldF->getMetaData());
-    newF->computeProjectionDirections();
-  }
-
+  // Every VertexT/EdgeT/FaceT cross-reference is an index into these three arrays, not a pointer,
+  // so a plain copy of the arrays is already an independent, correctly-linked mesh -- no relinking
+  // pass is needed (contrast the old shared_ptr/weak_ptr scheme, which required allocating fresh
+  // objects and remapping every pointer).
   auto newMesh = std::make_shared<Mesh>();
 
-  newMesh->getVertices() = std::move(newVertices);
-  newMesh->getEdges()    = std::move(newEdges);
-  newMesh->getFaces()    = std::move(newFaces);
+  newMesh->getVertices() = m_vertices;
+  newMesh->getEdges()    = m_edges;
+  newMesh->getFaces()    = m_faces;
   newMesh->setSearchAlgorithm(m_algorithm);
 
   return newMesh;
@@ -199,44 +95,33 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::sanityCheck(const std::string a_id) const
 {
-  const std::string f_null       = "nullptr face";
   const std::string f_noEdge     = "face with no edge";
   const std::string f_degenerate = "degenerate face";
 
-  const std::string e_null       = "nullptr edges";
   const std::string e_degenerate = "degenerate edge";
   const std::string e_noPairEdge = "no pair edge (not watertight)";
   const std::string e_noNextEdge = "no next edge (badly linked dcel)";
   const std::string e_noOrigVert = "no origin vertex found for half edge (badly linked dcel)";
   const std::string e_noFace     = "no face found for half edge (badly linked dcel)";
 
-  const std::string v_null   = "nullptr vertex";
   const std::string v_noEdge = "no referenced edge for vertex (unreferenced vertex)";
 
-  std::map<std::string, size_t> warnings = {{f_null, 0},
-                                            {f_noEdge, 0},
+  std::map<std::string, size_t> warnings = {{f_noEdge, 0},
                                             {f_degenerate, 0},
-                                            {e_null, 0},
                                             {e_degenerate, 0},
                                             {e_noPairEdge, 0},
                                             {e_noNextEdge, 0},
                                             {e_noOrigVert, 0},
                                             {e_noFace, 0},
-                                            {v_null, 0},
                                             {v_noEdge, 0}};
 
   for (const auto& f : m_faces) {
-    if (f == nullptr) {
-      this->incrementWarning(warnings, f_null);
+    if (f.getHalfEdgeIndex() == UINT32_MAX) {
+      this->incrementWarning(warnings, f_noEdge);
       continue;
     }
 
-    const auto& halfEdge = f->getHalfEdge();
-    if (halfEdge == nullptr) {
-      this->incrementWarning(warnings, f_noEdge);
-    }
-
-    auto vertices = f->gatherVertices();
+    auto vertices = f.gatherVertexIndices(*this);
     std::sort(vertices.begin(), vertices.end());
     auto       it           = std::unique(vertices.begin(), vertices.end());
     const bool noDuplicates = (it == vertices.end());
@@ -246,34 +131,27 @@ MeshT<T, Meta>::sanityCheck(const std::string a_id) const
   }
 
   for (const auto& e : m_edges) {
-    if (e == nullptr) {
-      this->incrementWarning(warnings, e_null);
-      continue;
-    }
-
-    if (e->getVertex() == e->getOtherVertex()) {
-      this->incrementWarning(warnings, e_degenerate);
-    }
-    if (e->getPairEdge() == nullptr) {
-      this->incrementWarning(warnings, e_noPairEdge);
-    }
-    if (e->getNextEdge() == nullptr) {
-      this->incrementWarning(warnings, e_noNextEdge);
-    }
-    if (e->getVertex() == nullptr) {
+    if (e.getVertexIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, e_noOrigVert);
     }
-    if (e->getFace() == nullptr) {
+    else if (e.getNextEdgeIndex() != UINT32_MAX && e.getVertexIndex() == e.getNextEdge(*this).getVertexIndex()) {
+      this->incrementWarning(warnings, e_degenerate);
+    }
+
+    if (e.getPairEdgeIndex() == UINT32_MAX) {
+      this->incrementWarning(warnings, e_noPairEdge);
+    }
+    if (e.getNextEdgeIndex() == UINT32_MAX) {
+      this->incrementWarning(warnings, e_noNextEdge);
+    }
+    if (e.getFaceIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, e_noFace);
     }
   }
 
   // Vertex check
   for (const auto& v : m_vertices) {
-    if (v == nullptr) {
-      this->incrementWarning(warnings, v_null);
-    }
-    else if (v->getOutgoingEdge() == nullptr) {
+    if (v.getOutgoingEdgeIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, v_noEdge);
     }
   }
@@ -293,9 +171,7 @@ inline void
 MeshT<T, Meta>::setInsideOutsideAlgorithm(InsideOutsideAlgorithm a_algorithm) noexcept
 {
   for (auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    f->setInsideOutsideAlgorithm(a_algorithm);
+    f.setInsideOutsideAlgorithm(a_algorithm);
   }
 }
 
@@ -322,9 +198,7 @@ inline void
 MeshT<T, Meta>::reconcileFaces() noexcept
 {
   for (auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    f->reconcile();
+    f.reconcile(*this);
   }
 }
 
@@ -333,9 +207,7 @@ inline void
 MeshT<T, Meta>::reconcileEdges() noexcept
 {
   for (auto& e : m_edges) {
-    EBGEOMETRY_EXPECT(e != nullptr);
-
-    e->reconcile();
+    e.reconcile(*this);
   }
 }
 
@@ -343,17 +215,33 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::reconcileVertices(const DCEL::VertexNormalWeight a_weight) noexcept
 {
-  for (auto& v : m_vertices) {
-    EBGEOMETRY_EXPECT(v != nullptr);
+  // Transient (not stored) adjacency: for each vertex, every face touching it, found by walking
+  // each face's OWN boundary loop (nextEdge only -- no pair edge needed). This is exactly as
+  // robust to non-watertight/"dirty" meshes as the per-vertex face list this class used to cache
+  // permanently, but is rebuilt here and discarded once vertex normals are computed, so it never
+  // threatens VertexT's trivial copyability.
+  std::vector<std::vector<uint32_t>> facesTouchingVertex(m_vertices.size());
+
+  for (uint32_t faceIndex = 0; faceIndex < m_faces.size(); faceIndex++) {
+    for (const uint32_t vertexIndex : m_faces[faceIndex].gatherVertexIndices(*this)) {
+      EBGEOMETRY_EXPECT(vertexIndex < facesTouchingVertex.size());
+
+      facesTouchingVertex[vertexIndex].push_back(faceIndex);
+    }
+  }
+
+  for (uint32_t vertexIndex = 0; vertexIndex < m_vertices.size(); vertexIndex++) {
+    auto&       v           = m_vertices[vertexIndex];
+    const auto& faceIndices = facesTouchingVertex[vertexIndex];
 
     switch (a_weight) {
     case DCEL::VertexNormalWeight::None: {
-      v->computeVertexNormalAverage();
+      v.computeVertexNormalAverage(faceIndices, *this);
 
       break;
     }
     case DCEL::VertexNormalWeight::Angle: {
-      v->computeVertexNormalAngleWeighted();
+      v.computeVertexNormalAngleWeighted(vertexIndex, faceIndices, *this);
 
       break;
     }
@@ -375,9 +263,7 @@ inline void
 MeshT<T, Meta>::flipFaceNormals() noexcept
 {
   for (auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    f->flipNormal();
+    f.flipNormal();
   }
 }
 
@@ -386,9 +272,7 @@ inline void
 MeshT<T, Meta>::flipEdgeNormals() noexcept
 {
   for (auto& e : m_edges) {
-    EBGEOMETRY_EXPECT(e != nullptr);
-
-    e->flipNormal();
+    e.flipNormal();
   }
 }
 
@@ -397,49 +281,47 @@ inline void
 MeshT<T, Meta>::flipVertexNormals() noexcept
 {
   for (auto& v : m_vertices) {
-    EBGEOMETRY_EXPECT(v != nullptr);
-
-    v->flipNormal();
+    v.flipNormal();
   }
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<VertexT<T, Meta>>>&
+inline std::vector<VertexT<T, Meta>>&
 MeshT<T, Meta>::getVertices() noexcept
 {
   return m_vertices;
 }
 
 template <class T, class Meta>
-inline const std::vector<std::shared_ptr<VertexT<T, Meta>>>&
+inline const std::vector<VertexT<T, Meta>>&
 MeshT<T, Meta>::getVertices() const noexcept
 {
   return m_vertices;
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<EdgeT<T, Meta>>>&
+inline std::vector<EdgeT<T, Meta>>&
 MeshT<T, Meta>::getEdges() noexcept
 {
   return m_edges;
 }
 
 template <class T, class Meta>
-inline const std::vector<std::shared_ptr<EdgeT<T, Meta>>>&
+inline const std::vector<EdgeT<T, Meta>>&
 MeshT<T, Meta>::getEdges() const noexcept
 {
   return m_edges;
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<FaceT<T, Meta>>>&
+inline std::vector<FaceT<T, Meta>>&
 MeshT<T, Meta>::getFaces() noexcept
 {
   return m_faces;
 }
 
 template <class T, class Meta>
-inline const std::vector<std::shared_ptr<FaceT<T, Meta>>>&
+inline const std::vector<FaceT<T, Meta>>&
 MeshT<T, Meta>::getFaces() const noexcept
 {
   return m_faces;
@@ -452,9 +334,7 @@ MeshT<T, Meta>::getAllVertexCoordinates() const noexcept
   std::vector<Vec3> vertexCoordinates;
   vertexCoordinates.reserve(m_vertices.size());
   for (const auto& v : m_vertices) {
-    EBGEOMETRY_EXPECT(v != nullptr);
-
-    vertexCoordinates.emplace_back(v->getPosition());
+    vertexCoordinates.emplace_back(v.getPosition());
   }
 
   return vertexCoordinates;
@@ -486,9 +366,7 @@ MeshT<T, Meta>::unsignedDistance2(const Vec3& a_point) const noexcept
   T minDist2 = std::numeric_limits<T>::max();
 
   for (const auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    const T curDist2 = f->unsignedDistance2(a_point);
+    const T curDist2 = f.unsignedDistance2(a_point, *this);
 
     minDist2 = std::min(minDist2, curDist2);
   }
@@ -543,15 +421,11 @@ MeshT<T, Meta>::DirectSignedDistance(const Vec3& a_point) const noexcept
     return std::numeric_limits<T>::infinity();
   }
 
-  EBGEOMETRY_EXPECT(m_faces.front() != nullptr);
-
-  T minDist  = m_faces.front()->signedDistance(a_point);
+  T minDist  = m_faces.front().signedDistance(a_point, *this);
   T minDist2 = minDist * minDist;
 
   for (const auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    const T curDist  = f->signedDistance(a_point);
+    const T curDist  = f.signedDistance(a_point, *this);
     const T curDist2 = curDist * curDist;
 
     if (curDist2 < minDist2) {
@@ -575,23 +449,19 @@ MeshT<T, Meta>::DirectSignedDistance2(const Vec3& a_point) const noexcept
     return std::numeric_limits<T>::infinity();
   }
 
-  EBGEOMETRY_EXPECT(m_faces.front() != nullptr);
-
-  FacePtr closest  = m_faces.front();
-  T       minDist2 = closest->unsignedDistance2(a_point);
+  const Face* closest  = &m_faces.front();
+  T           minDist2 = closest->unsignedDistance2(a_point, *this);
 
   for (const auto& f : m_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    const T curDist2 = f->unsignedDistance2(a_point);
+    const T curDist2 = f.unsignedDistance2(a_point, *this);
 
     if (curDist2 < minDist2) {
-      closest  = f;
+      closest  = &f;
       minDist2 = curDist2;
     }
   }
 
-  return closest->signedDistance(a_point);
+  return closest->signedDistance(a_point, *this);
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_Vertex.hpp
+++ b/Source/EBGeometry_DCEL_Vertex.hpp
@@ -13,7 +13,7 @@
 #define EBGEOMETRY_DCEL_VERTEX_HPP
 
 // Std includes
-#include <memory>
+#include <cstdint>
 #include <type_traits>
 #include <vector>
 
@@ -30,11 +30,27 @@ namespace DCEL {
  * @brief Class which represents a vertex node in a double-edge connected list
  * (DCEL).
  * @details This class is used in DCEL functionality which stores polygonal
- * surfaces in a mesh. The VertexT class has a position, a normal vector, and a
- * pointer to one of the outgoing edges from the vertex. For performance reasons
- * we also include pointers to all the polygon faces that share this vertex.
+ * surfaces in a mesh. The VertexT class has a position, a normal vector, and the
+ * index of one of the outgoing edges from the vertex.
  * @note The normal vector is outgoing, i.e. a point x is "outside" the vertex if
  * the dot product between n and (x - x0) is positive.
+ * @note m_outgoingEdge is an index into the owning DCEL::MeshT's own edge array,
+ * resolved by passing that mesh to the accessors below (see EdgeT for why
+ * indices rather than pointers are used). It is the sole topology this class
+ * stores: which faces touch this vertex is not cached here -- storing a
+ * face-index list per vertex was a since-removed convenience, not a
+ * requirement, and it would have been the one member keeping VertexT from being
+ * trivially copyable (per-vertex variable-length lists cannot be plain values).
+ * Every remaining member is a plain value (Vec3, uint32_t, Meta), so as long as
+ * Meta and T are trivially copyable, VertexT itself is trivially copyable.
+ * computeVertexNormalAverage()/computeVertexNormalAngleWeighted() take the
+ * touching-faces list as an explicit parameter instead: MeshT::reconcileVertices()
+ * rebuilds it transiently by walking every face's own boundary loop (no pair
+ * edges needed), which is exactly as robust to non-watertight/"dirty" meshes as
+ * the old per-vertex cache was, and discards it once normals are computed.
+ * m_outgoingEdge itself is unrelated to this -- it is not read by either normal
+ * computation -- and remains purely a convenience for callers who want O(1)
+ * access to some edge leaving this vertex.
  * @tparam T    Floating-point precision.
  * @tparam Meta Meta-data type stored per vertex.
  */
@@ -65,19 +81,9 @@ public:
   using Face = FaceT<T, Meta>;
 
   /**
-   * @brief Alias for vertex pointer type
+   * @brief Alias for mesh type
    */
-  using VertexPtr = std::shared_ptr<Vertex>;
-
-  /**
-   * @brief Alias for edge pointer type
-   */
-  using EdgePtr = std::shared_ptr<Edge>;
-
-  /**
-   * @brief Alias for face pointer type
-   */
-  using FacePtr = std::shared_ptr<Face>;
+  using Mesh = MeshT<T, Meta>;
 
   /**
    * @brief Alias for edge iterator
@@ -87,7 +93,7 @@ public:
   /**
    * @brief Default constructor.
    * @details Defaulted: the position and normal vectors zero-initialize via Vec3T's own default
-   * constructor, the outgoing edge pointer defaults to null, the face list defaults to empty, and
+   * constructor, the outgoing edge index defaults to the unset sentinel (see m_outgoingEdge), and
    * the meta-data value-initializes (see m_metaData). Not marked noexcept since Meta is an
    * unconstrained template parameter whose default constructor is not guaranteed to be noexcept.
    */
@@ -97,7 +103,7 @@ public:
    * @brief Partial constructor.
    * @param[in] a_position Vertex position
    * @details This initializes the position to a_position and the normal vector
-   * to the zero vector. The polygon face list is empty.
+   * to the zero vector.
    */
   VertexT(const Vec3& a_position);
 
@@ -106,33 +112,26 @@ public:
    * @param[in] a_position    Vertex position
    * @param[in] a_normal Vertex normal vector
    * @details This initializes the position to a_position and the normal vector
-   * to a_normal. The polygon face list is empty.
+   * to a_normal.
    */
   VertexT(const Vec3& a_position, const Vec3& a_normal);
 
   /**
    * @brief Copy constructor.
    * @param[in] a_otherVertex Other vertex.
-   * @details Copies only the position, normal vector, and outgoing edge pointer from the other
-   * vertex. The polygon face list (m_faces) and meta-data (m_metaData) are deliberately NOT
-   * copied -- they default-construct empty/default instead; use addFace()/setMetaData()
-   * afterwards if they need to be populated. Rationale: m_faces and m_outgoingEdge are
-   * back-references into a specific mesh's topology (the faces/edges they point to still
-   * reference the original vertex, not this copy), so copying them wholesale would not be
-   * topologically meaningful; only the geometric value (position, normal) survives a copy.
+   * @details Defaulted memberwise copy of every member -- position, normal vector, outgoing edge
+   * index, and meta-data. Copying every member (rather than the narrow, metadata-excluding copy
+   * this used to have) is what lets VertexT be trivially copyable: `std::is_trivially_copyable`
+   * requires the copy constructor to be the implicit/defaulted one, so a user-provided body --
+   * even one that does nothing but a plain memberwise copy -- would disqualify it.
    * operator=(const Vertex&) has identical semantics.
    */
-  VertexT(const Vertex& a_otherVertex);
+  VertexT(const Vertex& a_otherVertex) = default;
 
   /**
    * @brief Move constructor.
-   * @details Unlike the copy constructor, this transfers the entire state (including m_faces and
-   * m_metaData) from a_otherVertex, since moving relocates a single object's identity rather than
-   * grafting a copy into a different mesh's topology. Defaulted (memberwise move) rather than
-   * hand-written: explicitly defaulting is required here since the presence of a user-declared
-   * copy constructor would otherwise suppress the implicitly-generated move constructor. Not
-   * marked noexcept since Meta is an unconstrained template parameter whose move constructor is
-   * not guaranteed to be noexcept.
+   * @details Defaulted memberwise move; equivalent to the copy constructor since every member is a
+   * plain value.
    * @param[in, out] a_otherVertex Other vertex.
    */
   VertexT(Vertex&& a_otherVertex) = default;
@@ -144,14 +143,12 @@ public:
 
   /**
    * @brief Copy assignment operator.
-   * @details Has the same narrow-copy semantics as the copy constructor (including that m_faces
-   * and m_metaData are not copied; use addFace()/setMetaData() afterwards if they need to be
-   * populated). See the copy constructor's documentation for details.
+   * @details Defaulted memberwise copy; see the copy constructor's documentation.
    * @param[in] a_otherVertex Other vertex.
    * @return Reference to (*this).
    */
   Vertex&
-  operator=(const Vertex& a_otherVertex);
+  operator=(const Vertex& a_otherVertex) = default;
 
   /**
    * @brief Move assignment operator.
@@ -166,12 +163,13 @@ public:
   /**
    * @brief Define function
    * @param[in] a_position    Vertex position
-   * @param[in] a_edge   Pointer to outgoing edge
+   * @param[in] a_edgeIndex   Index of the outgoing edge in the owning mesh's edge array, or
+   * UINT32_MAX if not yet wired into a mesh.
    * @param[in] a_normal Vertex normal vector
-   * @details This sets the position, normal vector, and edge pointer.
+   * @details This sets the position, normal vector, and outgoing edge index.
    */
   inline void
-  define(const Vec3& a_position, const EdgePtr& a_edge, const Vec3& a_normal) noexcept;
+  define(const Vec3& a_position, const uint32_t a_edgeIndex, const Vec3& a_normal) noexcept;
 
   /**
    * @brief Set the vertex position
@@ -188,11 +186,12 @@ public:
   setNormal(const Vec3& a_normal) noexcept;
 
   /**
-   * @brief Set the reference to the outgoing edge
-   * @param[in] a_edge Pointer to an outgoing edge
+   * @brief Set the index of the outgoing edge.
+   * @param[in] a_edgeIndex Index of an outgoing edge in the owning mesh's edge array, or
+   * UINT32_MAX to mark it unset.
    */
   inline void
-  setEdge(const EdgePtr& a_edge) noexcept;
+  setEdge(const uint32_t a_edgeIndex) noexcept;
 
   /**
    * @brief Set the meta-data.
@@ -200,13 +199,6 @@ public:
    */
   inline void
   setMetaData(const Meta& a_metaData) noexcept;
-
-  /**
-   * @brief Add a face to the polygon face list.
-   * @param[in] a_face Pointer to face.
-   */
-  inline void
-  addFace(const FacePtr& a_face);
 
   /**
    * @brief Normalize the normal vector, ensuring its length is 1
@@ -217,42 +209,34 @@ public:
   normalizeNormalVector() noexcept;
 
   /**
-   * @brief Compute the vertex normal, using an average the normal vector in this
-   * vertex's face list (m_faces)
+   * @brief Compute the vertex normal, as an unweighted average of the normal vectors of the faces
+   * touching this vertex.
+   * @param[in] a_faceIndices Indices, into the owning mesh's face array, of every face touching
+   * this vertex. Not cached anywhere -- callers (see MeshT::reconcileVertices()) discover this by
+   * walking each candidate face's own boundary loop, which needs no pair edges and so works
+   * regardless of whether the mesh is watertight.
+   * @param[in] a_mesh Owning mesh, used to resolve a_faceIndices to actual faces.
+   * @note This computes the vertex normal as n = sum(normal(face))/num(faces).
    */
   inline void
-  computeVertexNormalAverage() noexcept;
-
-  /**
-   * @brief Compute the vertex normal, using an average of the normal vectors in
-   * the input face list
-   * @param[in] a_faces Faces
-   * @note This computes the vertex normal as n = sum(normal(face))/num(faces)
-   */
-  inline void
-  computeVertexNormalAverage(const std::vector<FacePtr>& a_faces) noexcept;
+  computeVertexNormalAverage(const std::vector<uint32_t>& a_faceIndices, const Mesh& a_mesh) noexcept;
 
   /**
    * @brief Compute the vertex normal, using the pseudonormal algorithm which
    * weights the normal with the subtended angle to each connected face.
-   * @details This calls the other version with a_faces = m_faces
+   * @param[in] a_thisVertexIndex This vertex's own index in the owning mesh's vertex array, used to
+   * identify which of a face's vertices is "this" one while walking that face's boundary.
+   * @param[in] a_faceIndices Indices, into the owning mesh's face array, of every face touching
+   * this vertex (see computeVertexNormalAverage() for how these are found).
+   * @param[in] a_mesh Owning mesh, used to resolve a_faceIndices and a_thisVertexIndex.
    * @note This computes the normal vector using the pseudnormal algorithm from
    * Baerentzen and Aanes in "Signed distance computation using the angle
-   * weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49)
+   * weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49).
    */
   inline void
-  computeVertexNormalAngleWeighted();
-
-  /**
-   * @brief Compute the vertex normal, using the pseudonormal algorithm which
-   * weights the normal with the subtended angle to each connected face.
-   * @param[in] a_faces Faces to use for computation.
-   * @note This computes the normal vector using the pseudnormal algorithm from
-   * Baerentzen and Aanes in "Signed distance computation using the angle
-   * weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49)
-   */
-  inline void
-  computeVertexNormalAngleWeighted(const std::vector<FacePtr>& a_faces);
+  computeVertexNormalAngleWeighted(const uint32_t               a_thisVertexIndex,
+                                   const std::vector<uint32_t>& a_faceIndices,
+                                   const Mesh&                  a_mesh);
 
   /**
    * @brief Flip the normal vector
@@ -289,35 +273,28 @@ public:
   getNormal() const noexcept;
 
   /**
-   * @brief Get the outgoing edge.
-   * @details Returns a shared_ptr obtained by locking the internal weak_ptr (see the class-level
-   * note on ownership near m_outgoingEdge). Returns nullptr if the edge has been destroyed, which
-   * should not happen while the owning mesh is alive.
-   * @return Outgoing edge, or nullptr.
+   * @brief Get the index of the outgoing edge.
+   * @return Index of the outgoing edge in the owning mesh's edge array, or UINT32_MAX if unset.
    */
-  [[nodiscard]] inline EdgePtr
-  getOutgoingEdge() noexcept;
+  [[nodiscard]] inline uint32_t
+  getOutgoingEdgeIndex() const noexcept;
+
+  /**
+   * @brief Get the outgoing edge.
+   * @param[in] a_mesh Owning mesh, used to resolve the outgoing edge index.
+   * @return Reference to the outgoing edge. m_outgoingEdge must be set (see getOutgoingEdgeIndex()).
+   */
+  [[nodiscard]] inline Edge&
+  getOutgoingEdge(Mesh& a_mesh) noexcept;
 
   /**
    * @brief Get the outgoing edge (const overload).
-   * @return Outgoing edge, or nullptr.
+   * @param[in] a_mesh Owning mesh, used to resolve the outgoing edge index.
+   * @return Const reference to the outgoing edge. m_outgoingEdge must be set (see
+   * getOutgoingEdgeIndex()).
    */
-  [[nodiscard]] inline EdgePtr
-  getOutgoingEdge() const noexcept;
-
-  /**
-   * @brief Get modifiable polygon face list for this vertex.
-   * @return Reference to m_faces.
-   */
-  [[nodiscard]] inline std::vector<FacePtr>&
-  getFaces() noexcept;
-
-  /**
-   * @brief Get immutable polygon face list for this vertex.
-   * @return Const reference to m_faces.
-   */
-  [[nodiscard]] inline const std::vector<FacePtr>&
-  getFaces() const noexcept;
+  [[nodiscard]] inline const Edge&
+  getOutgoingEdge(const Mesh& a_mesh) const noexcept;
 
   /**
    * @brief Get the signed distance to this vertex
@@ -354,13 +331,12 @@ public:
 
 protected:
   /**
-   * @brief Pointer to an outgoing edge from this vertex.
-   * @details Stored as a weak_ptr: the edge is owned by the mesh's own edge list, and a plain
-   * shared_ptr here would form a reference cycle with EdgeT::m_vertex (and, transitively, with
-   * EdgeT::m_nextEdge/m_pairEdge/m_face and FaceT::m_halfEdge) that shared_ptr's reference
-   * counting can never collect.
+   * @brief Index of an outgoing edge from this vertex.
+   * @details Index into the owning DCEL::MeshT's edge array, or UINT32_MAX if unset. This is also
+   * the seed half-edge for circulating the faces touching this vertex (see
+   * computeVertexNormalAverage()/computeVertexNormalAngleWeighted()).
    */
-  std::weak_ptr<Edge> m_outgoingEdge;
+  uint32_t m_outgoingEdge = UINT32_MAX;
 
   /**
    * @brief Vertex position
@@ -373,13 +349,6 @@ protected:
   Vec3 m_normal;
 
   /**
-   * @brief List of faces connected to this vertex.
-   * @details These must be added by addFace(), and is used when computing the vertex
-   * normal vector.
-   */
-  std::vector<FacePtr> m_faces;
-
-  /**
    * @brief Meta-data for this vertex
    * @details Value-initialized so that every constructor leaves it in a defined state: for a
    * fundamental Meta type (e.g. short, int), a member with no initializer and no explicit
@@ -387,6 +356,12 @@ protected:
    */
   Meta m_metaData{};
 };
+
+static_assert(std::is_trivially_copyable_v<VertexT<float, DefaultMetaData>>,
+              "VertexT<float,DefaultMetaData> must be trivially copyable");
+static_assert(std::is_trivially_copyable_v<VertexT<double, DefaultMetaData>>,
+              "VertexT<double,DefaultMetaData> must be trivially copyable");
+
 } // namespace DCEL
 
 } // namespace EBGeometry

--- a/Source/EBGeometry_DCEL_VertexImplem.hpp
+++ b/Source/EBGeometry_DCEL_VertexImplem.hpp
@@ -16,7 +16,6 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
-#include <memory>
 #include <vector>
 
 // Our includes
@@ -55,29 +54,8 @@ inline VertexT<T, Meta>::VertexT(const Vec3& a_position, const Vec3& a_normal) :
 }
 
 template <class T, class Meta>
-inline VertexT<T, Meta>::VertexT(const VertexT<T, Meta>& a_otherVertex)
-{
-  m_position     = a_otherVertex.m_position;
-  m_normal       = a_otherVertex.m_normal;
-  m_outgoingEdge = a_otherVertex.m_outgoingEdge;
-}
-
-template <class T, class Meta>
-inline VertexT<T, Meta>&
-VertexT<T, Meta>::operator=(const VertexT<T, Meta>& a_otherVertex)
-{
-  if (this != &a_otherVertex) {
-    m_position     = a_otherVertex.m_position;
-    m_normal       = a_otherVertex.m_normal;
-    m_outgoingEdge = a_otherVertex.m_outgoingEdge;
-  }
-
-  return *this;
-}
-
-template <class T, class Meta>
 inline void
-VertexT<T, Meta>::define(const Vec3& a_position, const EdgePtr& a_edge, const Vec3& a_normal) noexcept
+VertexT<T, Meta>::define(const Vec3& a_position, const uint32_t a_edgeIndex, const Vec3& a_normal) noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_position[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_position[1]));
@@ -86,9 +64,9 @@ VertexT<T, Meta>::define(const Vec3& a_position, const EdgePtr& a_edge, const Ve
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_normal[2]));
 
-  // a_edge == nullptr is valid here (e.g. a freshly-created vertex not yet wired into the mesh).
+  // a_edgeIndex == UINT32_MAX is valid here (e.g. a freshly-created vertex not yet wired into a mesh).
   m_position     = a_position;
-  m_outgoingEdge = a_edge;
+  m_outgoingEdge = a_edgeIndex;
   m_normal       = a_normal;
 }
 
@@ -105,11 +83,11 @@ VertexT<T, Meta>::setPosition(const Vec3& a_position) noexcept
 
 template <class T, class Meta>
 inline void
-VertexT<T, Meta>::setEdge(const EdgePtr& a_edge) noexcept
+VertexT<T, Meta>::setEdge(const uint32_t a_edgeIndex) noexcept
 {
-  // a_edge == nullptr is valid here; callers that dereference m_outgoingEdge are responsible for
-  // checking it first (see e.g. computeVertexNormalAngleWeighted).
-  m_outgoingEdge = a_edge;
+  // a_edgeIndex == UINT32_MAX is valid here; callers that resolve m_outgoingEdge are responsible
+  // for checking it first (see e.g. computeVertexNormalAngleWeighted).
+  m_outgoingEdge = a_edgeIndex;
 }
 
 template <class T, class Meta>
@@ -132,15 +110,6 @@ VertexT<T, Meta>::setNormal(const Vec3& a_normal) noexcept
 
 template <class T, class Meta>
 inline void
-VertexT<T, Meta>::addFace(const FacePtr& a_face)
-{
-  EBGEOMETRY_EXPECT(a_face != nullptr);
-
-  m_faces.emplace_back(a_face);
-}
-
-template <class T, class Meta>
-inline void
 VertexT<T, Meta>::normalizeNormalVector() noexcept
 {
   const T len = m_normal.length();
@@ -154,27 +123,18 @@ VertexT<T, Meta>::normalizeNormalVector() noexcept
 
 template <class T, class Meta>
 inline void
-VertexT<T, Meta>::computeVertexNormalAverage() noexcept
+VertexT<T, Meta>::computeVertexNormalAverage(const std::vector<uint32_t>& a_faceIndices, const Mesh& a_mesh) noexcept
 {
-  this->computeVertexNormalAverage(m_faces);
-}
-
-template <class T, class Meta>
-inline void
-VertexT<T, Meta>::computeVertexNormalAverage(const std::vector<FacePtr>& a_faces) noexcept
-{
-  EBGEOMETRY_EXPECT(!a_faces.empty());
+  EBGEOMETRY_EXPECT(!a_faceIndices.empty());
 
   m_normal = Vec3::zeros();
 
   // TLDR: We simply compute the sum of the normal vectors for each face in
-  // a_faces and then normalize. This
+  // a_faceIndices and then normalize. This
   //       will yield an "average" of the normal vectors of the faces
   //       circulating this vertex.
-  for (const auto& f : a_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    m_normal += f->getNormal();
+  for (const uint32_t faceIndex : a_faceIndices) {
+    m_normal += a_mesh.getFaces()[faceIndex].getNormal();
   }
 
   this->normalizeNormalVector();
@@ -182,17 +142,10 @@ VertexT<T, Meta>::computeVertexNormalAverage(const std::vector<FacePtr>& a_faces
 
 template <class T, class Meta>
 inline void
-VertexT<T, Meta>::computeVertexNormalAngleWeighted()
+VertexT<T, Meta>::computeVertexNormalAngleWeighted(const uint32_t               a_thisVertexIndex,
+                                                   const std::vector<uint32_t>& a_faceIndices,
+                                                   const Mesh&                  a_mesh)
 {
-  this->computeVertexNormalAngleWeighted(m_faces);
-}
-
-template <class T, class Meta>
-inline void
-VertexT<T, Meta>::computeVertexNormalAngleWeighted(const std::vector<FacePtr>& a_faces)
-{
-  m_normal = Vec3::zeros();
-
   // This routine computes the pseudonormal from pseudnormal algorithm from
   // Baerentzen and Aanes in "Signed distance computation using the angle
   // weighted pseudonormal" (DOI: 10.1109/TVCG.2005.49). This algorithm computes
@@ -210,41 +163,41 @@ VertexT<T, Meta>::computeVertexNormalAngleWeighted(const std::vector<FacePtr>& a
   // want the two half edges that has the current vertex as a mutual vertex
   // (i.e. the "incoming" and "outgoing" edges into this vertex). Normally we'd
   // just iterate through edges, but if it happens that an input face is
-  // flipped, this will result in infinite iteration. Instead, we have stored
-  // the pointers to each face connected to this vertex. We look through each
-  // face to find the endpoints of the edges the have the current vertex as the
-  // common vertex, and then compute the subtended angle between those. Sigh...
+  // flipped, this will result in infinite iteration. Instead, the caller has
+  // given us the indices of each face connected to this vertex. We look through
+  // each face to find the endpoints of the edges that have the current vertex
+  // as the common vertex, and then compute the subtended angle between those.
+  // Sigh...
 
-  EBGEOMETRY_EXPECT(!a_faces.empty());
-  EBGEOMETRY_EXPECT(!m_outgoingEdge.expired());
-  const VertexPtr originVertex = m_outgoingEdge.lock()->getVertex(); // AKA 'this'
+  EBGEOMETRY_EXPECT(!a_faceIndices.empty());
 
-  for (const auto& f : a_faces) {
-    EBGEOMETRY_EXPECT(f != nullptr);
+  m_normal = Vec3::zeros();
 
-    std::vector<VertexPtr> inoutVertices(0);
-    for (EdgeIterator edgeIt(f->getHalfEdge()); edgeIt.ok(); ++edgeIt) {
-      const auto& e = edgeIt();
+  const uint32_t originVertexIndex = a_thisVertexIndex;
 
-      const auto& v1 = e->getVertex();
-      const auto& v2 = e->getOtherVertex();
+  for (const uint32_t faceIndex : a_faceIndices) {
+    const Face& f = a_mesh.getFaces()[faceIndex];
 
-      EBGEOMETRY_EXPECT(v1 != nullptr);
-      EBGEOMETRY_EXPECT(v2 != nullptr);
+    std::vector<uint32_t> inoutVertices(0);
+    for (EdgeIterator edgeIt(a_mesh, f); edgeIt.ok(); ++edgeIt) {
+      const Edge& e = a_mesh.getEdges()[edgeIt()];
 
-      if (v1 == originVertex || v2 == originVertex) {
-        if (v1 == originVertex) {
+      const uint32_t v1 = e.getVertexIndex();
+      const uint32_t v2 = e.getNextEdge(a_mesh).getVertexIndex();
+
+      if (v1 == originVertexIndex || v2 == originVertexIndex) {
+        if (v1 == originVertexIndex) {
           inoutVertices.emplace_back(v2);
         }
-        else if (v2 == originVertex) {
+        else if (v2 == originVertexIndex) {
           inoutVertices.emplace_back(v1);
         }
         else {
           std::cerr << "VertexT<T, Meta>::computeVertexNormalAngleWeighted(): unreachable branch "
-                       "hit -- a half-edge of face f was found to have originVertex as one of its "
-                       "two endpoints, but neither v1 nor v2 compares equal to it. This points to "
-                       "a corrupted or inconsistent half-edge/vertex topology (e.g. a stale vertex "
-                       "pointer) rather than a normal mesh-quality issue.\n";
+                       "hit -- a half-edge of face f was found to have originVertexIndex as one of "
+                       "its two endpoints, but neither v1 nor v2 compares equal to it. This points "
+                       "to a corrupted or inconsistent half-edge/vertex topology (e.g. a stale "
+                       "vertex index) rather than a normal mesh-quality issue.\n";
         }
       }
     }
@@ -264,9 +217,9 @@ VertexT<T, Meta>::computeVertexNormalAngleWeighted(const std::vector<FacePtr>& a
     // well-formed triangle incident on exactly two edges at this vertex.
     EBGEOMETRY_EXPECT(inoutVertices.size() == 2);
 
-    const Vec3& x0 = originVertex->getPosition();
-    const Vec3& x1 = inoutVertices[0]->getPosition();
-    const Vec3& x2 = inoutVertices[1]->getPosition();
+    const Vec3& x0 = a_mesh.getVertices()[originVertexIndex].getPosition();
+    const Vec3& x1 = a_mesh.getVertices()[inoutVertices[0]].getPosition();
+    const Vec3& x2 = a_mesh.getVertices()[inoutVertices[1]].getPosition();
 
     if (x0 == x1 || x0 == x2 || x1 == x2) {
       std::cerr << "VertexT<T, Meta>::computeVertexNormalAngleWeighted(): degenerate face f -- two "
@@ -289,7 +242,7 @@ VertexT<T, Meta>::computeVertexNormalAngleWeighted(const std::vector<FacePtr>& a
     v1 = v1 / v1.length();
     v2 = v2 / v2.length();
 
-    const Vec3& norm = f->getNormal();
+    const Vec3& norm = f.getNormal();
 
     // Clamp to [-1,1] to guard against std::acos(NaN) from floating-point rounding.
     const T alpha = std::acos(std::clamp(v1.dot(v2), T(-1), T(1)));
@@ -336,31 +289,28 @@ VertexT<T, Meta>::getNormal() const noexcept
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-VertexT<T, Meta>::getOutgoingEdge() noexcept
+inline uint32_t
+VertexT<T, Meta>::getOutgoingEdgeIndex() const noexcept
 {
-  return m_outgoingEdge.lock();
+  return m_outgoingEdge;
 }
 
 template <class T, class Meta>
-inline std::shared_ptr<EdgeT<T, Meta>>
-VertexT<T, Meta>::getOutgoingEdge() const noexcept
+inline EdgeT<T, Meta>&
+VertexT<T, Meta>::getOutgoingEdge(Mesh& a_mesh) noexcept
 {
-  return m_outgoingEdge.lock();
+  EBGEOMETRY_EXPECT(m_outgoingEdge != UINT32_MAX);
+
+  return a_mesh.getEdges()[m_outgoingEdge];
 }
 
 template <class T, class Meta>
-inline std::vector<std::shared_ptr<FaceT<T, Meta>>>&
-VertexT<T, Meta>::getFaces() noexcept
+inline const EdgeT<T, Meta>&
+VertexT<T, Meta>::getOutgoingEdge(const Mesh& a_mesh) const noexcept
 {
-  return m_faces;
-}
+  EBGEOMETRY_EXPECT(m_outgoingEdge != UINT32_MAX);
 
-template <class T, class Meta>
-inline const std::vector<std::shared_ptr<FaceT<T, Meta>>>&
-VertexT<T, Meta>::getFaces() const noexcept
-{
-  return m_faces;
+  return a_mesh.getEdges()[m_outgoingEdge];
 }
 
 template <class T, class Meta>

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -134,14 +134,16 @@ protected:
  * SIMD-accelerated traversal. Accepts any polygon, not just triangles.
  * @details The mesh faces are packed into a flat-array PackedBVH. SIMD traversal
  * is used when T and K match an available ISA path. Unlike TriMeshSDF, MeshSDF does not expose a
- * PackedBVH StoragePolicy choice: its PackedBVH always uses BVH::SharedPtrStorage<Face>, sharing
- * each packed face with the DCEL mesh's own face list rather than copying it. A DCEL::FaceT is not a
- * self-contained value -- its point-in-face test walks the face's half-edge loop into the mesh's
- * edges and vertices -- so MeshSDF retains the source mesh (m_mesh) to keep that topology alive, and
- * shares the faces with it rather than storing independent copies that would depend on the same mesh
- * anyway. TriMeshSDF's SoA groups, by contrast, are self-contained value types (they pack the
- * triangle geometry by value), which is why it can store them inline and offers a StoragePolicy. See
- * the user documentation for the full rationale.
+ * PackedBVH StoragePolicy choice: its PackedBVH always uses BVH::SharedPtrStorage<Face>, each
+ * packed face being a fresh copy of the corresponding DCEL mesh face (DCEL::FaceT is a plain,
+ * trivially-copyable value, so copying it is cheap and free of aliasing). That copy is only
+ * meaningful together with the mesh it was built from, though: a FaceT stores its half-edge as an
+ * index into its owning mesh's edge array, not a self-resolving reference, so MeshSDF retains the
+ * source mesh (m_mesh) and passes it to every DCEL::FaceT query that needs to resolve topology
+ * (point-in-face tests, signed distance). TriMeshSDF's SoA groups, by contrast, need no such
+ * external context -- they pack the triangle geometry by value with no index into anything else --
+ * which is why it can store them inline and offers a StoragePolicy. See the user documentation for
+ * the full rationale.
  * @tparam T    Floating-point precision type (float or double).
  * @tparam Meta Triangle metadata type stored on each DCEL face.
  * @tparam K    BVH branching factor (number of children per internal node).

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -66,13 +66,15 @@ buildDCELTreeBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcel
   using Prim          = EBGeometry::DCEL::FaceT<T, Meta>;
   using PrimAndBVList = std::vector<std::pair<std::shared_ptr<const Prim>, BV>>;
 
-  // Create a pair-wise list of DCEL faces and their bounding volumes.
+  // Create a pair-wise list of DCEL faces and their bounding volumes. Each face is copied into a
+  // fresh shared_ptr here (rather than aliasing the mesh's own array) since DCEL::FaceT is now a
+  // plain, trivially-copyable value -- the copy's topology indices remain valid because they are
+  // resolved against the same retained mesh (see MeshSDF::m_mesh) both before and after the copy.
   PrimAndBVList primsAndBVs;
 
   for (const auto& f : a_dcelMesh->getFaces()) {
-    EBGEOMETRY_EXPECT(f != nullptr);
-
-    primsAndBVs.emplace_back(std::make_pair(f, BV(f->getAllVertexCoordinates())));
+    primsAndBVs.emplace_back(
+      std::make_pair(std::make_shared<const Prim>(f), BV(f.getAllVertexCoordinates(*a_dcelMesh))));
   }
 
   // Partition the BVH using the default input arguments.
@@ -256,12 +258,10 @@ MeshSDF<T, Meta, K>::MeshSDF(const std::shared_ptr<Mesh>& a_mesh, const BVH::Bui
 
   m_bvh = bvh->pack();
 
-  // DCEL::FaceT/EdgeT/VertexT only hold weak_ptr back-references to their neighboring
-  // half-edges/vertices/faces (to avoid reference cycles); the mesh's own vertex/edge/face
-  // vectors are the sole owners keeping them alive. m_bvh only keeps the faces themselves
-  // alive (as its primitives), so the source mesh must be retained here too, or every face's
-  // half-edge (and the rest of its edge loop) would dangle as soon as the caller's mesh
-  // shared_ptr goes out of scope.
+  // Each DCEL::FaceT held by m_bvh only stores a half-edge INDEX, meaningful solely against the
+  // mesh's own vertex/edge/face arrays -- it carries no owning reference to them. The source mesh
+  // must therefore be retained here too, or those indices would dangle as soon as the caller's
+  // mesh shared_ptr goes out of scope.
   m_mesh = a_mesh;
 }
 
@@ -274,12 +274,15 @@ MeshSDF<T, Meta, K>::signedDistance(const Vec3T<T>& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
+  EBGEOMETRY_EXPECT(m_mesh != nullptr);
+
   T           minDist = std::numeric_limits<T>::max();
   const auto& faces   = m_bvh->getPrimitives();
+  const auto& mesh    = *m_mesh;
 
-  const auto evalLeaf = [&faces, &a_point](T& a_state, size_t a_offset, size_t a_count) noexcept {
+  const auto evalLeaf = [&faces, &a_point, &mesh](T& a_state, size_t a_offset, size_t a_count) noexcept {
     for (size_t i = a_offset; i < a_offset + a_count; i++) {
-      const T curDist = faces[i]->signedDistance(a_point);
+      const T curDist = faces[i]->signedDistance(a_point, mesh);
 
       EBGEOMETRY_EXPECT(!std::isnan(curDist));
 
@@ -299,9 +302,12 @@ std::vector<std::pair<std::shared_ptr<const EBGeometry::DCEL::FaceT<T, Meta>>, T
 MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorted) const
 {
   EBGEOMETRY_EXPECT(m_bvh != nullptr);
+  EBGEOMETRY_EXPECT(m_mesh != nullptr);
   EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
+
+  const auto& mesh = *m_mesh;
 
   using FaceAndDist = std::pair<std::shared_ptr<const Face>, T>;
 
@@ -331,10 +337,10 @@ MeshSDF<T, Meta, K>::getClosestFaces(const Vec3T<T>& a_point, const bool a_sorte
     [&a_point](const Node& a_node) noexcept -> BVHNodeKey { return a_node.getDistanceToBoundingVolume(a_point); };
 
   const EBGeometry::BVH::PackedLeafEvaluator<Face> leafEvaluator =
-    [&shortestDistanceSoFar, &a_point, &candidateFaces](
+    [&shortestDistanceSoFar, &a_point, &candidateFaces, &mesh](
       const std::vector<std::shared_ptr<const Face>>& a_faces, size_t offset, size_t count) noexcept -> void {
     for (size_t i = offset; i < offset + count; i++) {
-      const T distToFace = std::sqrt(a_faces[i]->unsignedDistance2(a_point));
+      const T distToFace = std::sqrt(a_faces[i]->unsignedDistance2(a_point, mesh));
 
       EBGEOMETRY_EXPECT(!std::isnan(distToFace));
 
@@ -427,26 +433,32 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>
   std::vector<std::shared_ptr<Tri>> triangles;
 
   for (const auto& f : a_mesh->getFaces()) {
-    EBGEOMETRY_EXPECT(f != nullptr);
+    const auto normal        = f.getNormal();
+    const auto vertexIndices = f.gatherVertexIndices(*a_mesh);
+    const auto edgeIndices   = f.gatherEdgeIndices(*a_mesh);
 
-    const auto normal   = f->getNormal();
-    const auto vertices = f->gatherVertices();
-    const auto edges    = f->gatherEdges();
+    EBGEOMETRY_EXPECT(vertexIndices.size() == 3);
+    EBGEOMETRY_EXPECT(edgeIndices.size() == 3);
 
-    EBGEOMETRY_EXPECT(vertices.size() == 3);
-    EBGEOMETRY_EXPECT(edges.size() == 3);
-
-    if ((vertices.size() != 3) || (edges.size() != 3)) {
+    if ((vertexIndices.size() != 3) || (edgeIndices.size() != 3)) {
       std::cerr << "TriMeshSDF -- mesh not triangulated!\n";
     }
+
+    const auto& v0 = a_mesh->getVertices()[vertexIndices[0]];
+    const auto& v1 = a_mesh->getVertices()[vertexIndices[1]];
+    const auto& v2 = a_mesh->getVertices()[vertexIndices[2]];
+
+    const auto& e0 = a_mesh->getEdges()[edgeIndices[0]];
+    const auto& e1 = a_mesh->getEdges()[edgeIndices[1]];
+    const auto& e2 = a_mesh->getEdges()[edgeIndices[2]];
 
     auto tri = std::make_shared<Tri>();
 
     tri->setNormal(normal);
-    tri->setVertexPositions({vertices[0]->getPosition(), vertices[1]->getPosition(), vertices[2]->getPosition()});
-    tri->setVertexNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
-    tri->setEdgeNormals({edges[0]->getNormal(), edges[1]->getNormal(), edges[2]->getNormal()});
-    tri->setMetaData(f->getMetaData());
+    tri->setVertexPositions({v0.getPosition(), v1.getPosition(), v2.getPosition()});
+    tri->setVertexNormals({v0.getNormal(), v1.getNormal(), v2.getNormal()});
+    tri->setEdgeNormals({e0.getNormal(), e1.getNormal(), e2.getNormal()});
+    tri->setMetaData(f.getMetaData());
 
     triangles.emplace_back(tri);
   }

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -1848,21 +1848,24 @@ Parser::readIntoTriangles(const std::string a_filename)
   bool onlyTriangles = true;
 
   for (const auto& f : mesh->getFaces()) {
-    const auto normal   = f->getNormal();
-    const auto vertices = f->gatherVertices();
-    const auto edges    = f->gatherEdges();
+    const auto normal        = f.getNormal();
+    const auto vertexIndices = f.gatherVertexIndices(*mesh);
 
-    if (vertices.size() != 3) {
+    if (vertexIndices.size() != 3) {
       onlyTriangles = false;
     }
+
+    const auto& v0 = mesh->getVertices()[vertexIndices[0]];
+    const auto& v1 = mesh->getVertices()[vertexIndices[1]];
+    const auto& v2 = mesh->getVertices()[vertexIndices[2]];
 
     // Create the triangle
     auto tri = std::make_shared<Triangle<T, Meta>>();
 
     tri->setNormal(normal);
-    tri->setVertexPositions({vertices[0]->getPosition(), vertices[1]->getPosition(), vertices[2]->getPosition()});
-    tri->setVertexNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
-    tri->setEdgeNormals({vertices[0]->getNormal(), vertices[1]->getNormal(), vertices[2]->getNormal()});
+    tri->setVertexPositions({v0.getPosition(), v1.getPosition(), v2.getPosition()});
+    tri->setVertexNormals({v0.getNormal(), v1.getNormal(), v2.getNormal()});
+    tri->setEdgeNormals({v0.getNormal(), v1.getNormal(), v2.getNormal()});
 
     triangles.emplace_back(tri);
   }

--- a/Source/EBGeometry_Soup.hpp
+++ b/Source/EBGeometry_Soup.hpp
@@ -13,7 +13,6 @@
 
 // Std includes
 #include <cstddef>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -74,15 +73,16 @@ soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
 /**
  * @brief Reconcile pair edges: link each half-edge with its reverse.
  * @details For every half-edge (u→v) the function finds the corresponding reverse
- * half-edge (v→u) by iterating over all faces incident to u and sets the pair-edge
- * pointer on both.
+ * half-edge (v→u) by circulating the half-edges around u (via pair/next edges of
+ * whichever edges already have their pair set, falling back to a scan of u's
+ * outgoing edges discovered so far) and sets the pair-edge index on both.
  * @tparam T    Floating-point precision type.
  * @tparam Meta Metadata type attached to DCEL edges.
- * @param[in,out] a_edges Collection of all half-edges to reconcile.
+ * @param[in,out] a_mesh Mesh whose half-edges are reconciled in place.
  */
 template <typename T, typename Meta>
 inline static void
-reconcilePairEdgesDCEL(std::vector<std::shared_ptr<EBGeometry::DCEL::EdgeT<T, Meta>>>& a_edges) noexcept;
+reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh) noexcept;
 
 } // namespace Soup
 

--- a/Source/EBGeometry_SoupImplem.hpp
+++ b/Source/EBGeometry_SoupImplem.hpp
@@ -14,9 +14,9 @@
 // Std includes
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <map>
-#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -158,67 +158,56 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
   using Edge   = EBGeometry::DCEL::EdgeT<T, Meta>;
   using Face   = EBGeometry::DCEL::FaceT<T, Meta>;
 
-  std::vector<std::shared_ptr<Vertex>>& vertices = a_mesh.getVertices();
-  std::vector<std::shared_ptr<Edge>>&   edges    = a_mesh.getEdges();
-  std::vector<std::shared_ptr<Face>>&   faces    = a_mesh.getFaces();
+  std::vector<Vertex>& vertices = a_mesh.getVertices();
+  std::vector<Edge>&   edges    = a_mesh.getEdges();
+  std::vector<Face>&   faces    = a_mesh.getFaces();
 
-  // Build the vertex vectors from the input vertices.
+  // Build the vertex array from the input vertices; index i here becomes vertex index i in the
+  // mesh, matching how a_facets already indexes into a_vertices.
+  vertices.reserve(a_vertices.size());
   for (const auto& v : a_vertices) {
-    vertices.emplace_back(std::make_shared<Vertex>(v, Vec3::zeros()));
+    vertices.emplace_back(v, Vec3::zeros());
   }
 
-  // Now build the faces.
+  // Now build the faces, appending each facet's half-edges directly into the mesh's own edge/face
+  // arrays and wiring them by index rather than by pointer.
   for (const auto& curFacet : a_facets) {
     if (curFacet.size() < 3) {
       std::cerr << "Parser::soupToDCEL -- not enough vertices in face, skipping it\n";
 
-      // The cerr above only warns; falling through here would reach halfEdges.front() on a
-      // possibly-empty vector below, which is undefined behavior for a 0-vertex facet.
+      // The cerr above only warns; falling through here would reach edges[firstEdgeIndex] below
+      // on a 0-vertex facet, which is a bounds violation.
       EBGEOMETRY_EXPECT(curFacet.size() >= 3);
 
       continue;
     }
 
-    // Figure out which vertices are involved here.
-    std::vector<std::shared_ptr<Vertex>> faceVertices;
-    faceVertices.reserve(curFacet.size());
-    for (const size_t i : curFacet) {
-      EBGEOMETRY_EXPECT(i < vertices.size());
+    const uint32_t firstEdgeIndex = static_cast<uint32_t>(edges.size());
+    const uint32_t numEdges       = static_cast<uint32_t>(curFacet.size());
 
-      faceVertices.emplace_back(vertices[i]);
+    // Build the half-edges for this polygon: one per vertex, appended contiguously.
+    for (uint32_t i = 0; i < numEdges; i++) {
+      const uint32_t vertexIndex = static_cast<uint32_t>(curFacet[i]);
+      EBGEOMETRY_EXPECT(vertexIndex < vertices.size());
+
+      edges.emplace_back(vertexIndex);
+      vertices[vertexIndex].setEdge(firstEdgeIndex + i);
     }
 
-    // Build the half-edges for this polygon.
-    std::vector<std::shared_ptr<Edge>> halfEdges;
-    for (const auto& v : faceVertices) {
-      halfEdges.emplace_back(std::make_shared<Edge>(v));
-      v->setEdge(halfEdges.back());
+    for (uint32_t i = 0; i < numEdges; i++) {
+      edges[firstEdgeIndex + i].setNextEdge(firstEdgeIndex + (i + 1) % numEdges);
     }
 
-    for (size_t i = 0; i < halfEdges.size(); i++) {
-      auto& curEdge  = halfEdges[i];
-      auto& nextEdge = halfEdges[(i + 1) % halfEdges.size()];
+    const uint32_t faceIndex = static_cast<uint32_t>(faces.size());
+    faces.emplace_back(firstEdgeIndex);
 
-      curEdge->setNextEdge(nextEdge);
-    }
-
-    edges.insert(edges.end(), halfEdges.begin(), halfEdges.end());
-
-    faces.emplace_back(std::make_shared<Face>(halfEdges.front()));
-    auto& curFace = faces.back();
-
-    for (auto& e : halfEdges) {
-      e->setFace(curFace);
-    }
-
-    // Must give vertices access to all faces associated them.
-    for (const auto& v : faceVertices) {
-      v->addFace(curFace);
+    for (uint32_t i = 0; i < numEdges; i++) {
+      edges[firstEdgeIndex + i].setFace(faceIndex);
     }
   }
 
   // Reconcile the pair edges and run a sanity check.
-  Soup::reconcilePairEdgesDCEL(edges);
+  Soup::reconcilePairEdgesDCEL(a_mesh);
 
   a_mesh.sanityCheck(a_id);
 
@@ -227,37 +216,48 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
 
 template <typename T, typename Meta>
 inline void
-Soup::reconcilePairEdgesDCEL(std::vector<std::shared_ptr<EBGeometry::DCEL::EdgeT<T, Meta>>>& a_edges) noexcept
+Soup::reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh) noexcept
 {
   static_assert(std::is_floating_point_v<T>, "Soup::reconcilePairEdgesDCEL requires a floating-point T");
 
-  for (auto& curEdge : a_edges) {
-    EBGEOMETRY_EXPECT(curEdge != nullptr);
+  using Edge = EBGeometry::DCEL::EdgeT<T, Meta>;
 
-    const auto& nextEdge = curEdge->getNextEdge();
-    EBGEOMETRY_EXPECT(nextEdge != nullptr);
+  std::vector<Edge>& edges       = a_mesh.getEdges();
+  const size_t       numVertices = a_mesh.getVertices().size();
 
-    const auto& vertexStart = curEdge->getVertex();
-    const auto& vertexEnd   = nextEdge->getVertex();
-    EBGEOMETRY_EXPECT(vertexStart != nullptr);
+  // Local, transient bookkeeping (NOT stored on VertexT, which keeps only a single outgoing-edge
+  // index -- see its class-level note): which half-edges start at each vertex, so the search below
+  // stays O(V + E) instead of an O(E^2) scan over every edge pair.
+  std::vector<std::vector<uint32_t>> edgesStartingAtVertex(numVertices);
+  for (uint32_t i = 0; i < edges.size(); i++) {
+    const uint32_t v = edges[i].getVertexIndex();
 
-    for (const auto& p : vertexStart->getFaces()) {
-      EBGEOMETRY_EXPECT(p != nullptr);
+    EBGEOMETRY_EXPECT(v < numVertices);
 
-      for (EBGeometry::DCEL::EdgeIteratorT<T, Meta> edgeIt(*p); edgeIt.ok(); ++edgeIt) {
-        const auto& polyCurEdge = edgeIt();
-        EBGEOMETRY_EXPECT(polyCurEdge != nullptr);
+    edgesStartingAtVertex[v].push_back(i);
+  }
 
-        const auto& polyNextEdge = polyCurEdge->getNextEdge();
-        EBGEOMETRY_EXPECT(polyNextEdge != nullptr);
+  for (uint32_t curIndex = 0; curIndex < edges.size(); curIndex++) {
+    Edge& curEdge = edges[curIndex];
 
-        const auto& polyVertexStart = polyCurEdge->getVertex();
-        const auto& polyVertexEnd   = polyNextEdge->getVertex();
+    const uint32_t nextIndex = curEdge.getNextEdgeIndex();
+    EBGEOMETRY_EXPECT(nextIndex != UINT32_MAX);
 
-        if (vertexStart == polyVertexEnd && polyVertexStart == vertexEnd) { // Found the pair edge
-          curEdge->setPairEdge(polyCurEdge);
-          polyCurEdge->setPairEdge(curEdge);
-        }
+    const uint32_t vertexStart = curEdge.getVertexIndex();
+    const uint32_t vertexEnd   = edges[nextIndex].getVertexIndex();
+
+    // The pair edge starts where this edge ends, and ends where this edge starts.
+    for (const uint32_t candIndex : edgesStartingAtVertex[vertexEnd]) {
+      Edge&          candEdge      = edges[candIndex];
+      const uint32_t candNextIndex = candEdge.getNextEdgeIndex();
+
+      EBGEOMETRY_EXPECT(candNextIndex != UINT32_MAX);
+
+      if (edges[candNextIndex].getVertexIndex() == vertexStart) { // Found the pair edge
+        curEdge.setPairEdge(candIndex);
+        candEdge.setPairEdge(curIndex);
+
+        break;
       }
     }
   }

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -95,7 +95,7 @@ TEMPLATE_TEST_CASE("Dodecahedron: all four file formats parse into an identical,
     REQUIRE(mesh->getEdges().size() == 108); // 54 undirected edges * 2 half-edges each.
 
     for (const auto& e : mesh->getEdges()) {
-      REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+      REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
     }
   }
 
@@ -126,7 +126,7 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
 
   BVH::PrimAndBVList<Face, AABB> primsAndBVs;
   for (const auto& f : mesh->getFaces()) {
-    primsAndBVs.emplace_back(f, AABB(f->getAllVertexCoordinates()));
+    primsAndBVs.emplace_back(std::make_shared<const Face>(f), AABB(f.getAllVertexCoordinates(*mesh)));
   }
   REQUIRE(primsAndBVs.size() == 36);
 
@@ -153,9 +153,9 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
     for (const auto& p : queryPoints<T>()) {
       T state = std::numeric_limits<T>::max();
 
-      const auto evalLeaf = [&faces, &p](T& a_state, size_t a_offset, size_t a_count) noexcept {
+      const auto evalLeaf = [&faces, &p, &mesh](T& a_state, size_t a_offset, size_t a_count) noexcept {
         for (size_t i = 0; i < a_count; i++) {
-          const T d = faces[a_offset + i]->signedDistance(p);
+          const T d = faces[a_offset + i]->signedDistance(p, *mesh);
           if (std::abs(d) < std::abs(a_state)) {
             a_state = d;
           }
@@ -1950,7 +1950,7 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 
   BVH::PrimAndBVList<Face, AABB> primsAndBVs;
   for (const auto& f : mesh->getFaces()) {
-    primsAndBVs.emplace_back(f, AABB(f->getAllVertexCoordinates()));
+    primsAndBVs.emplace_back(std::make_shared<const Face>(f), AABB(f.getAllVertexCoordinates(*mesh)));
   }
 
   const FlatMeshSDF<T, Meta> flat(mesh);
@@ -1963,9 +1963,9 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 
     for (const auto& p : queryPoints<T>()) {
       T          state    = std::numeric_limits<T>::max();
-      const auto evalLeaf = [&faces, &p](T& a_state, size_t a_offset, size_t a_count) noexcept {
+      const auto evalLeaf = [&faces, &p, &mesh](T& a_state, size_t a_offset, size_t a_count) noexcept {
         for (size_t i = 0; i < a_count; i++) {
-          const T d = faces[a_offset + i]->signedDistance(p);
+          const T d = faces[a_offset + i]->signedDistance(p, *mesh);
           if (std::abs(d) < std::abs(a_state)) {
             a_state = d;
           }

--- a/Tests/TestDCEL.cpp
+++ b/Tests/TestDCEL.cpp
@@ -4,6 +4,7 @@
 #include "EBGeometry.hpp"
 #include "TestFloatingPointUtils.hpp"
 
+#include <cstdint>
 #include <string>
 #include <type_traits>
 
@@ -118,8 +119,7 @@ TEMPLATE_TEST_CASE("VertexT: default construction leaves defined, zeroed state",
 
   REQUIRE(v.getPosition() == Vec3T<T>::zeros());
   REQUIRE(v.getNormal() == Vec3T<T>::zeros());
-  REQUIRE(v.getOutgoingEdge() == nullptr);
-  REQUIRE(v.getFaces().empty());
+  REQUIRE(v.getOutgoingEdgeIndex() == UINT32_MAX);
   REQUIRE(v.getMetaData() == 0);
 }
 
@@ -134,7 +134,6 @@ TEMPLATE_TEST_CASE("VertexT: position-only and position+normal constructors",
   TestVertex<T> vPosOnly(pos);
   REQUIRE(vPosOnly.getPosition() == pos);
   REQUIRE(vPosOnly.getNormal() == Vec3T<T>::zeros());
-  REQUIRE(vPosOnly.getFaces().empty());
 
   TestVertex<T> vBoth(pos, normal);
   REQUIRE(vBoth.getPosition() == pos);
@@ -145,7 +144,6 @@ TEMPLATE_TEST_CASE("VertexT: setPosition, setNormal, setEdge, define", "[DCEL][V
 {
   using T = TestType;
   TestVertex<T> v;
-  auto          edge = std::make_shared<TestEdge<T>>();
 
   v.setPosition(Vec3T<T>(4, 5, 6));
   REQUIRE(v.getPosition() == Vec3T<T>(4, 5, 6));
@@ -153,29 +151,17 @@ TEMPLATE_TEST_CASE("VertexT: setPosition, setNormal, setEdge, define", "[DCEL][V
   v.setNormal(Vec3T<T>(1, 0, 0));
   REQUIRE(v.getNormal() == Vec3T<T>(1, 0, 0));
 
-  v.setEdge(edge);
-  REQUIRE(v.getOutgoingEdge() == edge);
+  v.setEdge(3);
+  REQUIRE(v.getOutgoingEdgeIndex() == 3);
 
-  // Setting the edge pointer to nullptr is explicitly valid.
-  v.setEdge(nullptr);
-  REQUIRE(v.getOutgoingEdge() == nullptr);
+  // Setting the edge index to UINT32_MAX is explicitly valid.
+  v.setEdge(UINT32_MAX);
+  REQUIRE(v.getOutgoingEdgeIndex() == UINT32_MAX);
 
-  v.define(Vec3T<T>(7, 8, 9), edge, Vec3T<T>(0, 1, 0));
+  v.define(Vec3T<T>(7, 8, 9), 3, Vec3T<T>(0, 1, 0));
   REQUIRE(v.getPosition() == Vec3T<T>(7, 8, 9));
-  REQUIRE(v.getOutgoingEdge() == edge);
+  REQUIRE(v.getOutgoingEdgeIndex() == 3);
   REQUIRE(v.getNormal() == Vec3T<T>(0, 1, 0));
-}
-
-TEMPLATE_TEST_CASE("VertexT: addFace appends to the face list", "[DCEL][Vertex]", EBGEOMETRY_TEST_PRECISIONS)
-{
-  using T = TestType;
-  TestVertex<T> v;
-  auto          face = std::make_shared<TestFace<T>>();
-
-  REQUIRE(v.getFaces().empty());
-  v.addFace(face);
-  REQUIRE(v.getFaces().size() == 1);
-  REQUIRE(v.getFaces()[0] == face);
 }
 
 TEMPLATE_TEST_CASE("VertexT: normalizeNormalVector produces a unit vector",
@@ -227,39 +213,32 @@ TEMPLATE_TEST_CASE("VertexT: getMetaData reads and writes", "[DCEL][Vertex]", EB
   REQUIRE(v.getMetaData() == 9);
 }
 
-TEMPLATE_TEST_CASE("VertexT: copy construction only copies position, normal, and outgoing edge",
+TEMPLATE_TEST_CASE("VertexT: copy construction copies every member, including meta-data",
                    "[DCEL][Vertex]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  auto edge = std::make_shared<TestEdge<T>>();
+  using T = TestType;
 
   TestVertex<T> src(Vec3T<T>(1, 2, 3), Vec3T<T>(0, 0, 1));
-  src.setEdge(edge);
-  src.addFace(face);
+  src.setEdge(7);
   src.getMetaData() = 42;
 
   TestVertex<T> copy(src);
 
   REQUIRE(copy.getPosition() == src.getPosition());
   REQUIRE(copy.getNormal() == src.getNormal());
-  REQUIRE(copy.getOutgoingEdge() == edge);
-  REQUIRE(copy.getFaces().empty());
-  REQUIRE(copy.getMetaData() == 0);
+  REQUIRE(copy.getOutgoingEdgeIndex() == 7);
+  REQUIRE(copy.getMetaData() == 42);
 }
 
-TEMPLATE_TEST_CASE("VertexT: copy assignment has the same narrow semantics as copy construction",
+TEMPLATE_TEST_CASE("VertexT: copy assignment has the same semantics as copy construction",
                    "[DCEL][Vertex]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  auto edge = std::make_shared<TestEdge<T>>();
+  using T = TestType;
 
   TestVertex<T> src(Vec3T<T>(1, 2, 3), Vec3T<T>(0, 0, 1));
-  src.setEdge(edge);
-  src.addFace(face);
+  src.setEdge(7);
   src.getMetaData() = 42;
 
   TestVertex<T> dst;
@@ -267,40 +246,33 @@ TEMPLATE_TEST_CASE("VertexT: copy assignment has the same narrow semantics as co
 
   REQUIRE(dst.getPosition() == src.getPosition());
   REQUIRE(dst.getNormal() == src.getNormal());
-  REQUIRE(dst.getOutgoingEdge() == edge);
-  REQUIRE(dst.getFaces().empty());
-  REQUIRE(dst.getMetaData() == 0);
+  REQUIRE(dst.getOutgoingEdgeIndex() == 7);
+  REQUIRE(dst.getMetaData() == 42);
 }
 
 TEMPLATE_TEST_CASE("VertexT: move construction and move assignment transfer the entire state",
                    "[DCEL][Vertex]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  auto edge = std::make_shared<TestEdge<T>>();
+  using T = TestType;
 
   TestVertex<T> moveCtorSrc(Vec3T<T>(1, 2, 3), Vec3T<T>(0, 0, 1));
-  moveCtorSrc.setEdge(edge);
-  moveCtorSrc.addFace(face);
+  moveCtorSrc.setEdge(7);
   moveCtorSrc.getMetaData() = 42;
 
   TestVertex<T> moved(std::move(moveCtorSrc));
   REQUIRE(moved.getPosition() == Vec3T<T>(1, 2, 3));
-  REQUIRE(moved.getOutgoingEdge() == edge);
-  REQUIRE(moved.getFaces().size() == 1);
+  REQUIRE(moved.getOutgoingEdgeIndex() == 7);
   REQUIRE(moved.getMetaData() == 42);
 
   TestVertex<T> moveAssignSrc(Vec3T<T>(4, 5, 6), Vec3T<T>(1, 0, 0));
-  moveAssignSrc.setEdge(edge);
-  moveAssignSrc.addFace(face);
+  moveAssignSrc.setEdge(7);
   moveAssignSrc.getMetaData() = 7;
 
   TestVertex<T> moveAssignDst;
   moveAssignDst = std::move(moveAssignSrc);
   REQUIRE(moveAssignDst.getPosition() == Vec3T<T>(4, 5, 6));
-  REQUIRE(moveAssignDst.getOutgoingEdge() == edge);
-  REQUIRE(moveAssignDst.getFaces().size() == 1);
+  REQUIRE(moveAssignDst.getOutgoingEdgeIndex() == 7);
   REQUIRE(moveAssignDst.getMetaData() == 7);
 }
 
@@ -316,10 +288,10 @@ TEMPLATE_TEST_CASE("EdgeT: default construction leaves defined, zeroed state",
   TestEdge<T> e;
 
   REQUIRE(e.getNormal() == Vec3T<T>::zeros());
-  REQUIRE(e.getVertex() == nullptr);
-  REQUIRE(e.getPairEdge() == nullptr);
-  REQUIRE(e.getNextEdge() == nullptr);
-  REQUIRE(e.getFace() == nullptr);
+  REQUIRE(e.getVertexIndex() == UINT32_MAX);
+  REQUIRE(e.getPairEdgeIndex() == UINT32_MAX);
+  REQUIRE(e.getNextEdgeIndex() == UINT32_MAX);
+  REQUIRE(e.getFaceIndex() == UINT32_MAX);
   REQUIRE(e.getMetaData() == 0);
   REQUIRE(e.size() == 2);
 }
@@ -329,13 +301,12 @@ TEMPLATE_TEST_CASE("EdgeT: partial (vertex) constructor sets only the starting v
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
-  auto v  = std::make_shared<TestVertex<T>>(Vec3T<T>(1, 2, 3));
 
-  TestEdge<T> e(v);
-  REQUIRE(e.getVertex() == v);
-  REQUIRE(e.getPairEdge() == nullptr);
-  REQUIRE(e.getNextEdge() == nullptr);
-  REQUIRE(e.getFace() == nullptr);
+  TestEdge<T> e(3u);
+  REQUIRE(e.getVertexIndex() == 3);
+  REQUIRE(e.getPairEdgeIndex() == UINT32_MAX);
+  REQUIRE(e.getNextEdgeIndex() == UINT32_MAX);
+  REQUIRE(e.getFaceIndex() == UINT32_MAX);
   REQUIRE(e.getNormal() == Vec3T<T>::zeros());
 }
 
@@ -343,44 +314,43 @@ TEMPLATE_TEST_CASE("EdgeT: define, setVertex, setPairEdge, setNextEdge, setFace,
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto v1   = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
+  using T = TestType;
 
   TestEdge<T> e;
-  e.define(v1, pair, next);
-  REQUIRE(e.getVertex() == v1);
-  REQUIRE(e.getPairEdge() == pair);
-  REQUIRE(e.getNextEdge() == next);
+  e.define(1, 2, 3);
+  REQUIRE(e.getVertexIndex() == 1);
+  REQUIRE(e.getPairEdgeIndex() == 2);
+  REQUIRE(e.getNextEdgeIndex() == 3);
 
-  e.setFace(face);
-  REQUIRE(e.getFace() == face);
+  e.setFace(4);
+  REQUIRE(e.getFaceIndex() == 4);
 
   e.setMetaData(9);
   REQUIRE(e.getMetaData() == 9);
 
-  // Setting pointers to nullptr is explicitly valid.
-  e.setVertex(nullptr);
-  e.setPairEdge(nullptr);
-  e.setNextEdge(nullptr);
-  e.setFace(nullptr);
-  REQUIRE(e.getVertex() == nullptr);
-  REQUIRE(e.getPairEdge() == nullptr);
-  REQUIRE(e.getNextEdge() == nullptr);
-  REQUIRE(e.getFace() == nullptr);
+  // Setting indices to UINT32_MAX is explicitly valid.
+  e.setVertex(UINT32_MAX);
+  e.setPairEdge(UINT32_MAX);
+  e.setNextEdge(UINT32_MAX);
+  e.setFace(UINT32_MAX);
+  REQUIRE(e.getVertexIndex() == UINT32_MAX);
+  REQUIRE(e.getPairEdgeIndex() == UINT32_MAX);
+  REQUIRE(e.getNextEdgeIndex() == UINT32_MAX);
+  REQUIRE(e.getFaceIndex() == UINT32_MAX);
 }
 
 TEMPLATE_TEST_CASE("EdgeT: flipNormal negates the normal vector", "[DCEL][Edge]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(0, 0, 1), nullptr);
+  using T = TestType;
 
-  TestEdge<T> e;
-  e.setFace(face);
-  e.reconcile();
+  TestMesh<T> mesh;
+  mesh.getFaces().emplace_back();
+  mesh.getFaces()[0].define(Vec3T<T>(0, 0, 1), UINT32_MAX);
+  mesh.getEdges().emplace_back();
+  mesh.getEdges()[0].setFace(0);
+
+  auto& e = mesh.getEdges()[0];
+  e.reconcile(mesh);
 
   REQUIRE(e.getNormal() == Vec3T<T>(0, 0, 1));
   e.flipNormal();
@@ -391,35 +361,41 @@ TEMPLATE_TEST_CASE("EdgeT: computeNormal with a single face returns that face's 
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(1, 0, 0), nullptr);
+  using T = TestType;
 
-  TestEdge<T> e;
-  e.setFace(face);
+  TestMesh<T> mesh;
+  mesh.getFaces().emplace_back();
+  mesh.getFaces()[0].define(Vec3T<T>(1, 0, 0), UINT32_MAX);
+  mesh.getEdges().emplace_back();
+  mesh.getEdges()[0].setFace(0);
 
-  REQUIRE(e.computeNormal() == Vec3T<T>(1, 0, 0));
+  REQUIRE(mesh.getEdges()[0].computeNormal(mesh) == Vec3T<T>(1, 0, 0));
 }
 
 TEMPLATE_TEST_CASE("EdgeT: computeNormal averages both incident faces' normals",
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T       = TestType;
-  auto face     = std::make_shared<TestFace<T>>();
-  auto pairFace = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(1, 0, 0), nullptr);
-  pairFace->define(Vec3T<T>(0, 1, 0), nullptr);
+  using T = TestType;
 
-  auto pairEdge = std::make_shared<TestEdge<T>>();
-  pairEdge->setFace(pairFace);
+  TestMesh<T> mesh;
+  auto&       faces = mesh.getFaces();
+  auto&       edges = mesh.getEdges();
 
-  TestEdge<T> e;
-  e.setFace(face);
-  e.setPairEdge(pairEdge);
+  faces.emplace_back();
+  faces[0].define(Vec3T<T>(1, 0, 0), UINT32_MAX);
+  faces.emplace_back();
+  faces[1].define(Vec3T<T>(0, 1, 0), UINT32_MAX);
+
+  edges.emplace_back(); // edge under test
+  edges.emplace_back(); // its pair edge
+
+  edges[0].setFace(0);
+  edges[1].setFace(1);
+  edges[0].setPairEdge(1);
 
   const Vec3T<T> expected = Vec3T<T>(1, 1, 0) / Vec3T<T>(1, 1, 0).length();
-  const Vec3T<T> actual   = e.computeNormal();
+  const Vec3T<T> actual   = edges[0].computeNormal(mesh);
 
   REQUIRE_THAT(actual[0], withinAbsT(expected[0], exactMargin<T>()));
   REQUIRE_THAT(actual[1], withinAbsT(expected[1], exactMargin<T>()));
@@ -428,13 +404,16 @@ TEMPLATE_TEST_CASE("EdgeT: computeNormal averages both incident faces' normals",
 
 TEMPLATE_TEST_CASE("EdgeT: reconcile stores computeNormal's result", "[DCEL][Edge]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(0, 1, 0), nullptr);
+  using T = TestType;
 
-  TestEdge<T> e;
-  e.setFace(face);
-  e.reconcile();
+  TestMesh<T> mesh;
+  mesh.getFaces().emplace_back();
+  mesh.getFaces()[0].define(Vec3T<T>(0, 1, 0), UINT32_MAX);
+  mesh.getEdges().emplace_back();
+  mesh.getEdges()[0].setFace(0);
+
+  auto& e = mesh.getEdges()[0];
+  e.reconcile(mesh);
 
   REQUIRE(e.getNormal() == Vec3T<T>(0, 1, 0));
 }
@@ -444,114 +423,107 @@ TEMPLATE_TEST_CASE("EdgeT: signedDistance and unsignedDistance2 on a simple segm
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
-  // Build a two-vertex chain: e1 (start v1) -> e2 (start v2), so e1's "other vertex" is v2.
-  auto v1 = std::make_shared<TestVertex<T>>(Vec3T<T>(0, 0, 0));
-  auto v2 = std::make_shared<TestVertex<T>>(Vec3T<T>(1, 0, 0));
 
-  auto e1 = std::make_shared<TestEdge<T>>();
-  auto e2 = std::make_shared<TestEdge<T>>();
-  e1->define(v1, nullptr, e2);
-  e2->setVertex(v2);
+  TestMesh<T> mesh;
+  auto&       vertices = mesh.getVertices();
+  auto&       edges    = mesh.getEdges();
+  auto&       faces    = mesh.getFaces();
+
+  // Build a two-vertex chain: e0 (start v0) -> e1 (start v1), so e0's "other vertex" is v1.
+  vertices.emplace_back(Vec3T<T>(0, 0, 0));
+  vertices.emplace_back(Vec3T<T>(1, 0, 0));
+
+  edges.emplace_back(0u);
+  edges.emplace_back(1u);
+  edges[0].setNextEdge(1);
 
   // Outward normal perpendicular to the edge, pointing +y.
-  auto face = std::make_shared<TestFace<T>>();
-  face->define(Vec3T<T>(0, 1, 0), nullptr);
-  e1->setFace(face);
-  e1->reconcile();
+  faces.emplace_back();
+  faces[0].define(Vec3T<T>(0, 1, 0), UINT32_MAX);
+  edges[0].setFace(0);
+  edges[0].reconcile(mesh);
 
-  REQUIRE(e1->getOtherVertex() == v2);
+  REQUIRE(edges[0].getOtherVertex(mesh).getPosition() == vertices[1].getPosition());
 
   // Point above the middle of the edge: on the normal side, distance 2.
-  REQUIRE_THAT(e1->signedDistance(Vec3T<T>(0.5, 2, 0)), WithinRel(T(2.0)));
+  REQUIRE_THAT(edges[0].signedDistance(Vec3T<T>(0.5, 2, 0), mesh), WithinRel(T(2.0)));
 
   // Point below the middle of the edge: against the normal, negative distance.
-  REQUIRE_THAT(e1->signedDistance(Vec3T<T>(0.5, -2, 0)), WithinRel(T(-2.0)));
+  REQUIRE_THAT(edges[0].signedDistance(Vec3T<T>(0.5, -2, 0), mesh), WithinRel(T(-2.0)));
 
   // unsignedDistance2 clamps the projection to the segment.
-  REQUIRE_THAT(e1->unsignedDistance2(Vec3T<T>(0.5, 3, 0)), WithinRel(T(9.0)));
+  REQUIRE_THAT(edges[0].unsignedDistance2(Vec3T<T>(0.5, 3, 0), mesh), WithinRel(T(9.0)));
 }
 
-TEMPLATE_TEST_CASE("EdgeT: copy construction copies topology pointers but not meta-data",
+TEMPLATE_TEST_CASE("EdgeT: copy construction copies every member, including meta-data",
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto v    = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
+  using T = TestType;
 
   TestEdge<T> src;
-  src.define(v, pair, next);
-  src.setFace(face);
+  src.define(1, 2, 3);
+  src.setFace(4);
   src.setMetaData(42);
 
   TestEdge<T> copy(src);
-  REQUIRE(copy.getVertex() == v);
-  REQUIRE(copy.getPairEdge() == pair);
-  REQUIRE(copy.getNextEdge() == next);
-  REQUIRE(copy.getFace() == face);
-  REQUIRE(copy.getMetaData() == 0);
+  REQUIRE(copy.getVertexIndex() == 1);
+  REQUIRE(copy.getPairEdgeIndex() == 2);
+  REQUIRE(copy.getNextEdgeIndex() == 3);
+  REQUIRE(copy.getFaceIndex() == 4);
+  REQUIRE(copy.getMetaData() == 42);
 }
 
 TEMPLATE_TEST_CASE("EdgeT: copy assignment has the same semantics as copy construction",
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto v    = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
+  using T = TestType;
 
   TestEdge<T> src;
-  src.define(v, pair, next);
-  src.setFace(face);
+  src.define(1, 2, 3);
+  src.setFace(4);
   src.setMetaData(42);
 
   TestEdge<T> dst;
   dst = src;
 
-  REQUIRE(dst.getVertex() == v);
-  REQUIRE(dst.getPairEdge() == pair);
-  REQUIRE(dst.getNextEdge() == next);
-  REQUIRE(dst.getFace() == face);
-  REQUIRE(dst.getMetaData() == 0);
+  REQUIRE(dst.getVertexIndex() == 1);
+  REQUIRE(dst.getPairEdgeIndex() == 2);
+  REQUIRE(dst.getNextEdgeIndex() == 3);
+  REQUIRE(dst.getFaceIndex() == 4);
+  REQUIRE(dst.getMetaData() == 42);
 }
 
 TEMPLATE_TEST_CASE("EdgeT: move construction and move assignment transfer the entire state",
                    "[DCEL][Edge]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto v    = std::make_shared<TestVertex<T>>();
-  auto pair = std::make_shared<TestEdge<T>>();
-  auto next = std::make_shared<TestEdge<T>>();
-  auto face = std::make_shared<TestFace<T>>();
+  using T = TestType;
 
   TestEdge<T> moveCtorSrc;
-  moveCtorSrc.define(v, pair, next);
-  moveCtorSrc.setFace(face);
+  moveCtorSrc.define(1, 2, 3);
+  moveCtorSrc.setFace(4);
   moveCtorSrc.setMetaData(42);
 
   TestEdge<T> moved(std::move(moveCtorSrc));
-  REQUIRE(moved.getVertex() == v);
-  REQUIRE(moved.getPairEdge() == pair);
-  REQUIRE(moved.getNextEdge() == next);
-  REQUIRE(moved.getFace() == face);
+  REQUIRE(moved.getVertexIndex() == 1);
+  REQUIRE(moved.getPairEdgeIndex() == 2);
+  REQUIRE(moved.getNextEdgeIndex() == 3);
+  REQUIRE(moved.getFaceIndex() == 4);
   REQUIRE(moved.getMetaData() == 42);
 
   TestEdge<T> moveAssignSrc;
-  moveAssignSrc.define(v, pair, next);
-  moveAssignSrc.setFace(face);
+  moveAssignSrc.define(1, 2, 3);
+  moveAssignSrc.setFace(4);
   moveAssignSrc.setMetaData(7);
 
   TestEdge<T> moveAssignDst;
   moveAssignDst = std::move(moveAssignSrc);
-  REQUIRE(moveAssignDst.getVertex() == v);
-  REQUIRE(moveAssignDst.getPairEdge() == pair);
-  REQUIRE(moveAssignDst.getNextEdge() == next);
-  REQUIRE(moveAssignDst.getFace() == face);
+  REQUIRE(moveAssignDst.getVertexIndex() == 1);
+  REQUIRE(moveAssignDst.getPairEdgeIndex() == 2);
+  REQUIRE(moveAssignDst.getNextEdgeIndex() == 3);
+  REQUIRE(moveAssignDst.getFaceIndex() == 4);
   REQUIRE(moveAssignDst.getMetaData() == 7);
 }
 
@@ -566,50 +538,54 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: iterating a face visits exactly its own half-
                    "[DCEL][Iterator]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
+  using T = TestType;
 
-  std::vector<std::shared_ptr<TestEdge<T>>> visited;
-  for (TestEdgeIterator<T> it(*face); it.ok(); ++it) {
-    REQUIRE(it()->getFace() == face);
+  auto        mesh = buildTetrahedron<T>();
+  const auto& face = mesh->getFaces()[0];
+
+  std::vector<uint32_t> visited;
+  for (TestEdgeIterator<T> it(*mesh, face); it.ok(); ++it) {
+    REQUIRE(mesh->getEdges()[it()].getFaceIndex() == 0);
     visited.push_back(it());
   }
 
   REQUIRE(visited.size() == 3); // Every face in a tetrahedron is a triangle.
-  REQUIRE(visited[0] == face->getHalfEdge());
-  REQUIRE(visited[0]->getNextEdge() == visited[1]);
-  REQUIRE(visited[1]->getNextEdge() == visited[2]);
-  REQUIRE(visited[2]->getNextEdge() == visited[0]); // Loops back to the start.
+  REQUIRE(visited[0] == face.getHalfEdgeIndex());
+  REQUIRE(mesh->getEdges()[visited[0]].getNextEdgeIndex() == visited[1]);
+  REQUIRE(mesh->getEdges()[visited[1]].getNextEdgeIndex() == visited[2]);
+  REQUIRE(mesh->getEdges()[visited[2]].getNextEdgeIndex() == visited[0]); // Loops back to the start.
 }
 
-TEMPLATE_TEST_CASE("EdgeIteratorT: constructing from an edge directly matches constructing from its face",
+TEMPLATE_TEST_CASE("EdgeIteratorT: constructing from an edge index directly matches constructing from its face",
                    "[DCEL][Iterator]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
+  using T = TestType;
 
-  std::vector<std::shared_ptr<TestEdge<T>>> fromFace;
-  for (TestEdgeIterator<T> it(*face); it.ok(); ++it) {
+  auto        mesh = buildTetrahedron<T>();
+  const auto& face = mesh->getFaces()[0];
+
+  std::vector<uint32_t> fromFace;
+  for (TestEdgeIterator<T> it(*mesh, face); it.ok(); ++it) {
     fromFace.push_back(it());
   }
 
-  std::vector<std::shared_ptr<TestEdge<T>>> fromEdge;
-  for (TestEdgeIterator<T> it(face->getHalfEdge()); it.ok(); ++it) {
+  std::vector<uint32_t> fromEdge;
+  for (TestEdgeIterator<T> it(*mesh, face.getHalfEdgeIndex()); it.ok(); ++it) {
     fromEdge.push_back(it());
   }
 
   REQUIRE(fromFace == fromEdge);
 }
 
-TEMPLATE_TEST_CASE("EdgeIteratorT: ok() is immediately false for a null starting edge",
+TEMPLATE_TEST_CASE("EdgeIteratorT: ok() is immediately false for an unset starting edge index",
                    "[DCEL][Iterator]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
-  TestEdgeIterator<T> it(std::shared_ptr<TestEdge<T>>(nullptr));
+
+  TestMesh<T>         mesh;
+  TestEdgeIterator<T> it(mesh, UINT32_MAX);
   REQUIRE_FALSE(it.ok());
 }
 
@@ -617,11 +593,12 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: reset returns the iterator to its starting ed
                    "[DCEL][Iterator]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
+  using T = TestType;
 
-  TestEdgeIterator<T> it(*face);
+  auto        mesh = buildTetrahedron<T>();
+  const auto& face = mesh->getFaces()[0];
+
+  TestEdgeIterator<T> it(*mesh, face);
   const auto          start = it();
 
   ++it;
@@ -637,11 +614,12 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: copy and move both preserve iteration state",
                    "[DCEL][Iterator]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
-  auto face = mesh->getFaces()[0];
+  using T = TestType;
 
-  TestEdgeIterator<T> src(*face);
+  auto        mesh = buildTetrahedron<T>();
+  const auto& face = mesh->getFaces()[0];
+
+  TestEdgeIterator<T> src(*mesh, face);
   ++src;
   const auto afterOneStep = src();
 
@@ -650,14 +628,14 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: copy and move both preserve iteration state",
   ++copied;
   REQUIRE(copied() != src()); // Independent copies: advancing one must not advance the other.
 
-  TestEdgeIterator<T> copyAssigned(*face);
+  TestEdgeIterator<T> copyAssigned(*mesh, face);
   copyAssigned = src;
   REQUIRE(copyAssigned() == afterOneStep);
 
   TestEdgeIterator<T> moved(std::move(src));
   REQUIRE(moved() == afterOneStep);
 
-  TestEdgeIterator<T> moveAssigned(*face);
+  TestEdgeIterator<T> moveAssigned(*mesh, face);
   moveAssigned = std::move(copied);
   REQUIRE(moveAssigned.ok());
 }
@@ -686,19 +664,20 @@ TEMPLATE_TEST_CASE("MeshT: full constructor assigns vertices, edges, and faces",
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T                                           = TestType;
-  std::vector<std::shared_ptr<TestVertex<T>>> verts = {std::make_shared<TestVertex<T>>()};
-  std::vector<std::shared_ptr<TestEdge<T>>>   edges = {std::make_shared<TestEdge<T>>()};
-  std::vector<std::shared_ptr<TestFace<T>>>   faces = {std::make_shared<TestFace<T>>()};
+  using T = TestType;
+
+  std::vector<TestVertex<T>> verts = {TestVertex<T>(Vec3T<T>(1, 2, 3))};
+  std::vector<TestEdge<T>>   edges = {TestEdge<T>(0u)};
+  std::vector<TestFace<T>>   faces = {TestFace<T>(0u)};
 
   TestMesh<T> mesh(faces, edges, verts);
 
   REQUIRE(mesh.getVertices().size() == 1);
   REQUIRE(mesh.getEdges().size() == 1);
   REQUIRE(mesh.getFaces().size() == 1);
-  REQUIRE(mesh.getVertices()[0] == verts[0]);
-  REQUIRE(mesh.getEdges()[0] == edges[0]);
-  REQUIRE(mesh.getFaces()[0] == faces[0]);
+  REQUIRE(mesh.getVertices()[0].getPosition() == Vec3T<T>(1, 2, 3));
+  REQUIRE(mesh.getEdges()[0].getVertexIndex() == 0);
+  REQUIRE(mesh.getFaces()[0].getHalfEdgeIndex() == 0);
 }
 
 TEMPLATE_TEST_CASE("MeshT: copy is disallowed, move is allowed", "[DCEL][Mesh]", EBGEOMETRY_TEST_PRECISIONS)
@@ -714,21 +693,22 @@ TEMPLATE_TEST_CASE("MeshT: move construction and move assignment transfer owners
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T          = TestType;
-  auto moveCtorSrc = buildTetrahedron<T>();
-  auto v0          = moveCtorSrc->getVertices()[0];
+  using T = TestType;
+
+  auto       moveCtorSrc = buildTetrahedron<T>();
+  const auto v0Position  = moveCtorSrc->getVertices()[0].getPosition();
 
   TestMesh<T> moved(std::move(*moveCtorSrc));
   REQUIRE(moved.getVertices().size() == 4);
   REQUIRE(moved.getFaces().size() == 4);
-  REQUIRE(moved.getVertices()[0] == v0);
+  REQUIRE(moved.getVertices()[0].getPosition() == v0Position);
 
   auto        moveAssignSrc = buildTetrahedron<T>();
-  auto        v0b           = moveAssignSrc->getVertices()[0];
+  const auto  v0PositionB   = moveAssignSrc->getVertices()[0].getPosition();
   TestMesh<T> moveAssignDst;
   moveAssignDst = std::move(*moveAssignSrc);
   REQUIRE(moveAssignDst.getVertices().size() == 4);
-  REQUIRE(moveAssignDst.getVertices()[0] == v0b);
+  REQUIRE(moveAssignDst.getVertices()[0].getPosition() == v0PositionB);
 }
 
 TEMPLATE_TEST_CASE("MeshT: reconcile computes positive face areas and unit-length normals",
@@ -739,8 +719,8 @@ TEMPLATE_TEST_CASE("MeshT: reconcile computes positive face areas and unit-lengt
   auto mesh = buildTetrahedron<T>();
 
   for (const auto& f : mesh->getFaces()) {
-    REQUIRE(f->getArea() > T(0.0));
-    REQUIRE_THAT(f->getNormal().length(), withinAbsT(T(1.0), exactMargin<T>()));
+    REQUIRE(f.getArea() > T(0.0));
+    REQUIRE_THAT(f.getNormal().length(), withinAbsT(T(1.0), exactMargin<T>()));
   }
 }
 
@@ -751,25 +731,25 @@ TEMPLATE_TEST_CASE("MeshT: flip negates all vertex, edge, and face normals", "[D
 
   std::vector<Vec3T<T>> vertexNormals, edgeNormals, faceNormals;
   for (const auto& v : mesh->getVertices()) {
-    vertexNormals.push_back(v->getNormal());
+    vertexNormals.push_back(v.getNormal());
   }
   for (const auto& e : mesh->getEdges()) {
-    edgeNormals.push_back(e->getNormal());
+    edgeNormals.push_back(e.getNormal());
   }
   for (const auto& f : mesh->getFaces()) {
-    faceNormals.push_back(f->getNormal());
+    faceNormals.push_back(f.getNormal());
   }
 
   mesh->flip();
 
   for (size_t i = 0; i < mesh->getVertices().size(); i++) {
-    REQUIRE((mesh->getVertices()[i]->getNormal() - (-vertexNormals[i])).length() < T(exactMargin<T>()));
+    REQUIRE((mesh->getVertices()[i].getNormal() - (-vertexNormals[i])).length() < T(exactMargin<T>()));
   }
   for (size_t i = 0; i < mesh->getEdges().size(); i++) {
-    REQUIRE((mesh->getEdges()[i]->getNormal() - (-edgeNormals[i])).length() < T(exactMargin<T>()));
+    REQUIRE((mesh->getEdges()[i].getNormal() - (-edgeNormals[i])).length() < T(exactMargin<T>()));
   }
   for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE((mesh->getFaces()[i]->getNormal() - (-faceNormals[i])).length() < T(exactMargin<T>()));
+    REQUIRE((mesh->getFaces()[i].getNormal() - (-faceNormals[i])).length() < T(exactMargin<T>()));
   }
 }
 
@@ -819,7 +799,7 @@ TEMPLATE_TEST_CASE("MeshT: getAllVertexCoordinates matches the vertex positions"
   REQUIRE(coords.size() == mesh->getVertices().size());
 
   for (size_t i = 0; i < coords.size(); i++) {
-    REQUIRE(coords[i] == mesh->getVertices()[i]->getPosition());
+    REQUIRE(coords[i] == mesh->getVertices()[i].getPosition());
   }
 }
 
@@ -836,14 +816,9 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy produces an independent mesh with the same g
   REQUIRE(copy->getEdges().size() == mesh->getEdges().size());
   REQUIRE(copy->getFaces().size() == mesh->getFaces().size());
 
-  // Topology must be fully decoupled: no shared vertex/edge/face pointers.
-  for (size_t i = 0; i < mesh->getVertices().size(); i++) {
-    REQUIRE(copy->getVertices()[i] != mesh->getVertices()[i]);
-  }
   for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE(copy->getFaces()[i] != mesh->getFaces()[i]);
-    REQUIRE((copy->getFaces()[i]->getNormal() - mesh->getFaces()[i]->getNormal()).length() < T(exactMargin<T>()));
-    REQUIRE_THAT(copy->getFaces()[i]->getArea(), withinAbsT(mesh->getFaces()[i]->getArea(), exactMargin<T>()));
+    REQUIRE((copy->getFaces()[i].getNormal() - mesh->getFaces()[i].getNormal()).length() < T(exactMargin<T>()));
+    REQUIRE_THAT(copy->getFaces()[i].getArea(), withinAbsT(mesh->getFaces()[i].getArea(), exactMargin<T>()));
   }
 
   // The copy must be usable for signed-distance queries (validates that the projection axes were
@@ -852,9 +827,10 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy produces an independent mesh with the same g
   const Vec3T<T> p(0.1, 0.1, 0.1);
   REQUIRE_THAT(copy->signedDistance(p), withinAbsT(mesh->signedDistance(p), formulaMargin<T>()));
 
-  // Mutating the copy must not affect the original.
-  copy->getVertices()[0]->setPosition(Vec3T<T>(999, 999, 999));
-  REQUIRE(mesh->getVertices()[0]->getPosition() != Vec3T<T>(999, 999, 999));
+  // Mutating the copy must not affect the original -- this is the meaningful test of independence
+  // now that vertices/edges/faces are plain values rather than shared_ptr-identified objects.
+  copy->getVertices()[0].setPosition(Vec3T<T>(999, 999, 999));
+  REQUIRE(mesh->getVertices()[0].getPosition() != Vec3T<T>(999, 999, 999));
 }
 
 TEMPLATE_TEST_CASE("MeshT: deepCopy preserves a prior flip() instead of silently re-deriving normals",
@@ -868,7 +844,7 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy preserves a prior flip() instead of silently
   auto copy = mesh->deepCopy();
 
   for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE((copy->getFaces()[i]->getNormal() - mesh->getFaces()[i]->getNormal()).length() < T(exactMargin<T>()));
+    REQUIRE((copy->getFaces()[i].getNormal() - mesh->getFaces()[i].getNormal()).length() < T(exactMargin<T>()));
   }
 }
 
@@ -967,9 +943,10 @@ TEMPLATE_TEST_CASE("Soup::soupToDCEL reconciles every half-edge's pair edge on a
   using T   = TestType;
   auto mesh = buildTetrahedron<T>();
 
-  for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr);
-    REQUIRE(e->getPairEdge()->getPairEdge() == e); // Pairing must be symmetric.
+  const auto& edges = mesh->getEdges();
+  for (uint32_t i = 0; i < edges.size(); i++) {
+    REQUIRE(edges[i].getPairEdgeIndex() != UINT32_MAX);
+    REQUIRE(edges[edges[i].getPairEdgeIndex()].getPairEdgeIndex() == i); // Pairing must be symmetric.
   }
 }
 
@@ -1005,8 +982,7 @@ TEMPLATE_TEST_CASE("DCEL: all faces have a half-edge", "[DCEL]", EBGEOMETRY_TEST
   REQUIRE(mesh != nullptr);
 
   for (const auto& face : mesh->getFaces()) {
-    REQUIRE(face != nullptr);
-    REQUIRE(face->getHalfEdge() != nullptr);
+    REQUIRE(face.getHalfEdgeIndex() != UINT32_MAX);
   }
 }
 
@@ -1017,9 +993,8 @@ TEMPLATE_TEST_CASE("DCEL: all half-edges have a pair and a face", "[DCEL]", EBGE
   REQUIRE(mesh != nullptr);
 
   for (const auto& edge : mesh->getEdges()) {
-    REQUIRE(edge != nullptr);
-    REQUIRE(edge->getPairEdge() != nullptr);
-    REQUIRE(edge->getFace() != nullptr);
+    REQUIRE(edge.getPairEdgeIndex() != UINT32_MAX);
+    REQUIRE(edge.getFaceIndex() != UINT32_MAX);
   }
 }
 
@@ -1030,7 +1005,7 @@ TEMPLATE_TEST_CASE("DCEL: all face normals are unit-length", "[DCEL]", EBGEOMETR
   REQUIRE(mesh != nullptr);
 
   for (const auto& face : mesh->getFaces()) {
-    REQUIRE_THAT(face->getNormal().length(), withinAbsT(T(1.0), formulaMargin<T>()));
+    REQUIRE_THAT(face.getNormal().length(), withinAbsT(T(1.0), formulaMargin<T>()));
   }
 }
 

--- a/Tests/TestOBJ.cpp
+++ b/Tests/TestOBJ.cpp
@@ -134,6 +134,6 @@ TEMPLATE_TEST_CASE("OBJ: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestPLY.cpp
+++ b/Tests/TestPLY.cpp
@@ -164,6 +164,6 @@ TEMPLATE_TEST_CASE("PLY: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestPolygon2D.cpp
+++ b/Tests/TestPolygon2D.cpp
@@ -30,54 +30,72 @@ allAlgorithms()
 }
 
 // Test-only subclass that exposes FaceT's protected point-in-face test (used internally by
-// signedDistance()) so the containment algorithms can be exercised directly.
+// signedDistance()) so the containment algorithms can be exercised directly. MeshT stores plain
+// FaceT<T,Meta> by value (no polymorphism), so this can't be the type actually stored in a mesh's
+// face array; instead, castIsPointInsideFace() below reinterprets a real mesh-owned FaceT as this
+// subclass to call the promoted method. That's safe here because AccessibleFace adds no data
+// members and no virtual functions -- the `using` declaration only changes name visibility, so the
+// call resolves to the exact same non-virtual FaceT method on the exact same object.
 template <class T>
 struct AccessibleFace : public DCEL::FaceT<T, DCEL::DefaultMetaData>
 {
   using DCEL::FaceT<T, DCEL::DefaultMetaData>::isPointInsideFace;
 };
 
-// A single DCEL face wired up from a vertex list, holding its vertices/edges alive so the face's
-// on-the-fly (half-edge-walking) containment test can be queried. reconcile() derives the normal,
-// centroid, and 2D-projection axes from the geometry, matching how a parsed mesh's faces are set up.
+template <class T>
+[[nodiscard]] bool
+castIsPointInsideFace(DCEL::FaceT<T, DCEL::DefaultMetaData>&       a_face,
+                      const Vec3T<T>&                              a_point,
+                      const DCEL::MeshT<T, DCEL::DefaultMetaData>& a_mesh)
+{
+  return static_cast<AccessibleFace<T>&>(a_face).isPointInsideFace(a_point, a_mesh);
+}
+
+// A single DCEL face wired up from a vertex list, held inside a real DCEL::MeshT so the face's
+// on-the-fly (half-edge-walking, index-based) containment test can be queried against it.
+// reconcile() derives the normal, centroid, and 2D-projection axes from the geometry, matching how
+// a parsed mesh's faces are set up.
 template <class T>
 struct BuiltFace
 {
-  using Vertex = DCEL::VertexT<T, DCEL::DefaultMetaData>;
-  using Edge   = DCEL::EdgeT<T, DCEL::DefaultMetaData>;
-  using Face   = AccessibleFace<T>;
+  using Meta = DCEL::DefaultMetaData;
+  using Mesh = DCEL::MeshT<T, Meta>;
 
-  std::shared_ptr<Face>                m_face;
-  std::vector<std::shared_ptr<Vertex>> m_vertices;
-  std::vector<std::shared_ptr<Edge>>   m_edges;
+  Mesh m_mesh;
 
   explicit BuiltFace(const std::vector<Vec3T<T>>& a_positions)
   {
-    const size_t N = a_positions.size();
+    const uint32_t N = static_cast<uint32_t>(a_positions.size());
 
-    m_face = std::make_shared<Face>();
+    auto& vertices = m_mesh.getVertices();
+    auto& edges    = m_mesh.getEdges();
+    auto& faces    = m_mesh.getFaces();
 
-    for (size_t i = 0; i < N; i++) {
-      m_vertices.push_back(std::make_shared<Vertex>(a_positions[i]));
-      m_edges.push_back(std::make_shared<Edge>());
+    for (const auto& p : a_positions) {
+      vertices.emplace_back(p);
     }
 
-    for (size_t i = 0; i < N; i++) {
-      m_edges[i]->setVertex(m_vertices[i]);
-      m_edges[i]->setNextEdge(m_edges[(i + 1) % N]);
-      m_edges[i]->setFace(m_face);
+    for (uint32_t i = 0; i < N; i++) {
+      edges.emplace_back(i); // half-edge i starts at vertex i
     }
 
-    m_face->setHalfEdge(m_edges[0]);
-    m_face->reconcile();
+    for (uint32_t i = 0; i < N; i++) {
+      edges[i].setNextEdge((i + 1) % N);
+      edges[i].setFace(0);
+    }
+
+    faces.emplace_back(0u); // half-edge index 0
+    faces[0].reconcile(m_mesh);
   }
 
   [[nodiscard]] bool
-  isPointInside(const Vec3T<T>& a_point, DCEL::InsideOutsideAlgorithm a_algorithm) const
+  isPointInside(const Vec3T<T>& a_point, DCEL::InsideOutsideAlgorithm a_algorithm)
   {
-    m_face->setInsideOutsideAlgorithm(a_algorithm);
+    auto& face = m_mesh.getFaces()[0];
 
-    return m_face->isPointInsideFace(a_point);
+    face.setInsideOutsideAlgorithm(a_algorithm);
+
+    return castIsPointInsideFace(face, a_point, m_mesh);
   }
 };
 
@@ -113,7 +131,7 @@ TEMPLATE_TEST_CASE("FaceT: a point clearly inside a square reads as inside for e
   using T    = TestType;
   using Vec3 = Vec3T<T>;
 
-  const BuiltFace<T> square = unitSquare<T>();
+  BuiltFace<T> square = unitSquare<T>();
 
   for (const auto algo : allAlgorithms<T>()) {
     REQUIRE(square.isPointInside(Vec3(0.5, 0.5, 0), algo));
@@ -127,7 +145,7 @@ TEMPLATE_TEST_CASE("FaceT: a point clearly outside a square reads as outside for
   using T    = TestType;
   using Vec3 = Vec3T<T>;
 
-  const BuiltFace<T> square = unitSquare<T>();
+  BuiltFace<T> square = unitSquare<T>();
 
   for (const auto algo : allAlgorithms<T>()) {
     REQUIRE_FALSE(square.isPointInside(Vec3(2, 2, 0), algo));
@@ -142,7 +160,7 @@ TEMPLATE_TEST_CASE("FaceT: containment ignores the coordinate normal to the poly
   using T    = TestType;
   using Vec3 = Vec3T<T>;
 
-  const BuiltFace<T> square = unitSquare<T>();
+  BuiltFace<T> square = unitSquare<T>();
 
   // The polygon lies in z=0, but containment only depends on (x, y): the projection direction
   // discards z, so a point "floating" well above or below the plane still reads as inside when its
@@ -160,7 +178,7 @@ TEMPLATE_TEST_CASE("FaceT: a concave polygon correctly excludes points in its no
   using T    = TestType;
   using Vec3 = Vec3T<T>;
 
-  const BuiltFace<T> lPolygon = lShape<T>();
+  BuiltFace<T> lPolygon = lShape<T>();
 
   // Inside the solid part of the L.
   for (const auto algo : allAlgorithms<T>()) {
@@ -186,7 +204,7 @@ TEMPLATE_TEST_CASE("FaceT: containment works for a triangle in a non-axis-aligne
   using Vec3 = Vec3T<T>;
 
   // A triangle in the plane x + y + z = 3, with an oblique (but not axis-aligned) normal.
-  const BuiltFace<T> triangle({Vec3(3, 0, 0), Vec3(0, 3, 0), Vec3(0, 0, 3)});
+  BuiltFace<T> triangle({Vec3(3, 0, 0), Vec3(0, 3, 0), Vec3(0, 0, 3)});
 
   // The triangle's centroid (1, 1, 1) must project to the inside.
   for (const auto algo : allAlgorithms<T>()) {
@@ -206,7 +224,7 @@ TEMPLATE_TEST_CASE("FaceT: the three containment algorithms agree over a grid of
   using T    = TestType;
   using Vec3 = Vec3T<T>;
 
-  const BuiltFace<T> lPolygon = lShape<T>();
+  BuiltFace<T> lPolygon = lShape<T>();
 
   // Offset the grid so it never lands exactly on one of the L-shape's edges or vertices (all at
   // multiples of 0.25) -- boundary points are inherently ambiguous between algorithms and aren't a

--- a/Tests/TestSTL.cpp
+++ b/Tests/TestSTL.cpp
@@ -172,6 +172,6 @@ TEMPLATE_TEST_CASE("Parser::readSTL + convertToDCEL round-trips into a valid, wa
   REQUIRE(mesh->getEdges().size() == 12);
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestVTK.cpp
+++ b/Tests/TestVTK.cpp
@@ -164,6 +164,6 @@ TEMPLATE_TEST_CASE("VTK: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
 
   for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e->getPairEdge() != nullptr); // Watertight: every half-edge has a pair.
+    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }


### PR DESCRIPTION
## Summary

### Background

This is the second PR in the DCEL GPU-porting sequence (following #137, which removed
`Polygon2D` by folding point-in-face containment into `FaceT`). The goal of the overall
port is to migrate the library's core data structures onto a POD memory layer suitable
for CUDA/HIP, and DCEL's `weak_ptr`/`shared_ptr` topology was the next blocker: a class
holding a `weak_ptr` can never be trivially copyable, and trivial copyability is a
prerequisite for `memcpy`-based host-to-device mirroring.

### Solution

`VertexT`/`EdgeT`/`FaceT` cross-references (outgoing edge, vertex/pair-edge/next-edge/face,
half-edge) are now plain `uint32_t` indices into the owning `MeshT`'s own
vertex/edge/face arrays (`UINT32_MAX` sentinel for "unset"), replacing the `weak_ptr`
back-reference scheme. `MeshT` stores its three arrays by value instead of
`vector<shared_ptr<...>>`.

All three primitive classes are now trivially copyable given trivially-copyable `T`/`Meta`
(verified by `static_assert` in each header): every member is a plain value, and copy/move
construction/assignment are defaulted — copying everything, including meta-data, rather
than the old narrow/metadata-excluding copy. Methods that need to resolve an index take
the owning mesh as an explicit parameter, mirroring the existing `Pool`/`PODVector`
base+offset convention already used elsewhere in the GPU port.

`VertexT` drops its per-vertex face-adjacency list entirely: pseudonormal computation
(`computeVertexNormalAverage`/`AngleWeighted`) now takes the touching-face list as an
explicit parameter, rebuilt transiently by `MeshT::reconcileVertices()` by walking each
face's own boundary loop (no pair edges needed) — so non-watertight/"dirty" meshes are
still supported exactly as before, just without a permanently-stored adjacency list.

`MeshT::deepCopy()` simplifies substantially: since every cross-reference is now an index
rather than an address, copying the three arrays is already a correct, fully independent
mesh with no relinking pass required (this removed ~50 lines of allocate-and-remap logic).

`Soup::soupToDCEL`/`reconcilePairEdgesDCEL`, `MeshDistanceFunctions`
(`MeshSDF`/`TriMeshSDF`/`buildDCELTreeBVH`), and `Parser::readIntoTriangles` are updated
for the new API. Pair-edge reconciliation uses a transient (not stored) vertex→edges
lookup instead of the removed per-vertex face list, keeping the same O(V+E) complexity.

Tests updated throughout (`TestDCEL` rewritten, `TestBVH`/`TestPolygon2D`/parser tests
adjusted); `TestPolygon2D`'s `AccessibleFace` helper now builds a real backing `MeshT`,
since `FaceT`'s containment test requires one to resolve its topology.

Docs: `ImplemDCEL.rst` and `Implementation.rst` updated to describe the index-based
topology instead of the old `weak_ptr` scheme.

### Side-effects

- `VertexT::getFaces()`/`addFace()` (the cached per-vertex face-pointer list) are removed
  from the public API — this was tested directly in `TestDCEL.cpp` and is now gone. Any
  external code enumerating a vertex's incident faces via this API would need to switch to
  scanning the mesh's face array (or a future public traversal helper, not added here).
- `FaceT::gatherVertices()`/`gatherEdges()` are renamed to `gatherVertexIndices()`/
  `gatherEdgeIndices()` and now return indices rather than `shared_ptr` lists.
- `FaceT::getHalfEdge()` is renamed to `getHalfEdgeIndex()`.
- Every `EdgeT`/`FaceT` accessor that walks topology (`getVertex()`, `getNextEdge()`,
  `signedDistance()`, `isPointInsideFace()`, etc.) now takes the owning `MeshT` as an
  additional parameter.

### Alternative solutions

An earlier draft cached a raw pointer to the mesh's arrays on every `VertexT`/`EdgeT`/`FaceT`
instance (matching how a reference early-GPU-port attempt, EBGeometry-dev, does it) instead
of taking the mesh as an explicit parameter. That was rejected: a cached pointer is only
valid in the address space it was set in, so mirroring to device would require an
additional per-element pointer-patching pass — exactly what the offset-based `Pool`/
`PODVector` design was built to avoid.

### Validation

- `ctest --preset debug` (both precisions): 560/560 passing.
- `ctest --preset release-test -L unit` (`-Werror`): 298/298 passing.
- `ctest --preset examples`: 11/11 passing.
- `clang-format`, Doxygen (0 warnings), Sphinx HTML all clean.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation.
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.


---
_Generated by [Claude Code](https://claude.ai/code/session_0142n7QLFLTVsXJKJ8hcx3DS)_