### PR TITLE
DCEL: migrate MeshT storage onto Pool-backed PODVector arrays

### DIFF
--- a/Docs/Sphinx/source/ConfigurationOptions.rst
+++ b/Docs/Sphinx/source/ConfigurationOptions.rst
@@ -21,8 +21,11 @@ when instantiating a class or calling a function template:
 
 .. code-block:: cpp
 
-   auto sdfDouble = EBGeometry::Parser::readIntoTriangleBVH<double>("bunny.ply");
-   auto sdfFloat  = EBGeometry::Parser::readIntoTriangleBVH<float>("bunny.ply");
+   EBGeometry::Pool poolDouble(EBGeometry::hostMemoryResource());
+   EBGeometry::Pool poolFloat(EBGeometry::hostMemoryResource());
+
+   auto sdfDouble = EBGeometry::Parser::readIntoTriangleBVH<double>("bunny.ply", poolDouble);
+   auto sdfFloat  = EBGeometry::Parser::readIntoTriangleBVH<float>("bunny.ply", poolFloat);
 
 Consuming code (including every example under :file:`Examples/`) typically reads precision from
 a preprocessor define so it can be overridden from the build system without editing source:

--- a/Docs/Sphinx/source/ImplemDCEL.rst
+++ b/Docs/Sphinx/source/ImplemDCEL.rst
@@ -60,7 +60,11 @@ instance:
    every packed face's ``signedDistance()``/``unsignedDistance2()`` call, since a face's half-edge
    index is only meaningful together with the mesh it was built from. A mesh is typically never
    constructed by hand -- it is built by a file parser reading vertices and faces from disk, see
-   :ref:`Chap:Parsers`. For the full API, see the Doxygen reference for
+   :ref:`Chap:Parsers`. Its vertex/edge/face arrays are reserved from a caller-supplied, non-owning
+   `Pool <doxygen/html/classEBGeometry_1_1Pool.html>`__ passed to its constructor (and, one level up,
+   to every ``Parser::readInto*`` entry point) -- the caller owns and manages the Pool's lifetime,
+   which must outlive the mesh (and, transitively, anything retaining it -- see
+   :ref:`Chap:MeshSDFClasses`). For the full API, see the Doxygen reference for
    `MeshT <doxygen/html/classEBGeometry_1_1DCEL_1_1MeshT.html>`__.
 
 Meta-data can be attached to the DCEL primitives by selecting an appropriate type for ``Meta`` above.

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -21,16 +21,23 @@ The source code is implemented in :file:`Source/EBGeometry_Parser.hpp`.
 Quickstart
 ----------
 
-Every reader function in ``EBGeometry::Parser`` comes in two overloads: one that takes a single
-file name, and one that takes a ``std::vector<std::string>`` of file names and returns a vector
-of results, one per file.  If you have one or multiple mesh files, the quickest way to turn them
-into BVH-accelerated signed distance fields is
+Every ``readInto*`` function in ``EBGeometry::Parser`` takes an explicit
+`Pool <doxygen/html/classEBGeometry_1_1Pool.html>`__, in addition to a single file name or a
+``std::vector<std::string>`` of file names (with a vector-per-file result for the latter): every
+DCEL mesh it builds reserves its vertex/edge/face storage from that Pool. The Pool is
+caller-owned and caller-managed -- EBGeometry never constructs one for you -- so it must outlive
+every mesh (or SDF wrapper retaining one, see :ref:`Chap:MeshSDFClasses`) built into it. One Pool
+can back many meshes, built one after another with their arrays laid out contiguously in the same
+block, which is cheaper than giving every mesh its own Pool. If you have one or multiple mesh
+files, the quickest way to turn them into BVH-accelerated signed distance fields is
 
 .. code-block:: c++
 
    std::vector<std::string> files; // <---- List of file names.
 
-   const auto distanceFields = EBGeometry::Parser::readIntoPackedBVH<float>(files);
+   EBGeometry::Pool pool(EBGeometry::hostMemoryResource());
+
+   const auto distanceFields = EBGeometry::Parser::readIntoPackedBVH<float>(files, pool);
 
 This will build a DCEL mesh for each input file and wrap it in a :cpp:class:`MeshSDF`, backed by
 a SIMD-accelerated ``PackedBVH`` over the mesh's faces.  See :ref:`Chap:PackedBVHParser` for
@@ -44,7 +51,9 @@ further details.
 
       std::vector<std::string> files; // <---- List of file names.
 
-      const auto distanceFields = EBGeometry::Parser::readIntoTriangleBVH<float>(files);
+      EBGeometry::Pool pool(EBGeometry::hostMemoryResource());
+
+      const auto distanceFields = EBGeometry::Parser::readIntoTriangleBVH<float>(files, pool);
 
    This version will convert all DCEL polygons to triangles, pack them into SIMD-width groups,
    and usually provides a nice code speedup over ``readIntoPackedBVH``.
@@ -107,8 +116,9 @@ See :ref:`Chap:MeshSDFClasses` for how the three SDF classes (options 2-4 above)
 DCEL representation
 ___________________
 
-To read one or multiple files and turn it into DCEL meshes, use ``readIntoDCEL<T, Meta>(filename)``
-(or the ``std::vector<std::string>`` overload for multiple files at once), returning a
+To read one or multiple files and turn it into DCEL meshes, use
+``readIntoDCEL<T, Meta>(filename, pool)`` (or the ``std::vector<std::string>`` overload for
+multiple files at once, which reserves every mesh's storage from the same ``pool``), returning a
 ``shared_ptr<DCEL::MeshT<T, Meta>>`` (or a vector thereof).
 Note that this will only expose the DCEL mesh, but not include any signed distance functionality.
 
@@ -116,43 +126,52 @@ DCEL mesh SDF
 _____________
 
 To read one or multiple files and also turn it into a bare (BVH-free) signed distance
-representation, use ``readIntoMesh<T, Meta>(filename)``, returning a
-``shared_ptr<FlatMeshSDF<T, Meta>>`` (or a vector thereof for the multi-file overload).
+representation, use ``readIntoMesh<T, Meta>(filename, pool)``, returning a
+``shared_ptr<FlatMeshSDF<T, Meta>>`` (or a vector thereof for the multi-file overload). The
+returned ``FlatMeshSDF`` retains the mesh (see :ref:`Chap:MeshSDFClasses`), so ``pool`` must
+outlive it.
 
 .. _Chap:PackedBVHParser:
 
 DCEL mesh SDF with PackedBVH
 _____________________________
 
-``readIntoPackedBVH<T, Meta, K>(filename, build)`` wraps a DCEL mesh in a ``PackedBVH`` (depth-first
-flat layout) with SIMD traversal, returning a ``shared_ptr<MeshSDF<T, Meta, K>>`` (or a vector
-thereof). It supports any polygon, not just triangles; the BVH branching factor ``K`` defaults to
-4 and the build strategy ``a_build`` defaults to ``BVH::Build::SAH``. For maximum throughput on
+``readIntoPackedBVH<T, Meta, K>(filename, pool, build)`` wraps a DCEL mesh in a ``PackedBVH``
+(depth-first flat layout) with SIMD traversal, returning a ``shared_ptr<MeshSDF<T, Meta, K>>`` (or
+a vector thereof). It supports any polygon, not just triangles; the BVH branching factor ``K``
+defaults to 4 and the build strategy ``a_build`` defaults to ``BVH::Build::SAH``. The returned
+``MeshSDF`` retains the mesh, so ``pool`` must outlive it. For maximum throughput on
 triangle-only meshes, prefer ``readIntoTriangleBVH`` below.
 
 Triangle meshes with PackedBVH
 ________________________________
 
-``readIntoTriangleBVH<T, Meta, K, W, StoragePolicy>(filename, maxLeafGroups, build)`` converts all
-DCEL polygons to triangles, packs them into SoA groups of ``W``, and builds a ``PackedBVH``,
-returning a ``shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>`` (or a vector thereof). SIMD
-intrinsics evaluate up to ``W`` triangles per leaf visit. ``K`` and ``W`` default to the
-SIMD-optimal values for ``T`` on the current ISA (``BVH::DefaultBranchingRatio<T>()`` and
+``readIntoTriangleBVH<T, Meta, K, W, StoragePolicy>(filename, pool, maxLeafGroups, build)``
+converts all DCEL polygons to triangles, packs them into SoA groups of ``W``, and builds a
+``PackedBVH``, returning a ``shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>`` (or a vector
+thereof). SIMD intrinsics evaluate up to ``W`` triangles per leaf visit. ``K`` and ``W`` default to
+the SIMD-optimal values for ``T`` on the current ISA (``BVH::DefaultBranchingRatio<T>()`` and
 ``TriangleSoA::DefaultWidth<T>()``, see :ref:`Chap:MeshSDFClasses`); ``maxLeafGroups`` (default 4)
 bounds the number of full ``W``-sized SoA groups per BVH leaf; ``StoragePolicy`` defaults to
 ``BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>``, matching ``TriMeshSDF``'s own default (see
 :ref:`Chap:MeshSDFClasses` for the rationale, and why ``readIntoPackedBVH``/``MeshSDF`` above has
-no equivalent parameter). The code will raise an error if any face is not a triangle.
+no equivalent parameter). The code will raise an error if any face is not a triangle. Unlike
+``readIntoMesh``/``readIntoPackedBVH``, the returned ``TriMeshSDF`` extracts flat ``Triangle``
+values from the intermediate DCEL mesh and does not retain it, so ``pool`` only needs to outlive
+this call -- though since a ``Pool`` never individually frees what it reserves (see
+`Pool <doxygen/html/classEBGeometry_1_1Pool.html>`__), that intermediate mesh's storage stays
+reserved in ``pool`` regardless.
 
 Flat triangle list
 ____________________
 
-``readIntoTriangles<T, Meta>(filename)`` returns a flat ``std::vector<shared_ptr<Triangle<T,
+``readIntoTriangles<T, Meta>(filename, pool)`` returns a flat ``std::vector<shared_ptr<Triangle<T,
 Meta>>>`` (or, for the multi-file overload, one such vector per file) -- every face of the
 parsed mesh as an independent, self-contained ``Triangle`` value, with no DCEL/half-edge
-topology connecting them. Use this when some other part of your code wants raw triangle values
-(for example, to build a custom acceleration structure) rather than any of EBGeometry's own SDF
-wrappers.
+topology connecting them. As with ``readIntoTriangleBVH`` above, the intermediate DCEL mesh built
+along the way is not retained by the result, so ``pool`` only needs to outlive this call. Use this
+when some other part of your code wants raw triangle values (for example, to build a custom
+acceleration structure) rather than any of EBGeometry's own SDF wrappers.
 
 .. note::
 
@@ -192,7 +211,9 @@ in namespace ``EBGeometry::Soup``:
   (already-compressed) soup into the output DCEL mesh, reconciles pair edges (internally, via
   ``reconcilePairEdgesDCEL``, which links each half-edge :math:`u \to v` to its reverse
   :math:`v \to u`), and runs a mesh sanity check. This also computes the vertex and edge normal
-  vectors.
+  vectors. ``mesh`` must already be constructed against a ``Pool`` (i.e. via
+  ``DCEL::MeshT<T, Meta>(pool)``) before this call -- ``soupToDCEL`` reserves the mesh's
+  vertex/edge/half-edge storage from that pool itself, sized from ``vertices``/``facets``.
 
 .. note::
 

--- a/Examples/CSGUnion/main.cpp
+++ b/Examples/CSGUnion/main.cpp
@@ -49,9 +49,12 @@ main(int argc, char* argv[])
               << "Usage: ./a.out <mesh-file>  (STL/PLY/VTK/OBJ)\n";
   }
 
-  // Read the mesh into a signed distance function and bound it with an axis-aligned box.
-  const auto meshSDF = EBGeometry::Parser::readIntoMesh<T, Meta>(file);
-  const BV   meshBV(meshSDF->getMesh()->getAllVertexCoordinates());
+  // Read the mesh into a signed distance function and bound it with an axis-aligned box. The mesh's
+  // vertex/edge/face storage is reserved from this Pool; meshSDF retains the mesh (see MeshSDF's
+  // docs), so the Pool must outlive it -- keeping both in main()'s scope satisfies that.
+  EBGeometry::Pool pool(EBGeometry::hostMemoryResource());
+  const auto       meshSDF = EBGeometry::Parser::readIntoMesh<T, Meta>(file, pool);
+  const BV         meshBV(meshSDF->getMesh()->getAllVertexCoordinates());
 
   // Analytic sphere centred on the mesh, with radius equal to the shortest axis (half-extent) of the
   // mesh bounding box. It is bounded by its own axis-aligned box for the union hierarchy.

--- a/Examples/MeshSDF/main.cpp
+++ b/Examples/MeshSDF/main.cpp
@@ -52,9 +52,14 @@ main(int argc, char* argv[])
   // Note that this reads the mesh and builds the BVH tree independently for each
   // representation. There are converters that avoid this, but users will almost always
   // only use one of these representations.
-  const auto dcelSDF = EBGeometry::Parser::readIntoMesh<T, Meta>(file);
-  const auto meshSDF = EBGeometry::Parser::readIntoPackedBVH<T, Meta, K>(file);
-  const auto triSDF  = EBGeometry::Parser::readIntoTriangleBVH<T, Meta>(file, 4, BVH::Build::SAH);
+  // Each representation reserves its DCEL mesh storage from this Pool; dcelSDF and meshSDF retain
+  // their mesh for its lifetime (see FlatMeshSDF/MeshSDF's docs), so the Pool must outlive them --
+  // keeping it in main()'s scope alongside them satisfies that.
+  EBGeometry::Pool pool(EBGeometry::hostMemoryResource());
+
+  const auto dcelSDF = EBGeometry::Parser::readIntoMesh<T, Meta>(file, pool);
+  const auto meshSDF = EBGeometry::Parser::readIntoPackedBVH<T, Meta, K>(file, pool);
+  const auto triSDF  = EBGeometry::Parser::readIntoTriangleBVH<T, Meta>(file, pool, 4, BVH::Build::SAH);
 
   // Sample some random points around the object.
   constexpr size_t Nsamp = 1000;

--- a/Examples/NestedBVH/main.cpp
+++ b/Examples/NestedBVH/main.cpp
@@ -66,7 +66,11 @@ main(int argc, char* argv[])
   // same object, shared by pointer and never rebuilt or copied per placement. This is the idiomatic
   // way to replicate one mesh across a scene. (To place genuinely different meshes instead, read one
   // TriMeshSDF per mesh file and translate each.)
-  const auto tri   = EBGeometry::Parser::readIntoTriangleBVH<T, Meta>(file);
+  // TriMeshSDF extracts flat Triangle objects from the parsed DCEL mesh and does not retain the
+  // mesh itself, so this Pool only needs to outlive the readIntoTriangleBVH call.
+  EBGeometry::Pool pool(EBGeometry::hostMemoryResource());
+
+  const auto tri   = EBGeometry::Parser::readIntoTriangleBVH<T, Meta>(file, pool);
   const BV   triBV = tri->computeBoundingVolume();
 
   const std::vector<Vec3> shifts = {

--- a/Integrations/AMReX/MeshSDF/main.cpp
+++ b/Integrations/AMReX/MeshSDF/main.cpp
@@ -30,11 +30,15 @@ public:
   */
   AMReXSDF(const std::string a_filename, const bool a_use_bvh)
   {
+    // The mesh reserves its storage from m_pool. readIntoMesh's FlatMeshSDF retains its mesh (see
+    // its docs), so m_pool is a shared_ptr member kept alive alongside m_sdf.
+    m_pool = std::make_shared<EBGeometry::Pool>(EBGeometry::hostMemoryResource());
+
     if (a_use_bvh) {
-      m_sdf = EBGeometry::Parser::readIntoTriangleBVH<T, Meta, K>(a_filename);
+      m_sdf = EBGeometry::Parser::readIntoTriangleBVH<T, Meta, K>(a_filename, *m_pool);
     }
     else {
-      m_sdf = EBGeometry::Parser::readIntoMesh<T, Meta>(a_filename);
+      m_sdf = EBGeometry::Parser::readIntoMesh<T, Meta>(a_filename, *m_pool);
     }
   }
 
@@ -66,6 +70,11 @@ protected:
     @brief Signed distance function (BVH-accelerated or flat mesh).
   */
   std::shared_ptr<EBGeometry::ImplicitFunction<T>> m_sdf;
+
+  /*!
+    @brief Pool backing the DCEL mesh's vertex/edge/face storage.
+  */
+  std::shared_ptr<EBGeometry::Pool> m_pool;
 };
 
 int

--- a/Integrations/AMReX/PaintEB/main.cpp
+++ b/Integrations/AMReX/PaintEB/main.cpp
@@ -34,13 +34,16 @@ public:
   */
   AMReXSDF(const std::string a_filename)
   {
-    // Read in the mesh into a DCEL mesh and partition it into a bounding volume hierarchy
-    auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
+    // Read in the mesh into a DCEL mesh and partition it into a bounding volume hierarchy. The mesh
+    // reserves its storage from m_pool; MeshSDF retains the mesh (see its docs), so m_pool is a
+    // shared_ptr member kept alive alongside m_sdf for exactly as long as this object needs it.
+    m_pool = std::make_shared<EBGeometry::Pool>(EBGeometry::hostMemoryResource());
+
+    auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename, *m_pool);
 
     // Set the meta-data for all facets to their "index", i.e. position in the list of facets
-    auto& faces = mesh->getFaces();
-    for (size_t i = 0; i < faces.size(); i++) {
-      faces[i].getMetaData() = 1.0 * i;
+    for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+      mesh->getFace(i).getMetaData() = 1.0 * i;
     }
 
     m_sdf = std::make_shared<EBGeometry::MeshSDF<T, Meta, K>>(mesh, EBGeometry::BVH::Build::SAH);
@@ -52,7 +55,8 @@ public:
   */
   AMReXSDF(const AMReXSDF& a_other)
   {
-    this->m_sdf = a_other.m_sdf;
+    this->m_sdf  = a_other.m_sdf;
+    this->m_pool = a_other.m_pool;
   }
 
   /*!
@@ -87,6 +91,11 @@ protected:
     @brief DCEL mesh represented as a BVH of its facets, exposed as an implicit function.
   */
   std::shared_ptr<EBGeometry::MeshSDF<T, Meta, K>> m_sdf;
+
+  /*!
+    @brief Pool backing m_sdf's retained mesh's vertex/edge/face storage.
+  */
+  std::shared_ptr<EBGeometry::Pool> m_pool;
 };
 
 int

--- a/Integrations/Chombo/MeshSDF/main.cpp
+++ b/Integrations/Chombo/MeshSDF/main.cpp
@@ -26,13 +26,19 @@ public:
 
   ChomboSDF(const std::string a_filename)
   {
-    m_implicitFunction = EBGeometry::Parser::readIntoTriangleBVH<T, Meta, K>(a_filename);
+    // TriMeshSDF extracts flat Triangle objects from the parsed DCEL mesh and does not retain the
+    // mesh itself, so m_pool only needs to outlive this constructor -- but it is still kept as a
+    // member (rather than a local) so the copy constructor below has something to copy.
+    m_pool = std::make_shared<EBGeometry::Pool>(EBGeometry::hostMemoryResource());
+
+    m_implicitFunction = EBGeometry::Parser::readIntoTriangleBVH<T, Meta, K>(a_filename, *m_pool);
     m_implicitFunction = EBGeometry::Complement<T>(m_implicitFunction);
   }
 
   ChomboSDF(const ChomboSDF& a_other)
   {
     m_implicitFunction = a_other.m_implicitFunction;
+    m_pool             = a_other.m_pool;
   }
 
   Real
@@ -57,6 +63,11 @@ public:
 
 protected:
   std::shared_ptr<EBGeometry::ImplicitFunction<T>> m_implicitFunction;
+
+  /*!
+    @brief Pool backing the DCEL mesh's vertex/edge/face storage.
+  */
+  std::shared_ptr<EBGeometry::Pool> m_pool;
 };
 
 int

--- a/Source/EBGeometry_DCEL_EdgeImplem.hpp
+++ b/Source/EBGeometry_DCEL_EdgeImplem.hpp
@@ -189,7 +189,7 @@ EdgeT<T, Meta>::getVertex(Mesh& a_mesh) noexcept
 {
   EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
 
-  return a_mesh.getVertices()[m_vertex];
+  return a_mesh.getVertex(m_vertex);
 }
 
 template <class T, class Meta>
@@ -198,7 +198,7 @@ EdgeT<T, Meta>::getVertex(const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(m_vertex != UINT32_MAX);
 
-  return a_mesh.getVertices()[m_vertex];
+  return a_mesh.getVertex(m_vertex);
 }
 
 template <class T, class Meta>
@@ -225,7 +225,7 @@ EdgeT<T, Meta>::getPairEdge(Mesh& a_mesh) noexcept
 {
   EBGEOMETRY_EXPECT(m_pairEdge != UINT32_MAX);
 
-  return a_mesh.getEdges()[m_pairEdge];
+  return a_mesh.getEdge(m_pairEdge);
 }
 
 template <class T, class Meta>
@@ -234,7 +234,7 @@ EdgeT<T, Meta>::getPairEdge(const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(m_pairEdge != UINT32_MAX);
 
-  return a_mesh.getEdges()[m_pairEdge];
+  return a_mesh.getEdge(m_pairEdge);
 }
 
 template <class T, class Meta>
@@ -243,7 +243,7 @@ EdgeT<T, Meta>::getNextEdge(Mesh& a_mesh) noexcept
 {
   EBGEOMETRY_EXPECT(m_nextEdge != UINT32_MAX);
 
-  return a_mesh.getEdges()[m_nextEdge];
+  return a_mesh.getEdge(m_nextEdge);
 }
 
 template <class T, class Meta>
@@ -252,7 +252,7 @@ EdgeT<T, Meta>::getNextEdge(const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(m_nextEdge != UINT32_MAX);
 
-  return a_mesh.getEdges()[m_nextEdge];
+  return a_mesh.getEdge(m_nextEdge);
 }
 
 template <class T, class Meta>
@@ -273,7 +273,7 @@ EdgeT<T, Meta>::getFace(Mesh& a_mesh) noexcept
 {
   EBGEOMETRY_EXPECT(m_face != UINT32_MAX);
 
-  return a_mesh.getFaces()[m_face];
+  return a_mesh.getFace(m_face);
 }
 
 template <class T, class Meta>
@@ -282,7 +282,7 @@ EdgeT<T, Meta>::getFace(const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(m_face != UINT32_MAX);
 
-  return a_mesh.getFaces()[m_face];
+  return a_mesh.getFace(m_face);
 }
 
 template <class T, class Meta>

--- a/Source/EBGeometry_DCEL_FaceImplem.hpp
+++ b/Source/EBGeometry_DCEL_FaceImplem.hpp
@@ -105,7 +105,7 @@ FaceT<T, Meta>::computeCentroid(const Mesh& a_mesh)
   EBGEOMETRY_EXPECT(!vertexIndices.empty());
 
   for (const uint32_t v : vertexIndices) {
-    m_centroid += a_mesh.getVertices()[v].getPosition();
+    m_centroid += a_mesh.getVertex(v).getPosition();
   }
 
   m_centroid = m_centroid / vertexIndices.size();
@@ -125,9 +125,9 @@ FaceT<T, Meta>::computeNormal(const Mesh& a_mesh)
   // To compute the normal vector we find three vertices in this polygon face.
   // They span a plane, and we just compute the normal vector of that plane.
   for (size_t i = 0; i < N; i++) {
-    const auto& x0 = a_mesh.getVertices()[vertexIndices[i]].getPosition();
-    const auto& x1 = a_mesh.getVertices()[vertexIndices[(i + 1) % N]].getPosition();
-    const auto& x2 = a_mesh.getVertices()[vertexIndices[(i + 2) % N]].getPosition();
+    const auto& x0 = a_mesh.getVertex(vertexIndices[i]).getPosition();
+    const auto& x1 = a_mesh.getVertex(vertexIndices[(i + 1) % N]).getPosition();
+    const auto& x2 = a_mesh.getVertex(vertexIndices[(i + 2) % N]).getPosition();
 
     m_normal = (x2 - x0).cross(x2 - x1);
 
@@ -191,8 +191,8 @@ FaceT<T, Meta>::computeArea(const Mesh& a_mesh)
   // the origin, and omitting the wraparound edge silently produces a wrong (generally too large or
   // too small) area for any polygon that doesn't happen to pass through the origin.
   for (size_t i = 0; i < N; i++) {
-    const auto& v1 = a_mesh.getVertices()[vertexIndices[i]].getPosition();
-    const auto& v2 = a_mesh.getVertices()[vertexIndices[(i + 1) % N]].getPosition();
+    const auto& v1 = a_mesh.getVertex(vertexIndices[i]).getPosition();
+    const auto& v2 = a_mesh.getVertex(vertexIndices[(i + 1) % N]).getPosition();
 
     area += m_normal.dot(v2.cross(v1));
   }
@@ -285,7 +285,7 @@ FaceT<T, Meta>::gatherVertexIndices(const Mesh& a_mesh) const
   vertexIndices.reserve(3);
 
   for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
-    vertexIndices.emplace_back(a_mesh.getEdges()[iter()].getVertexIndex());
+    vertexIndices.emplace_back(a_mesh.getEdge(iter()).getVertexIndex());
   }
 
   return vertexIndices;
@@ -313,7 +313,7 @@ FaceT<T, Meta>::getAllVertexCoordinates(const Mesh& a_mesh) const
   ret.reserve(3);
 
   for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
-    ret.emplace_back(a_mesh.getEdges()[iter()].getVertex(a_mesh).getPosition());
+    ret.emplace_back(a_mesh.getEdge(iter()).getVertex(a_mesh).getPosition());
   }
 
   return ret;
@@ -385,7 +385,7 @@ FaceT<T, Meta>::computeWindingNumber(const Vec2T<T>& a_point, const Mesh& a_mesh
   };
 
   for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
-    const Edge&    edge = a_mesh.getEdges()[iter()];
+    const Edge&    edge = a_mesh.getEdge(iter());
     const Vec2T<T> P1   = this->projectPoint(edge.getVertex(a_mesh).getPosition());
     const Vec2T<T> P2   = this->projectPoint(edge.getNextEdge(a_mesh).getVertex(a_mesh).getPosition());
     const T        res  = isLeft(P1, P2, a_point);
@@ -416,7 +416,7 @@ FaceT<T, Meta>::computeCrossingNumber(const Vec2T<T>& a_point, const Mesh& a_mes
   size_t cn = 0;
 
   for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
-    const Edge&    edge = a_mesh.getEdges()[iter()];
+    const Edge&    edge = a_mesh.getEdge(iter());
     const Vec2T<T> P1   = this->projectPoint(edge.getVertex(a_mesh).getPosition());
     const Vec2T<T> P2   = this->projectPoint(edge.getNextEdge(a_mesh).getVertex(a_mesh).getPosition());
 
@@ -449,7 +449,7 @@ FaceT<T, Meta>::computeSubtendedAngle(const Vec2T<T>& a_point, const Mesh& a_mes
   T sumTheta = T(0);
 
   for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
-    const Edge&    edge = a_mesh.getEdges()[iter()];
+    const Edge&    edge = a_mesh.getEdge(iter());
     const Vec2T<T> p1   = this->projectPoint(edge.getVertex(a_mesh).getPosition()) - a_point;
     const Vec2T<T> p2   = this->projectPoint(edge.getNextEdge(a_mesh).getVertex(a_mesh).getPosition()) - a_point;
 
@@ -519,7 +519,7 @@ FaceT<T, Meta>::signedDistance(const Vec3& a_x0, const Mesh& a_mesh) const noexc
   }
   else {
     for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
-      const Edge& cur = a_mesh.getEdges()[iter()];
+      const Edge& cur = a_mesh.getEdge(iter());
 
       const T curDist = cur.signedDistance(a_x0, a_mesh);
 
@@ -550,7 +550,7 @@ FaceT<T, Meta>::unsignedDistance2(const Vec3& a_x0, const Mesh& a_mesh) const no
   }
   else {
     for (EdgeIterator iter(a_mesh, *this); iter.ok(); ++iter) {
-      const Edge& cur = a_mesh.getEdges()[iter()];
+      const Edge& cur = a_mesh.getEdge(iter());
 
       const T curDist2 = cur.unsignedDistance2(a_x0, a_mesh);
 

--- a/Source/EBGeometry_DCEL_Iterator.hpp
+++ b/Source/EBGeometry_DCEL_Iterator.hpp
@@ -33,7 +33,7 @@ namespace DCEL {
  * @code{.cpp}
  * for (EdgeIterator it(mesh, someFace); it.ok(); ++it) {
  *   const uint32_t edgeIndex = it();
- *   // ... use mesh.getEdges()[edgeIndex] ...
+ *   // ... use mesh.getEdge(edgeIndex) ...
  * }
  * @endcode
  * @tparam T    Floating-point precision type.

--- a/Source/EBGeometry_DCEL_IteratorImplem.hpp
+++ b/Source/EBGeometry_DCEL_IteratorImplem.hpp
@@ -60,7 +60,7 @@ EdgeIteratorT<T, Meta>::operator++() noexcept
   EBGEOMETRY_EXPECT(m_curEdge != UINT32_MAX);
   EBGEOMETRY_EXPECT(m_mesh != nullptr);
 
-  m_curEdge  = m_mesh->getEdges()[m_curEdge].getNextEdgeIndex();
+  m_curEdge  = m_mesh->getEdge(m_curEdge).getNextEdgeIndex();
   m_fullLoop = (m_curEdge == m_startEdge);
 }
 

--- a/Source/EBGeometry_DCEL_Mesh.hpp
+++ b/Source/EBGeometry_DCEL_Mesh.hpp
@@ -52,7 +52,15 @@ namespace DCEL {
  * giving every mesh its own Pool. The caller is responsible for keeping the
  * Pool alive for at least as long as any MeshT built into it, and for its
  * lifetime otherwise (see EBGeometry_Pool.hpp -- a Pool is a pure bump
- * allocator; nothing reserved from it is individually freed).
+ * allocator; nothing reserved from it is individually freed). MeshT stores a
+ * raw, non-owning pointer to that Pool object (not merely to its underlying
+ * block): the Pool object itself must also not be moved once a mesh has been
+ * built into it, since Pool's move constructor/assignment relocate its state
+ * into the destination object, leaving every already-built MeshT holding a
+ * pointer to a moved-from Pool. Keep a Pool that already backs a MeshT in a
+ * fixed location (e.g. a local variable or a heap allocation held by
+ * shared_ptr/unique_ptr) rather than moving it into a container or a new
+ * owner.
  * @note This class is not for the light of heart -- it will almost always be
  * instantiated through a file parser which reads vertices and edges from file
  * and builds the mesh from that. Do not try to build a MeshT object yourself,

--- a/Source/EBGeometry_DCEL_Mesh.hpp
+++ b/Source/EBGeometry_DCEL_Mesh.hpp
@@ -14,6 +14,7 @@
 
 // Std includes
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -25,6 +26,8 @@
 #include "EBGeometry_DCEL_Edge.hpp"
 #include "EBGeometry_DCEL_Face.hpp"
 #include "EBGeometry_DCEL_Vertex.hpp"
+#include "EBGeometry_PODVector.hpp"
+#include "EBGeometry_Pool.hpp"
 
 namespace EBGeometry {
 
@@ -35,14 +38,21 @@ namespace DCEL {
  * functions)
  * @details This encapsulates a full DCEL mesh, and also includes DIRECT signed
  * distance functions. The mesh consists of a set of vertices, half-edges, and
- * polygon faces, stored by value in this class's own arrays; every
- * cross-reference between them (vertex-to-outgoing-edge, edge-to-vertex/pair
- * edge/next edge/face, face-to-half-edge) is an index into these arrays rather
- * than a pointer -- see the class-level notes on VertexT/EdgeT/FaceT. The
- * signed distance functions DIRECT, which means that they go through ALL of the
- * polygon faces and compute the signed distance to them. This is extremely
- * inefficient, which is why this class is almost always embedded into a
- * bounding volume hierarchy.
+ * polygon faces, stored as PODVectors into a caller-owned, externally-supplied
+ * Pool; every cross-reference between them (vertex-to-outgoing-edge,
+ * edge-to-vertex/pair edge/next edge/face, face-to-half-edge) is an index into
+ * these arrays rather than a pointer -- see the class-level notes on
+ * VertexT/EdgeT/FaceT. The signed distance functions DIRECT, which means that
+ * they go through ALL of the polygon faces and compute the signed distance to
+ * them. This is extremely inefficient, which is why this class is almost
+ * always embedded into a bounding volume hierarchy.
+ * @note MeshT does not own the Pool it is built into -- see the constructor.
+ * This is deliberate: one Pool can back many meshes (built one after another,
+ * their arrays laid out contiguously in the same block), which is cheaper than
+ * giving every mesh its own Pool. The caller is responsible for keeping the
+ * Pool alive for at least as long as any MeshT built into it, and for its
+ * lifetime otherwise (see EBGeometry_Pool.hpp -- a Pool is a pure bump
+ * allocator; nothing reserved from it is individually freed).
  * @note This class is not for the light of heart -- it will almost always be
  * instantiated through a file parser which reads vertices and edges from file
  * and builds the mesh from that. Do not try to build a MeshT object yourself,
@@ -94,11 +104,22 @@ public:
   using Mesh = MeshT<T, Meta>;
 
   /**
-   * @brief Default constructor.
-   * @details Leaves the mesh empty (no vertices, edges, or faces) with the default search
-   * algorithm; use define() or the mutable getVertices()/getEdges()/getFaces() to populate it.
+   * @brief Disallowed default construction.
+   * @details A MeshT always needs a backing Pool to reserve its vertex/edge/face storage from;
+   * use the Pool-taking constructor.
    */
-  MeshT() noexcept = default;
+  MeshT() = delete;
+
+  /**
+   * @brief Full constructor. Associates this mesh with the Pool it will reserve its
+   * vertex/edge/face storage from.
+   * @details Leaves the mesh empty (no vertices, edges, or faces); use reserveVertices()/
+   * reserveEdges()/reserveFaces() followed by addVertex()/addEdge()/addFace() to populate it (a
+   * file parser normally does this).
+   * @param[in,out] a_pool Backing Pool. Non-owning: the caller must keep it alive for at least as
+   * long as this mesh (and any other mesh built into the same Pool).
+   */
+  explicit MeshT(Pool& a_pool) noexcept;
 
   /**
    * @brief Disallowed copy construction.
@@ -111,27 +132,17 @@ public:
 
   /**
    * @brief Move constructor.
+   * @details Defaulted memberwise move. Every member (the Pool pointer, and the PODVector
+   * descriptors) is a plain value, so this is a cheap value-copy of the descriptor rather than a
+   * transfer of exclusive ownership -- unlike the old std::vector-backed MeshT, the moved-from
+   * mesh is left referencing the exact same Pool data (not emptied), since the underlying storage
+   * was never owned by this mesh in the first place (see the class-level note on the Pool).
    * @param[in, out] a_otherMesh Other mesh.
    */
   MeshT(Mesh&& a_otherMesh) noexcept = default;
 
   /**
-   * @brief Full constructor. This provides the faces, edges, and vertices to the
-   * mesh.
-   * @details Copies the three vectors directly into m_faces/m_edges/m_vertices. This only
-   * associates the index-based topology already recorded on the faces/edges/vertices; internal
-   * parameters like face area and normal are computed by reconcile().
-   * @param[in] a_faces    Polygon faces
-   * @param[in] a_edges    Half-edges
-   * @param[in] a_vertices Vertices
-   * @note The constructor arguments should provide a complete DCEL mesh
-   * description. This is usually done through a file parser which reads a mesh
-   * file format and creates the DCEL mesh structure
-   */
-  MeshT(std::vector<Face>& a_faces, std::vector<Edge>& a_edges, std::vector<Vertex>& a_vertices) noexcept;
-
-  /**
-   * @brief Destructor (does nothing)
+   * @brief Destructor (does nothing; the backing Pool is not owned by this mesh)
    */
   ~MeshT() noexcept = default;
 
@@ -146,6 +157,7 @@ public:
 
   /**
    * @brief Move assignment operator.
+   * @details Has the same semantics as the move constructor; see its documentation.
    * @param[in, out] a_otherMesh Other mesh.
    * @return Reference to (*this).
    */
@@ -153,19 +165,20 @@ public:
   operator=(Mesh&& a_otherMesh) noexcept = default;
 
   /**
-   * @brief Create an independent, fully-decoupled copy of this mesh.
+   * @brief Create an independent, fully-decoupled copy of this mesh in another Pool.
    * @details Since copy construction/assignment are disallowed (see their documentation), this is
-   * the supported way to duplicate a mesh. Because every VertexT/EdgeT/FaceT cross-reference is an
-   * index into this mesh's own arrays rather than a pointer, a plain copy of the three arrays is
-   * already a fully independent, correctly-linked mesh -- every index remains meaningful against
-   * the copied arrays with no relinking pass required. Every field is preserved exactly (position,
-   * normal vector, centroid, area, meta-data, search algorithm) rather than recomputed, so a mesh
-   * that has had flipNormal()/flip() called on it and not yet been re-reconciled is copied
-   * faithfully rather than silently "un-flipped".
+   * the supported way to duplicate a mesh. Reserves fresh storage in a_dstPool and copies every
+   * vertex/edge/face by value; since every cross-reference is an index rather than a pointer, the
+   * copy is already fully independent and correctly linked -- no relinking pass is needed. Every
+   * field is preserved exactly (position, normal vector, centroid, area, meta-data, search
+   * algorithm) rather than recomputed, so a mesh that has had flipNormal()/flip() called on it and
+   * not yet been re-reconciled is copied faithfully rather than silently "un-flipped".
+   * @param[in,out] a_dstPool Pool to reserve the copy's storage from. May be the same Pool this
+   * mesh is built into, or a different one.
    * @return A new mesh, independent of this one.
    */
   [[nodiscard]] inline std::shared_ptr<Mesh>
-  deepCopy() const;
+  deepCopy(Pool& a_dstPool) const;
 
   /**
    * @brief Perform a sanity check.
@@ -216,18 +229,124 @@ public:
   flip() noexcept;
 
   /**
-   * @brief Get modifiable vertices in this mesh
-   * @return Reference to the vector of vertices.
+   * @brief Reserve storage for a_capacity vertices.
+   * @details Must be called before any addVertex() call, and only once -- PODVector never
+   * reallocates once reserved (see EBGeometry_PODVector.hpp).
+   * @param[in] a_capacity Number of vertex slots to reserve.
    */
-  [[nodiscard]] inline std::vector<Vertex>&
-  getVertices() noexcept;
+  inline void
+  reserveVertices(uint32_t a_capacity);
 
   /**
-   * @brief Get immutable vertices in this mesh
-   * @return Const reference to the vector of vertices.
+   * @brief Reserve storage for a_capacity half-edges.
+   * @details Must be called before any addEdge() call, and only once -- PODVector never
+   * reallocates once reserved (see EBGeometry_PODVector.hpp).
+   * @param[in] a_capacity Number of half-edge slots to reserve.
    */
-  [[nodiscard]] inline const std::vector<Vertex>&
-  getVertices() const noexcept;
+  inline void
+  reserveEdges(uint32_t a_capacity);
+
+  /**
+   * @brief Reserve storage for a_capacity faces.
+   * @details Must be called before any addFace() call, and only once -- PODVector never
+   * reallocates once reserved (see EBGeometry_PODVector.hpp).
+   * @param[in] a_capacity Number of face slots to reserve.
+   */
+  inline void
+  reserveFaces(uint32_t a_capacity);
+
+  /**
+   * @brief Append a vertex into the pre-reserved capacity (see reserveVertices()).
+   * @param[in] a_vertex Vertex to append.
+   * @return Index of the newly-appended vertex in this mesh's vertex array.
+   */
+  inline uint32_t
+  addVertex(const Vertex& a_vertex);
+
+  /**
+   * @brief Append a half-edge into the pre-reserved capacity (see reserveEdges()).
+   * @param[in] a_edge Half-edge to append.
+   * @return Index of the newly-appended half-edge in this mesh's edge array.
+   */
+  inline uint32_t
+  addEdge(const Edge& a_edge);
+
+  /**
+   * @brief Append a face into the pre-reserved capacity (see reserveFaces()).
+   * @param[in] a_face Face to append.
+   * @return Index of the newly-appended face in this mesh's face array.
+   */
+  inline uint32_t
+  addFace(const Face& a_face);
+
+  /**
+   * @brief Get modifiable vertex by index.
+   * @param[in] a_index Vertex index (must be < numVertices()).
+   * @return Reference to the vertex.
+   */
+  [[nodiscard]] inline Vertex&
+  getVertex(uint32_t a_index) noexcept;
+
+  /**
+   * @brief Get immutable vertex by index.
+   * @param[in] a_index Vertex index (must be < numVertices()).
+   * @return Const reference to the vertex.
+   */
+  [[nodiscard]] inline const Vertex&
+  getVertex(uint32_t a_index) const noexcept;
+
+  /**
+   * @brief Get modifiable half-edge by index.
+   * @param[in] a_index Half-edge index (must be < numEdges()).
+   * @return Reference to the half-edge.
+   */
+  [[nodiscard]] inline Edge&
+  getEdge(uint32_t a_index) noexcept;
+
+  /**
+   * @brief Get immutable half-edge by index.
+   * @param[in] a_index Half-edge index (must be < numEdges()).
+   * @return Const reference to the half-edge.
+   */
+  [[nodiscard]] inline const Edge&
+  getEdge(uint32_t a_index) const noexcept;
+
+  /**
+   * @brief Get modifiable face by index.
+   * @param[in] a_index Face index (must be < numFaces()).
+   * @return Reference to the face.
+   */
+  [[nodiscard]] inline Face&
+  getFace(uint32_t a_index) noexcept;
+
+  /**
+   * @brief Get immutable face by index.
+   * @param[in] a_index Face index (must be < numFaces()).
+   * @return Const reference to the face.
+   */
+  [[nodiscard]] inline const Face&
+  getFace(uint32_t a_index) const noexcept;
+
+  /**
+   * @brief Number of vertices in this mesh.
+   * @return Vertex count.
+   */
+  [[nodiscard]] inline uint32_t
+  numVertices() const noexcept;
+
+  /**
+   * @brief Number of half-edges in this mesh.
+   * @return Half-edge count.
+   */
+  [[nodiscard]] inline uint32_t
+  numEdges() const noexcept;
+
+  /**
+   * @brief Number of faces in this mesh.
+   * @return Face count.
+   */
+  [[nodiscard]] inline uint32_t
+  numFaces() const noexcept;
 
   /**
    * @brief Return all vertex coordinates in the mesh.
@@ -235,34 +354,6 @@ public:
    */
   [[nodiscard]] inline std::vector<Vec3T<T>>
   getAllVertexCoordinates() const noexcept;
-
-  /**
-   * @brief Get modifiable half-edges in this mesh
-   * @return Reference to the vector of half-edges.
-   */
-  [[nodiscard]] inline std::vector<Edge>&
-  getEdges() noexcept;
-
-  /**
-   * @brief Get immutable half-edges in this mesh
-   * @return Const reference to the vector of half-edges.
-   */
-  [[nodiscard]] inline const std::vector<Edge>&
-  getEdges() const noexcept;
-
-  /**
-   * @brief Get modifiable faces in this mesh
-   * @return Reference to the vector of polygon faces.
-   */
-  [[nodiscard]] inline std::vector<Face>&
-  getFaces() noexcept;
-
-  /**
-   * @brief Get immutable faces in this mesh
-   * @return Const reference to the vector of polygon faces.
-   */
-  [[nodiscard]] inline const std::vector<Face>&
-  getFaces() const noexcept;
 
   /**
    * @brief Compute the signed distance from a point to this mesh
@@ -306,6 +397,11 @@ public:
 
 protected:
   /**
+   * @brief Backing Pool. Non-owning -- see the class-level note and the constructor.
+   */
+  Pool* m_pool = nullptr;
+
+  /**
    * @brief Search algorithm. Only used in signed distance functions.
    */
   SearchAlgorithm m_algorithm = SearchAlgorithm::Direct2;
@@ -313,17 +409,17 @@ protected:
   /**
    * @brief Mesh vertices
    */
-  std::vector<Vertex> m_vertices;
+  PODVector<Vertex> m_vertices;
 
   /**
    * @brief Mesh half-edges
    */
-  std::vector<Edge> m_edges;
+  PODVector<Edge> m_edges;
 
   /**
    * @brief Mesh faces
    */
-  std::vector<Face> m_faces;
+  PODVector<Face> m_faces;
 
   /**
    * @brief Function which computes internal things for the polygon faces.

--- a/Source/EBGeometry_DCEL_MeshImplem.hpp
+++ b/Source/EBGeometry_DCEL_MeshImplem.hpp
@@ -35,31 +35,38 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-inline MeshT<T, Meta>::MeshT(std::vector<Face>&   a_faces,
-                             std::vector<Edge>&   a_edges,
-                             std::vector<Vertex>& a_vertices) noexcept
-  : MeshT()
-{
-  m_faces    = a_faces;
-  m_edges    = a_edges;
-  m_vertices = a_vertices;
-}
+inline MeshT<T, Meta>::MeshT(Pool& a_pool) noexcept : m_pool(&a_pool)
+{}
 
 template <class T, class Meta>
 inline std::shared_ptr<MeshT<T, Meta>>
-MeshT<T, Meta>::deepCopy() const
+MeshT<T, Meta>::deepCopy(Pool& a_dstPool) const
 {
-  EBGEOMETRY_EXPECT(m_vertices.size() > 0 || m_edges.size() > 0 || m_faces.size() > 0);
+  EBGEOMETRY_EXPECT(this->numVertices() > 0 || this->numEdges() > 0 || this->numFaces() > 0);
 
-  // Every VertexT/EdgeT/FaceT cross-reference is an index into these three arrays, not a pointer,
-  // so a plain copy of the arrays is already an independent, correctly-linked mesh -- no relinking
-  // pass is needed (contrast the old shared_ptr/weak_ptr scheme, which required allocating fresh
-  // objects and remapping every pointer).
-  auto newMesh = std::make_shared<Mesh>();
+  // Every VertexT/EdgeT/FaceT cross-reference is an index into the owning mesh's arrays, not a
+  // pointer, so copying each element by value into freshly-reserved storage is already an
+  // independent, correctly-linked mesh -- no relinking pass is needed (contrast the old
+  // shared_ptr/weak_ptr scheme, which required allocating fresh objects and remapping every
+  // pointer).
+  auto newMesh = std::make_shared<Mesh>(a_dstPool);
 
-  newMesh->getVertices() = m_vertices;
-  newMesh->getEdges()    = m_edges;
-  newMesh->getFaces()    = m_faces;
+  newMesh->reserveVertices(this->numVertices());
+  newMesh->reserveEdges(this->numEdges());
+  newMesh->reserveFaces(this->numFaces());
+
+  for (uint32_t i = 0; i < this->numVertices(); i++) {
+    newMesh->addVertex(this->getVertex(i));
+  }
+
+  for (uint32_t i = 0; i < this->numEdges(); i++) {
+    newMesh->addEdge(this->getEdge(i));
+  }
+
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    newMesh->addFace(this->getFace(i));
+  }
+
   newMesh->setSearchAlgorithm(m_algorithm);
 
   return newMesh;
@@ -115,7 +122,9 @@ MeshT<T, Meta>::sanityCheck(const std::string a_id) const
                                             {e_noFace, 0},
                                             {v_noEdge, 0}};
 
-  for (const auto& f : m_faces) {
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    const auto& f = this->getFace(i);
+
     if (f.getHalfEdgeIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, f_noEdge);
       continue;
@@ -130,7 +139,9 @@ MeshT<T, Meta>::sanityCheck(const std::string a_id) const
     }
   }
 
-  for (const auto& e : m_edges) {
+  for (uint32_t i = 0; i < this->numEdges(); i++) {
+    const auto& e = this->getEdge(i);
+
     if (e.getVertexIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, e_noOrigVert);
     }
@@ -150,8 +161,8 @@ MeshT<T, Meta>::sanityCheck(const std::string a_id) const
   }
 
   // Vertex check
-  for (const auto& v : m_vertices) {
-    if (v.getOutgoingEdgeIndex() == UINT32_MAX) {
+  for (uint32_t i = 0; i < this->numVertices(); i++) {
+    if (this->getVertex(i).getOutgoingEdgeIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, v_noEdge);
     }
   }
@@ -170,8 +181,8 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::setInsideOutsideAlgorithm(InsideOutsideAlgorithm a_algorithm) noexcept
 {
-  for (auto& f : m_faces) {
-    f.setInsideOutsideAlgorithm(a_algorithm);
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    this->getFace(i).setInsideOutsideAlgorithm(a_algorithm);
   }
 }
 
@@ -195,10 +206,151 @@ MeshT<T, Meta>::flip() noexcept
 
 template <class T, class Meta>
 inline void
+MeshT<T, Meta>::reserveVertices(uint32_t a_capacity)
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  m_vertices.reserveFrom(*m_pool, a_capacity);
+}
+
+template <class T, class Meta>
+inline void
+MeshT<T, Meta>::reserveEdges(uint32_t a_capacity)
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  m_edges.reserveFrom(*m_pool, a_capacity);
+}
+
+template <class T, class Meta>
+inline void
+MeshT<T, Meta>::reserveFaces(uint32_t a_capacity)
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  m_faces.reserveFrom(*m_pool, a_capacity);
+}
+
+template <class T, class Meta>
+inline uint32_t
+MeshT<T, Meta>::addVertex(const Vertex& a_vertex)
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  const uint32_t index = m_vertices.size();
+
+  m_vertices.push_back(m_pool->base(), a_vertex);
+
+  return index;
+}
+
+template <class T, class Meta>
+inline uint32_t
+MeshT<T, Meta>::addEdge(const Edge& a_edge)
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  const uint32_t index = m_edges.size();
+
+  m_edges.push_back(m_pool->base(), a_edge);
+
+  return index;
+}
+
+template <class T, class Meta>
+inline uint32_t
+MeshT<T, Meta>::addFace(const Face& a_face)
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  const uint32_t index = m_faces.size();
+
+  m_faces.push_back(m_pool->base(), a_face);
+
+  return index;
+}
+
+template <class T, class Meta>
+inline VertexT<T, Meta>&
+MeshT<T, Meta>::getVertex(uint32_t a_index) noexcept
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  return m_vertices.at(m_pool->base(), a_index);
+}
+
+template <class T, class Meta>
+inline const VertexT<T, Meta>&
+MeshT<T, Meta>::getVertex(uint32_t a_index) const noexcept
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  return m_vertices.at(m_pool->base(), a_index);
+}
+
+template <class T, class Meta>
+inline EdgeT<T, Meta>&
+MeshT<T, Meta>::getEdge(uint32_t a_index) noexcept
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  return m_edges.at(m_pool->base(), a_index);
+}
+
+template <class T, class Meta>
+inline const EdgeT<T, Meta>&
+MeshT<T, Meta>::getEdge(uint32_t a_index) const noexcept
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  return m_edges.at(m_pool->base(), a_index);
+}
+
+template <class T, class Meta>
+inline FaceT<T, Meta>&
+MeshT<T, Meta>::getFace(uint32_t a_index) noexcept
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  return m_faces.at(m_pool->base(), a_index);
+}
+
+template <class T, class Meta>
+inline const FaceT<T, Meta>&
+MeshT<T, Meta>::getFace(uint32_t a_index) const noexcept
+{
+  EBGEOMETRY_EXPECT(m_pool != nullptr);
+
+  return m_faces.at(m_pool->base(), a_index);
+}
+
+template <class T, class Meta>
+inline uint32_t
+MeshT<T, Meta>::numVertices() const noexcept
+{
+  return m_vertices.size();
+}
+
+template <class T, class Meta>
+inline uint32_t
+MeshT<T, Meta>::numEdges() const noexcept
+{
+  return m_edges.size();
+}
+
+template <class T, class Meta>
+inline uint32_t
+MeshT<T, Meta>::numFaces() const noexcept
+{
+  return m_faces.size();
+}
+
+template <class T, class Meta>
+inline void
 MeshT<T, Meta>::reconcileFaces() noexcept
 {
-  for (auto& f : m_faces) {
-    f.reconcile(*this);
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    this->getFace(i).reconcile(*this);
   }
 }
 
@@ -206,8 +358,8 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::reconcileEdges() noexcept
 {
-  for (auto& e : m_edges) {
-    e.reconcile(*this);
+  for (uint32_t i = 0; i < this->numEdges(); i++) {
+    this->getEdge(i).reconcile(*this);
   }
 }
 
@@ -220,18 +372,18 @@ MeshT<T, Meta>::reconcileVertices(const DCEL::VertexNormalWeight a_weight) noexc
   // robust to non-watertight/"dirty" meshes as the per-vertex face list this class used to cache
   // permanently, but is rebuilt here and discarded once vertex normals are computed, so it never
   // threatens VertexT's trivial copyability.
-  std::vector<std::vector<uint32_t>> facesTouchingVertex(m_vertices.size());
+  std::vector<std::vector<uint32_t>> facesTouchingVertex(this->numVertices());
 
-  for (uint32_t faceIndex = 0; faceIndex < m_faces.size(); faceIndex++) {
-    for (const uint32_t vertexIndex : m_faces[faceIndex].gatherVertexIndices(*this)) {
+  for (uint32_t faceIndex = 0; faceIndex < this->numFaces(); faceIndex++) {
+    for (const uint32_t vertexIndex : this->getFace(faceIndex).gatherVertexIndices(*this)) {
       EBGEOMETRY_EXPECT(vertexIndex < facesTouchingVertex.size());
 
       facesTouchingVertex[vertexIndex].push_back(faceIndex);
     }
   }
 
-  for (uint32_t vertexIndex = 0; vertexIndex < m_vertices.size(); vertexIndex++) {
-    auto&       v           = m_vertices[vertexIndex];
+  for (uint32_t vertexIndex = 0; vertexIndex < this->numVertices(); vertexIndex++) {
+    auto&       v           = this->getVertex(vertexIndex);
     const auto& faceIndices = facesTouchingVertex[vertexIndex];
 
     switch (a_weight) {
@@ -262,8 +414,8 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::flipFaceNormals() noexcept
 {
-  for (auto& f : m_faces) {
-    f.flipNormal();
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    this->getFace(i).flipNormal();
   }
 }
 
@@ -271,8 +423,8 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::flipEdgeNormals() noexcept
 {
-  for (auto& e : m_edges) {
-    e.flipNormal();
+  for (uint32_t i = 0; i < this->numEdges(); i++) {
+    this->getEdge(i).flipNormal();
   }
 }
 
@@ -280,51 +432,9 @@ template <class T, class Meta>
 inline void
 MeshT<T, Meta>::flipVertexNormals() noexcept
 {
-  for (auto& v : m_vertices) {
-    v.flipNormal();
+  for (uint32_t i = 0; i < this->numVertices(); i++) {
+    this->getVertex(i).flipNormal();
   }
-}
-
-template <class T, class Meta>
-inline std::vector<VertexT<T, Meta>>&
-MeshT<T, Meta>::getVertices() noexcept
-{
-  return m_vertices;
-}
-
-template <class T, class Meta>
-inline const std::vector<VertexT<T, Meta>>&
-MeshT<T, Meta>::getVertices() const noexcept
-{
-  return m_vertices;
-}
-
-template <class T, class Meta>
-inline std::vector<EdgeT<T, Meta>>&
-MeshT<T, Meta>::getEdges() noexcept
-{
-  return m_edges;
-}
-
-template <class T, class Meta>
-inline const std::vector<EdgeT<T, Meta>>&
-MeshT<T, Meta>::getEdges() const noexcept
-{
-  return m_edges;
-}
-
-template <class T, class Meta>
-inline std::vector<FaceT<T, Meta>>&
-MeshT<T, Meta>::getFaces() noexcept
-{
-  return m_faces;
-}
-
-template <class T, class Meta>
-inline const std::vector<FaceT<T, Meta>>&
-MeshT<T, Meta>::getFaces() const noexcept
-{
-  return m_faces;
 }
 
 template <class T, class Meta>
@@ -332,9 +442,10 @@ inline std::vector<Vec3T<T>>
 MeshT<T, Meta>::getAllVertexCoordinates() const noexcept
 {
   std::vector<Vec3> vertexCoordinates;
-  vertexCoordinates.reserve(m_vertices.size());
-  for (const auto& v : m_vertices) {
-    vertexCoordinates.emplace_back(v.getPosition());
+  vertexCoordinates.reserve(this->numVertices());
+
+  for (uint32_t i = 0; i < this->numVertices(); i++) {
+    vertexCoordinates.emplace_back(this->getVertex(i).getPosition());
   }
 
   return vertexCoordinates;
@@ -359,14 +470,14 @@ MeshT<T, Meta>::unsignedDistance2(const Vec3& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  if (m_faces.empty()) {
+  if (this->numFaces() == 0) {
     return std::numeric_limits<T>::infinity();
   }
 
   T minDist2 = std::numeric_limits<T>::max();
 
-  for (const auto& f : m_faces) {
-    const T curDist2 = f.unsignedDistance2(a_point, *this);
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    const T curDist2 = this->getFace(i).unsignedDistance2(a_point, *this);
 
     minDist2 = std::min(minDist2, curDist2);
   }
@@ -417,15 +528,15 @@ MeshT<T, Meta>::DirectSignedDistance(const Vec3& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  if (m_faces.empty()) {
+  if (this->numFaces() == 0) {
     return std::numeric_limits<T>::infinity();
   }
 
-  T minDist  = m_faces.front().signedDistance(a_point, *this);
+  T minDist  = this->getFace(0).signedDistance(a_point, *this);
   T minDist2 = minDist * minDist;
 
-  for (const auto& f : m_faces) {
-    const T curDist  = f.signedDistance(a_point, *this);
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    const T curDist  = this->getFace(i).signedDistance(a_point, *this);
     const T curDist2 = curDist * curDist;
 
     if (curDist2 < minDist2) {
@@ -445,23 +556,23 @@ MeshT<T, Meta>::DirectSignedDistance2(const Vec3& a_point) const noexcept
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
 
-  if (m_faces.empty()) {
+  if (this->numFaces() == 0) {
     return std::numeric_limits<T>::infinity();
   }
 
-  const Face* closest  = &m_faces.front();
-  T           minDist2 = closest->unsignedDistance2(a_point, *this);
+  uint32_t closestIndex = 0;
+  T        minDist2     = this->getFace(closestIndex).unsignedDistance2(a_point, *this);
 
-  for (const auto& f : m_faces) {
-    const T curDist2 = f.unsignedDistance2(a_point, *this);
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    const T curDist2 = this->getFace(i).unsignedDistance2(a_point, *this);
 
     if (curDist2 < minDist2) {
-      closest  = &f;
-      minDist2 = curDist2;
+      closestIndex = i;
+      minDist2     = curDist2;
     }
   }
 
-  return closest->signedDistance(a_point, *this);
+  return this->getFace(closestIndex).signedDistance(a_point, *this);
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_DCEL_VertexImplem.hpp
+++ b/Source/EBGeometry_DCEL_VertexImplem.hpp
@@ -134,7 +134,7 @@ VertexT<T, Meta>::computeVertexNormalAverage(const std::vector<uint32_t>& a_face
   //       will yield an "average" of the normal vectors of the faces
   //       circulating this vertex.
   for (const uint32_t faceIndex : a_faceIndices) {
-    m_normal += a_mesh.getFaces()[faceIndex].getNormal();
+    m_normal += a_mesh.getFace(faceIndex).getNormal();
   }
 
   this->normalizeNormalVector();
@@ -176,11 +176,11 @@ VertexT<T, Meta>::computeVertexNormalAngleWeighted(const uint32_t               
   const uint32_t originVertexIndex = a_thisVertexIndex;
 
   for (const uint32_t faceIndex : a_faceIndices) {
-    const Face& f = a_mesh.getFaces()[faceIndex];
+    const Face& f = a_mesh.getFace(faceIndex);
 
     std::vector<uint32_t> inoutVertices(0);
     for (EdgeIterator edgeIt(a_mesh, f); edgeIt.ok(); ++edgeIt) {
-      const Edge& e = a_mesh.getEdges()[edgeIt()];
+      const Edge& e = a_mesh.getEdge(edgeIt());
 
       const uint32_t v1 = e.getVertexIndex();
       const uint32_t v2 = e.getNextEdge(a_mesh).getVertexIndex();
@@ -217,9 +217,9 @@ VertexT<T, Meta>::computeVertexNormalAngleWeighted(const uint32_t               
     // well-formed triangle incident on exactly two edges at this vertex.
     EBGEOMETRY_EXPECT(inoutVertices.size() == 2);
 
-    const Vec3& x0 = a_mesh.getVertices()[originVertexIndex].getPosition();
-    const Vec3& x1 = a_mesh.getVertices()[inoutVertices[0]].getPosition();
-    const Vec3& x2 = a_mesh.getVertices()[inoutVertices[1]].getPosition();
+    const Vec3& x0 = a_mesh.getVertex(originVertexIndex).getPosition();
+    const Vec3& x1 = a_mesh.getVertex(inoutVertices[0]).getPosition();
+    const Vec3& x2 = a_mesh.getVertex(inoutVertices[1]).getPosition();
 
     if (x0 == x1 || x0 == x2 || x1 == x2) {
       std::cerr << "VertexT<T, Meta>::computeVertexNormalAngleWeighted(): degenerate face f -- two "
@@ -301,7 +301,7 @@ VertexT<T, Meta>::getOutgoingEdge(Mesh& a_mesh) noexcept
 {
   EBGEOMETRY_EXPECT(m_outgoingEdge != UINT32_MAX);
 
-  return a_mesh.getEdges()[m_outgoingEdge];
+  return a_mesh.getEdge(m_outgoingEdge);
 }
 
 template <class T, class Meta>
@@ -310,7 +310,7 @@ VertexT<T, Meta>::getOutgoingEdge(const Mesh& a_mesh) const noexcept
 {
   EBGEOMETRY_EXPECT(m_outgoingEdge != UINT32_MAX);
 
-  return a_mesh.getEdges()[m_outgoingEdge];
+  return a_mesh.getEdge(m_outgoingEdge);
 }
 
 template <class T, class Meta>

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -61,7 +61,7 @@ buildDCELTreeBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcel
   static_assert(K >= 2, "MeshDistanceFunctionsDetail::buildDCELTreeBVH: branching factor K must be at least 2");
 
   EBGEOMETRY_EXPECT(a_dcelMesh != nullptr);
-  EBGEOMETRY_EXPECT(!a_dcelMesh->getFaces().empty());
+  EBGEOMETRY_EXPECT(a_dcelMesh->numFaces() > 0);
 
   using Prim          = EBGeometry::DCEL::FaceT<T, Meta>;
   using PrimAndBVList = std::vector<std::pair<std::shared_ptr<const Prim>, BV>>;
@@ -72,7 +72,9 @@ buildDCELTreeBVH(const std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>& a_dcel
   // resolved against the same retained mesh (see MeshSDF::m_mesh) both before and after the copy.
   PrimAndBVList primsAndBVs;
 
-  for (const auto& f : a_dcelMesh->getFaces()) {
+  for (uint32_t i = 0; i < a_dcelMesh->numFaces(); i++) {
+    const auto& f = a_dcelMesh->getFace(i);
+
     primsAndBVs.emplace_back(
       std::make_pair(std::make_shared<const Prim>(f), BV(f.getAllVertexCoordinates(*a_dcelMesh))));
   }
@@ -432,10 +434,11 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>
 
   std::vector<std::shared_ptr<Tri>> triangles;
 
-  for (const auto& f : a_mesh->getFaces()) {
-    const auto normal        = f.getNormal();
-    const auto vertexIndices = f.gatherVertexIndices(*a_mesh);
-    const auto edgeIndices   = f.gatherEdgeIndices(*a_mesh);
+  for (uint32_t faceIndex = 0; faceIndex < a_mesh->numFaces(); faceIndex++) {
+    const auto& f             = a_mesh->getFace(faceIndex);
+    const auto  normal        = f.getNormal();
+    const auto  vertexIndices = f.gatherVertexIndices(*a_mesh);
+    const auto  edgeIndices   = f.gatherEdgeIndices(*a_mesh);
 
     EBGEOMETRY_EXPECT(vertexIndices.size() == 3);
     EBGEOMETRY_EXPECT(edgeIndices.size() == 3);
@@ -444,13 +447,13 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>
       std::cerr << "TriMeshSDF -- mesh not triangulated!\n";
     }
 
-    const auto& v0 = a_mesh->getVertices()[vertexIndices[0]];
-    const auto& v1 = a_mesh->getVertices()[vertexIndices[1]];
-    const auto& v2 = a_mesh->getVertices()[vertexIndices[2]];
+    const auto& v0 = a_mesh->getVertex(vertexIndices[0]);
+    const auto& v1 = a_mesh->getVertex(vertexIndices[1]);
+    const auto& v2 = a_mesh->getVertex(vertexIndices[2]);
 
-    const auto& e0 = a_mesh->getEdges()[edgeIndices[0]];
-    const auto& e1 = a_mesh->getEdges()[edgeIndices[1]];
-    const auto& e2 = a_mesh->getEdges()[edgeIndices[2]];
+    const auto& e0 = a_mesh->getEdge(edgeIndices[0]);
+    const auto& e1 = a_mesh->getEdge(edgeIndices[1]);
+    const auto& e2 = a_mesh->getEdge(edgeIndices[2]);
 
     auto tri = std::make_shared<Tri>();
 

--- a/Source/EBGeometry_OBJ.hpp
+++ b/Source/EBGeometry_OBJ.hpp
@@ -20,6 +20,7 @@
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
+#include "EBGeometry_Pool.hpp"
 #include "EBGeometry_Vec.hpp"
 
 namespace EBGeometry {
@@ -125,11 +126,12 @@ public:
    * @brief Turn the OBJ mesh into a DCEL mesh.
    * @details This call does not populate any meta-data in the DCEL mesh structures.
    * @tparam Meta Metadata type attached to DCEL vertices, edges, and faces.
+   * @param[in,out] a_pool Pool to reserve the constructed mesh's vertex/edge/face storage from.
    * @return Shared pointer to the constructed DCEL mesh.
    */
   template <typename Meta>
   [[nodiscard]] std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-  convertToDCEL() const noexcept;
+  convertToDCEL(Pool& a_pool) const noexcept;
 
 protected:
   /**

--- a/Source/EBGeometry_OBJImplem.hpp
+++ b/Source/EBGeometry_OBJImplem.hpp
@@ -76,7 +76,7 @@ OBJ<T>::getFacets() const noexcept
 template <typename T>
 template <typename Meta>
 std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-OBJ<T>::convertToDCEL() const noexcept
+OBJ<T>::convertToDCEL(Pool& a_pool) const noexcept
 {
   // Do a deep copy of the vertices and facets since they need to be compressed.
   std::vector<Vec3T<T>>            vertices = m_vertexCoordinates;
@@ -86,7 +86,7 @@ OBJ<T>::convertToDCEL() const noexcept
     std::cerr << "OBJ::convertToDCEL - OBJ contains degenerate faces\n";
   }
 
-  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>();
+  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>(a_pool);
 
   Soup::compress(vertices, facets);
   Soup::soupToDCEL(*mesh, vertices, facets, m_id);

--- a/Source/EBGeometry_PLY.hpp
+++ b/Source/EBGeometry_PLY.hpp
@@ -21,6 +21,7 @@
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
+#include "EBGeometry_Pool.hpp"
 #include "EBGeometry_Vec.hpp"
 
 namespace EBGeometry {
@@ -178,11 +179,12 @@ public:
    * @details This call does not populate any meta-data in the DCEL mesh structures. If you need to also populate
    * the meta-data on vertices and faces, you should not use this function but supply your own constructor.
    * @tparam Meta Metadata type attached to DCEL vertices, edges, and faces.
+   * @param[in,out] a_pool Pool to reserve the constructed mesh's vertex/edge/face storage from.
    * @return Shared pointer to the constructed DCEL mesh.
    */
   template <typename Meta>
   [[nodiscard]] std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-  convertToDCEL() const noexcept;
+  convertToDCEL(Pool& a_pool) const noexcept;
 
 protected:
   /**

--- a/Source/EBGeometry_PLYImplem.hpp
+++ b/Source/EBGeometry_PLYImplem.hpp
@@ -119,7 +119,7 @@ PLY<T>::setFaceProperties(const std::string a_property, std::vector<T> a_data)
 template <typename T>
 template <typename Meta>
 std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-PLY<T>::convertToDCEL() const noexcept
+PLY<T>::convertToDCEL(Pool& a_pool) const noexcept
 {
   // Do a deep copy of the vertices and facets since they might need to be compressed.
   std::vector<Vec3T<T>>            vertices = m_vertexCoordinates;
@@ -129,7 +129,7 @@ PLY<T>::convertToDCEL() const noexcept
     std::cerr << "PLY::convertToDCEL - PLY contains degenerate faces\n";
   }
 
-  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>();
+  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>(a_pool);
 
   Soup::compress(vertices, facets);
   Soup::soupToDCEL(*mesh, vertices, facets, m_id);

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -167,7 +167,9 @@ readVTK(const std::vector<std::string>& a_filenames);
  * @tparam Meta Per-face metadata type stored in the DCEL mesh.
  * @param[in]     a_filename File name (STL, PLY, or VTK).
  * @param[in,out] a_pool     Pool to reserve the constructed mesh's vertex/edge/face storage from.
- * @return Shared pointer to the constructed DCEL mesh.
+ * @return Shared pointer to the constructed DCEL mesh. Never null: if the file extension is not
+ * recognized, this logs to std::cerr and returns a valid but empty mesh (0 faces; its
+ * signedDistance()/unsignedDistance2() correctly report +infinity) rather than a nullptr.
  */
 template <typename T, typename Meta = DCEL::DefaultMetaData>
 [[nodiscard]] inline static std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>

--- a/Source/EBGeometry_Parser.hpp
+++ b/Source/EBGeometry_Parser.hpp
@@ -24,6 +24,7 @@
 #include "EBGeometry_MeshDistanceFunctions.hpp"
 #include "EBGeometry_OBJ.hpp"
 #include "EBGeometry_PLY.hpp"
+#include "EBGeometry_Pool.hpp"
 #include "EBGeometry_STL.hpp"
 #include "EBGeometry_Triangle.hpp"
 #include "EBGeometry_TriangleAoSoA.hpp"
@@ -164,45 +165,51 @@ readVTK(const std::vector<std::string>& a_filenames);
  * @brief Read a file containing a single watertight object and return it as a DCEL mesh.
  * @tparam T    Floating-point precision for vertex coordinates.
  * @tparam Meta Per-face metadata type stored in the DCEL mesh.
- * @param[in] a_filename File name (STL, PLY, or VTK).
+ * @param[in]     a_filename File name (STL, PLY, or VTK).
+ * @param[in,out] a_pool     Pool to reserve the constructed mesh's vertex/edge/face storage from.
  * @return Shared pointer to the constructed DCEL mesh.
  */
 template <typename T, typename Meta = DCEL::DefaultMetaData>
 [[nodiscard]] inline static std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-readIntoDCEL(const std::string a_filename);
+readIntoDCEL(const std::string a_filename, Pool& a_pool);
 
 /**
  * @brief Read multiple files containing single watertight objects and return them as DCEL meshes.
  * @tparam T    Floating-point precision for vertex coordinates.
  * @tparam Meta Per-face metadata type stored in the DCEL mesh.
- * @param[in] a_files List of file names (STL, PLY, or VTK).
+ * @param[in]     a_files List of file names (STL, PLY, or VTK).
+ * @param[in,out] a_pool  Pool to reserve every constructed mesh's storage from -- all meshes
+ * share this one Pool, laid out contiguously.
  * @return Vector of shared pointers to the constructed DCEL meshes, one per file.
  */
 template <typename T, typename Meta = DCEL::DefaultMetaData>
 [[nodiscard]] inline static std::vector<std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>>
-readIntoDCEL(const std::vector<std::string>& a_files);
+readIntoDCEL(const std::vector<std::string>& a_files, Pool& a_pool);
 
 /**
  * @brief Read a file and return it as a bare DCEL signed-distance function (O(N) scan, no BVH).
  * @tparam T    Floating-point precision for signed-distance evaluation.
  * @tparam Meta Per-face metadata type stored in the DCEL mesh.
- * @param[in] a_filename File name (STL, PLY, or VTK).
+ * @param[in]     a_filename File name (STL, PLY, or VTK).
+ * @param[in,out] a_pool     Pool to reserve the constructed mesh's vertex/edge/face storage from.
  * @return Shared pointer to the FlatMeshSDF wrapping the parsed DCEL mesh.
  */
 template <typename T, typename Meta = DCEL::DefaultMetaData>
 [[nodiscard]] inline static std::shared_ptr<FlatMeshSDF<T, Meta>>
-readIntoMesh(const std::string a_filename);
+readIntoMesh(const std::string a_filename, Pool& a_pool);
 
 /**
  * @brief Read multiple files and return each as a bare DCEL signed-distance function.
  * @tparam T    Floating-point precision for signed-distance evaluation.
  * @tparam Meta Per-face metadata type stored in the DCEL mesh.
- * @param[in] a_files List of file names (STL, PLY, or VTK).
+ * @param[in]     a_files List of file names (STL, PLY, or VTK).
+ * @param[in,out] a_pool  Pool to reserve every constructed mesh's storage from -- all meshes
+ * share this one Pool, laid out contiguously.
  * @return Vector of shared pointers to FlatMeshSDF objects, one per file.
  */
 template <typename T, typename Meta = DCEL::DefaultMetaData>
 [[nodiscard]] inline static std::vector<std::shared_ptr<FlatMeshSDF<T, Meta>>>
-readIntoMesh(const std::vector<std::string>& a_files);
+readIntoMesh(const std::vector<std::string>& a_files, Pool& a_pool);
 
 /**
  * @brief Read a file and return it enclosed in a SIMD-accelerated PackedBVH over DCEL faces.
@@ -211,26 +218,30 @@ readIntoMesh(const std::vector<std::string>& a_files);
  * @tparam T    Floating-point precision for signed-distance evaluation.
  * @tparam Meta Per-face metadata type stored in the DCEL mesh.
  * @tparam K    BVH branching factor (number of children per internal node).
- * @param[in] a_filename File name (STL, PLY, or VTK).
- * @param[in] a_build    BVH build strategy. SAH is the default and recommended choice.
+ * @param[in]     a_filename File name (STL, PLY, or VTK).
+ * @param[in,out] a_pool     Pool to reserve the underlying DCEL mesh's storage from. The
+ * returned MeshSDF retains the mesh, so a_pool must outlive it.
+ * @param[in]     a_build    BVH build strategy. SAH is the default and recommended choice.
  * @return Shared pointer to the MeshSDF enclosing the mesh.
  */
 template <typename T, typename Meta = DCEL::DefaultMetaData, size_t K = 4>
 [[nodiscard]] inline static std::shared_ptr<MeshSDF<T, Meta, K>>
-readIntoPackedBVH(const std::string a_filename, const BVH::Build a_build = BVH::Build::SAH);
+readIntoPackedBVH(const std::string a_filename, Pool& a_pool, const BVH::Build a_build = BVH::Build::SAH);
 
 /**
  * @brief Read multiple files and return each enclosed in a SIMD-accelerated PackedBVH over DCEL faces.
  * @tparam T    Floating-point precision for signed-distance evaluation.
  * @tparam Meta Per-face metadata type stored in the DCEL mesh.
  * @tparam K    BVH branching factor (number of children per internal node).
- * @param[in] a_files List of file names (STL, PLY, or VTK).
- * @param[in] a_build BVH build strategy. SAH is the default and recommended choice.
+ * @param[in]     a_files List of file names (STL, PLY, or VTK).
+ * @param[in,out] a_pool  Pool to reserve every underlying DCEL mesh's storage from -- all meshes
+ * share this one Pool, laid out contiguously. Must outlive the returned MeshSDF objects.
+ * @param[in]     a_build BVH build strategy. SAH is the default and recommended choice.
  * @return Vector of shared pointers to MeshSDF objects, one per file.
  */
 template <typename T, typename Meta = DCEL::DefaultMetaData, size_t K = 4>
 [[nodiscard]] inline static std::vector<std::shared_ptr<MeshSDF<T, Meta, K>>>
-readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Build a_build = BVH::Build::SAH);
+readIntoPackedBVH(const std::vector<std::string>& a_files, Pool& a_pool, const BVH::Build a_build = BVH::Build::SAH);
 
 /**
  * @brief Read a file and return the mesh enclosed in a SIMD-optimised triangle BVH.
@@ -246,11 +257,15 @@ readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Build a_bu
  * @tparam StoragePolicy PackedBVH primitive storage policy forwarded to TriMeshSDF (see
  * BVH::SharedPtrStorage / BVH::ValueStorage). Defaults to
  * BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>, matching TriMeshSDF's own default.
- * @param[in] a_filename      File name (STL, PLY, or VTK).
- * @param[in] a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf; the
+ * @param[in]     a_filename      File name (STL, PLY, or VTK).
+ * @param[in,out] a_pool          Pool to reserve the intermediate DCEL mesh's storage from. The
+ * mesh is only used transiently to extract triangles into the returned TriMeshSDF, which does not
+ * retain it, but the Pool itself is a pure bump allocator (see EBGeometry_Pool.hpp) -- the space
+ * reserved here is not reclaimed until a_pool itself is destroyed.
+ * @param[in]     a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf; the
  * actual raw-triangle leaf-size bound used is a_maxLeafGroups * W (see TriMeshSDF's mesh-based
  * constructor for the tree-quality/SIMD-occupancy trade-off). Defaults to 4.
- * @param[in] a_build         BVH build strategy. SAH is the default and recommended choice.
+ * @param[in]     a_build         BVH build strategy. SAH is the default and recommended choice.
  * @return Shared pointer to the TriMeshSDF enclosing the mesh.
  */
 template <typename T,
@@ -260,6 +275,7 @@ template <typename T,
           class StoragePolicy = BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>>
 [[nodiscard]] inline static std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>
 readIntoTriangleBVH(const std::string a_filename,
+                    Pool&             a_pool,
                     const size_t      a_maxLeafGroups = 4,
                     const BVH::Build  a_build         = BVH::Build::SAH);
 
@@ -271,10 +287,12 @@ readIntoTriangleBVH(const std::string a_filename,
  * @tparam W    SIMD lane width: triangles per SoA group. Defaults to TriangleSoA::DefaultWidth<T>().
  * @tparam StoragePolicy PackedBVH primitive storage policy forwarded to TriMeshSDF (see the
  * single-file overload).
- * @param[in] a_files         List of file names (STL, PLY, or VTK).
- * @param[in] a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf (see
+ * @param[in]     a_files         List of file names (STL, PLY, or VTK).
+ * @param[in,out] a_pool          Pool to reserve every intermediate DCEL mesh's storage from (see
+ * the single-file overload for details) -- all meshes share this one Pool, laid out contiguously.
+ * @param[in]     a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf (see
  * the single-file overload for details). Defaults to 4.
- * @param[in] a_build         BVH build strategy. SAH is the default and recommended choice.
+ * @param[in]     a_build         BVH build strategy. SAH is the default and recommended choice.
  * @return Vector of shared pointers to TriMeshSDF objects, one per file.
  */
 template <typename T,
@@ -284,6 +302,7 @@ template <typename T,
           class StoragePolicy = BVH::ValueStorage<TriangleAoSoA<T, Meta, W>>>
 [[nodiscard]] inline static std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>>
 readIntoTriangleBVH(const std::vector<std::string>& a_files,
+                    Pool&                           a_pool,
                     const size_t                    a_maxLeafGroups = 4,
                     const BVH::Build                a_build         = BVH::Build::SAH);
 
@@ -293,23 +312,29 @@ readIntoTriangleBVH(const std::vector<std::string>& a_files,
  * independent Triangle with precomputed vertex positions, normals, and edge normals.
  * @tparam T    Floating-point precision for vertex coordinates and normals.
  * @tparam Meta Per-face metadata type.
- * @param[in] a_filename File name (STL, PLY, or VTK).
+ * @param[in]     a_filename File name (STL, PLY, or VTK).
+ * @param[in,out] a_pool     Pool to reserve the intermediate DCEL mesh's storage from. The mesh is
+ * only used transiently to extract triangles and is not retained by the returned list, but the
+ * Pool itself is a pure bump allocator (see EBGeometry_Pool.hpp) -- the space reserved here is not
+ * reclaimed until a_pool itself is destroyed.
  * @return Flat vector of shared pointers to Triangle objects.
  */
 template <typename T, typename Meta>
 [[nodiscard]] inline static std::vector<std::shared_ptr<Triangle<T, Meta>>>
-readIntoTriangles(const std::string a_filename);
+readIntoTriangles(const std::string a_filename, Pool& a_pool);
 
 /**
  * @brief Read multiple files and return all faces from each as flat lists of Triangle objects.
  * @tparam T    Floating-point precision for vertex coordinates and normals.
  * @tparam Meta Per-face metadata type.
- * @param[in] a_files List of file names (STL, PLY, or VTK).
+ * @param[in]     a_files List of file names (STL, PLY, or VTK).
+ * @param[in,out] a_pool  Pool to reserve every intermediate DCEL mesh's storage from -- all meshes
+ * share this one Pool, laid out contiguously (see the single-file overload for details).
  * @return Outer vector indexed by file; each inner vector is the flat triangle list for that file.
  */
 template <typename T, typename Meta>
 [[nodiscard]] inline static std::vector<std::vector<std::shared_ptr<Triangle<T, Meta>>>>
-readIntoTriangles(const std::vector<std::string>& a_files);
+readIntoTriangles(const std::vector<std::string>& a_files, Pool& a_pool);
 } // namespace Parser
 
 } // namespace EBGeometry

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -1752,7 +1752,13 @@ template <typename T, typename Meta>
 Parser::readIntoDCEL(const std::string a_filename, Pool& a_pool)
 {
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoDCEL requires T to be a floating-point type");
-  std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>> mesh;
+
+  // Default to an empty (but valid, non-null) mesh so that an unsupported file type -- caught only
+  // by the Unsupported/default branches below, which just log to std::cerr -- still returns a mesh
+  // callers can safely use (0 faces; signedDistance()/unsignedDistance2() correctly report
+  // +infinity), rather than a nullptr that every readInto*/convertToDCEL caller downstream would
+  // need to guard against separately.
+  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>(a_pool);
 
   const auto ft = Parser::getFileType(a_filename);
 

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -1749,10 +1749,10 @@ Parser::readOBJ(const std::vector<std::string>& a_filenames)
 
 template <typename T, typename Meta>
 [[nodiscard]] inline std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-Parser::readIntoDCEL(const std::string a_filename)
+Parser::readIntoDCEL(const std::string a_filename, Pool& a_pool)
 {
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoDCEL requires T to be a floating-point type");
-  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>();
+  std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>> mesh;
 
   const auto ft = Parser::getFileType(a_filename);
 
@@ -1760,28 +1760,28 @@ Parser::readIntoDCEL(const std::string a_filename)
   case Parser::FileType::STL: {
     const STL<T> stl = readSTL<T>(a_filename);
 
-    mesh = stl.template convertToDCEL<Meta>();
+    mesh = stl.template convertToDCEL<Meta>(a_pool);
 
     break;
   }
   case Parser::FileType::PLY: {
     const PLY<T> ply = readPLY<T>(a_filename);
 
-    mesh = ply.template convertToDCEL<Meta>();
+    mesh = ply.template convertToDCEL<Meta>(a_pool);
 
     break;
   }
   case Parser::FileType::VTK: {
     const VTK<T> vtk = readVTK<T>(a_filename);
 
-    mesh = vtk.template convertToDCEL<Meta>();
+    mesh = vtk.template convertToDCEL<Meta>(a_pool);
 
     break;
   }
   case Parser::FileType::OBJ: {
     const OBJ<T> obj = readOBJ<T>(a_filename);
 
-    mesh = obj.template convertToDCEL<Meta>();
+    mesh = obj.template convertToDCEL<Meta>(a_pool);
 
     break;
   }
@@ -1802,13 +1802,13 @@ Parser::readIntoDCEL(const std::string a_filename)
 
 template <typename T, typename Meta>
 [[nodiscard]] inline std::vector<std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>>
-Parser::readIntoDCEL(const std::vector<std::string>& a_files)
+Parser::readIntoDCEL(const std::vector<std::string>& a_files, Pool& a_pool)
 {
   std::vector<std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>> objects;
 
   objects.reserve(a_files.size());
   for (const auto& file : a_files) {
-    objects.emplace_back(Parser::readIntoDCEL<T, Meta>(file));
+    objects.emplace_back(Parser::readIntoDCEL<T, Meta>(file, a_pool));
   }
 
   return objects;
@@ -1816,22 +1816,22 @@ Parser::readIntoDCEL(const std::vector<std::string>& a_files)
 
 template <typename T, typename Meta>
 [[nodiscard]] inline std::shared_ptr<FlatMeshSDF<T, Meta>>
-Parser::readIntoMesh(const std::string a_filename)
+Parser::readIntoMesh(const std::string a_filename, Pool& a_pool)
 {
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(a_filename);
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(a_filename, a_pool);
 
   return std::make_shared<FlatMeshSDF<T, Meta>>(mesh);
 }
 
 template <typename T, typename Meta>
 [[nodiscard]] inline std::vector<std::shared_ptr<FlatMeshSDF<T, Meta>>>
-Parser::readIntoMesh(const std::vector<std::string>& a_files)
+Parser::readIntoMesh(const std::vector<std::string>& a_files, Pool& a_pool)
 {
   std::vector<std::shared_ptr<FlatMeshSDF<T, Meta>>> implicitFunctions;
 
   implicitFunctions.reserve(a_files.size());
   for (const auto& file : a_files) {
-    implicitFunctions.emplace_back(Parser::readIntoMesh<T, Meta>(file));
+    implicitFunctions.emplace_back(Parser::readIntoMesh<T, Meta>(file, a_pool));
   }
 
   return implicitFunctions;
@@ -1839,25 +1839,26 @@ Parser::readIntoMesh(const std::vector<std::string>& a_files)
 
 template <typename T, typename Meta>
 [[nodiscard]] std::vector<std::shared_ptr<Triangle<T, Meta>>>
-Parser::readIntoTriangles(const std::string a_filename)
+Parser::readIntoTriangles(const std::string a_filename, Pool& a_pool)
 {
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(a_filename);
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(a_filename, a_pool);
 
   std::vector<std::shared_ptr<Triangle<T, Meta>>> triangles;
 
   bool onlyTriangles = true;
 
-  for (const auto& f : mesh->getFaces()) {
-    const auto normal        = f.getNormal();
-    const auto vertexIndices = f.gatherVertexIndices(*mesh);
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    const auto& f             = mesh->getFace(i);
+    const auto  normal        = f.getNormal();
+    const auto  vertexIndices = f.gatherVertexIndices(*mesh);
 
     if (vertexIndices.size() != 3) {
       onlyTriangles = false;
     }
 
-    const auto& v0 = mesh->getVertices()[vertexIndices[0]];
-    const auto& v1 = mesh->getVertices()[vertexIndices[1]];
-    const auto& v2 = mesh->getVertices()[vertexIndices[2]];
+    const auto& v0 = mesh->getVertex(vertexIndices[0]);
+    const auto& v1 = mesh->getVertex(vertexIndices[1]);
+    const auto& v2 = mesh->getVertex(vertexIndices[2]);
 
     // Create the triangle
     auto tri = std::make_shared<Triangle<T, Meta>>();
@@ -1879,13 +1880,13 @@ Parser::readIntoTriangles(const std::string a_filename)
 
 template <typename T, typename Meta>
 [[nodiscard]] std::vector<std::vector<std::shared_ptr<Triangle<T, Meta>>>>
-Parser::readIntoTriangles(const std::vector<std::string>& a_files)
+Parser::readIntoTriangles(const std::vector<std::string>& a_files, Pool& a_pool)
 {
   std::vector<std::vector<std::shared_ptr<Triangle<T, Meta>>>> triangles;
 
   triangles.reserve(a_files.size());
   for (const auto& file : a_files) {
-    triangles.emplace_back(Parser::readIntoTriangles<T, Meta>(file));
+    triangles.emplace_back(Parser::readIntoTriangles<T, Meta>(file, a_pool));
   }
 
   return triangles;
@@ -1893,12 +1894,15 @@ Parser::readIntoTriangles(const std::vector<std::string>& a_files)
 
 template <typename T, typename Meta, size_t K, size_t W, class StoragePolicy>
 [[nodiscard]] inline std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>
-Parser::readIntoTriangleBVH(const std::string a_filename, const size_t a_maxLeafGroups, const BVH::Build a_build)
+Parser::readIntoTriangleBVH(const std::string a_filename,
+                            Pool&             a_pool,
+                            const size_t      a_maxLeafGroups,
+                            const BVH::Build  a_build)
 {
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoTriangleBVH requires T to be a floating-point type");
   static_assert(K > 0, "Parser::readIntoTriangleBVH requires K > 0");
   static_assert(W > 0, "Parser::readIntoTriangleBVH requires W > 0");
-  const auto mesh = EBGeometry::Parser::readIntoTriangles<T, Meta>(a_filename);
+  const auto mesh = EBGeometry::Parser::readIntoTriangles<T, Meta>(a_filename, a_pool);
 
   return std::make_shared<TriMeshSDF<T, Meta, K, W, StoragePolicy>>(mesh, a_build, a_maxLeafGroups);
 }
@@ -1906,6 +1910,7 @@ Parser::readIntoTriangleBVH(const std::string a_filename, const size_t a_maxLeaf
 template <typename T, typename Meta, size_t K, size_t W, class StoragePolicy>
 [[nodiscard]] inline std::vector<std::shared_ptr<TriMeshSDF<T, Meta, K, W, StoragePolicy>>>
 Parser::readIntoTriangleBVH(const std::vector<std::string>& a_files,
+                            Pool&                           a_pool,
                             const size_t                    a_maxLeafGroups,
                             const BVH::Build                a_build)
 {
@@ -1917,7 +1922,7 @@ Parser::readIntoTriangleBVH(const std::vector<std::string>& a_files,
   implicitFunctions.reserve(a_files.size());
   for (const auto& file : a_files) {
     implicitFunctions.emplace_back(
-      Parser::readIntoTriangleBVH<T, Meta, K, W, StoragePolicy>(file, a_maxLeafGroups, a_build));
+      Parser::readIntoTriangleBVH<T, Meta, K, W, StoragePolicy>(file, a_pool, a_maxLeafGroups, a_build));
   }
 
   return implicitFunctions;
@@ -1925,18 +1930,18 @@ Parser::readIntoTriangleBVH(const std::vector<std::string>& a_files,
 
 template <typename T, typename Meta, size_t K>
 [[nodiscard]] inline std::shared_ptr<MeshSDF<T, Meta, K>>
-Parser::readIntoPackedBVH(const std::string a_filename, const BVH::Build a_build)
+Parser::readIntoPackedBVH(const std::string a_filename, Pool& a_pool, const BVH::Build a_build)
 {
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoPackedBVH requires T to be a floating-point type");
   static_assert(K > 0, "Parser::readIntoPackedBVH requires K > 0");
-  const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename);
+  const auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename, a_pool);
 
   return std::make_shared<MeshSDF<T, Meta, K>>(mesh, a_build);
 }
 
 template <typename T, typename Meta, size_t K>
 [[nodiscard]] inline std::vector<std::shared_ptr<MeshSDF<T, Meta, K>>>
-Parser::readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Build a_build)
+Parser::readIntoPackedBVH(const std::vector<std::string>& a_files, Pool& a_pool, const BVH::Build a_build)
 {
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoPackedBVH requires T to be a floating-point type");
   static_assert(K > 0, "Parser::readIntoPackedBVH requires K > 0");
@@ -1944,7 +1949,7 @@ Parser::readIntoPackedBVH(const std::vector<std::string>& a_files, const BVH::Bu
 
   implicitFunctions.reserve(a_files.size());
   for (const auto& file : a_files) {
-    implicitFunctions.emplace_back(Parser::readIntoPackedBVH<T, Meta, K>(file, a_build));
+    implicitFunctions.emplace_back(Parser::readIntoPackedBVH<T, Meta, K>(file, a_pool, a_build));
   }
 
   return implicitFunctions;

--- a/Source/EBGeometry_STL.hpp
+++ b/Source/EBGeometry_STL.hpp
@@ -20,6 +20,7 @@
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
+#include "EBGeometry_Pool.hpp"
 #include "EBGeometry_Vec.hpp"
 
 namespace EBGeometry {
@@ -125,11 +126,12 @@ public:
    * @brief Turn the STL mesh into a DCEL mesh.
    * @details This call does not populate any meta-data in the DCEL mesh structures.
    * @tparam Meta Metadata type attached to DCEL vertices, edges, and faces.
+   * @param[in,out] a_pool Pool to reserve the constructed mesh's vertex/edge/face storage from.
    * @return Shared pointer to the constructed DCEL mesh.
    */
   template <typename Meta>
   [[nodiscard]] std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-  convertToDCEL() const noexcept;
+  convertToDCEL(Pool& a_pool) const noexcept;
 
 protected:
   /**

--- a/Source/EBGeometry_STLImplem.hpp
+++ b/Source/EBGeometry_STLImplem.hpp
@@ -76,7 +76,7 @@ STL<T>::getFacets() const noexcept
 template <typename T>
 template <typename Meta>
 std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-STL<T>::convertToDCEL() const noexcept
+STL<T>::convertToDCEL(Pool& a_pool) const noexcept
 {
   // Do a deep copy of the vertices and facets since they need to be compressed.
   std::vector<Vec3T<T>>            vertices = m_vertexCoordinates;
@@ -86,7 +86,7 @@ STL<T>::convertToDCEL() const noexcept
     std::cerr << "STL::convertToDCEL - STL contains degenerate faces\n";
   }
 
-  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>();
+  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>(a_pool);
 
   Soup::compress(vertices, facets);
   Soup::soupToDCEL(*mesh, vertices, facets, m_id);

--- a/Source/EBGeometry_SoupImplem.hpp
+++ b/Source/EBGeometry_SoupImplem.hpp
@@ -158,15 +158,23 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
   using Edge   = EBGeometry::DCEL::EdgeT<T, Meta>;
   using Face   = EBGeometry::DCEL::FaceT<T, Meta>;
 
-  std::vector<Vertex>& vertices = a_mesh.getVertices();
-  std::vector<Edge>&   edges    = a_mesh.getEdges();
-  std::vector<Face>&   faces    = a_mesh.getFaces();
+  // Upper bound on the half-edge count: every facet contributes one half-edge per vertex, even
+  // ones later skipped below for having fewer than 3 vertices. PODVector capacity need not be
+  // used exactly, so reserving this upper bound (rather than a second pass to compute the exact
+  // count) is fine.
+  size_t numEdgesUpperBound = 0;
+  for (const auto& curFacet : a_facets) {
+    numEdgesUpperBound += curFacet.size();
+  }
+
+  a_mesh.reserveVertices(static_cast<uint32_t>(a_vertices.size()));
+  a_mesh.reserveEdges(static_cast<uint32_t>(numEdgesUpperBound));
+  a_mesh.reserveFaces(static_cast<uint32_t>(a_facets.size()));
 
   // Build the vertex array from the input vertices; index i here becomes vertex index i in the
   // mesh, matching how a_facets already indexes into a_vertices.
-  vertices.reserve(a_vertices.size());
   for (const auto& v : a_vertices) {
-    vertices.emplace_back(v, Vec3::zeros());
+    a_mesh.addVertex(Vertex(v, Vec3::zeros()));
   }
 
   // Now build the faces, appending each facet's half-edges directly into the mesh's own edge/face
@@ -175,34 +183,34 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
     if (curFacet.size() < 3) {
       std::cerr << "Parser::soupToDCEL -- not enough vertices in face, skipping it\n";
 
-      // The cerr above only warns; falling through here would reach edges[firstEdgeIndex] below
+      // The cerr above only warns; falling through here would reach getEdge(firstEdgeIndex) below
       // on a 0-vertex facet, which is a bounds violation.
       EBGEOMETRY_EXPECT(curFacet.size() >= 3);
 
       continue;
     }
 
-    const uint32_t firstEdgeIndex = static_cast<uint32_t>(edges.size());
-    const uint32_t numEdges       = static_cast<uint32_t>(curFacet.size());
+    const uint32_t firstEdgeIndex = a_mesh.numEdges();
+    const uint32_t numFaceEdges   = static_cast<uint32_t>(curFacet.size());
 
     // Build the half-edges for this polygon: one per vertex, appended contiguously.
-    for (uint32_t i = 0; i < numEdges; i++) {
+    for (uint32_t i = 0; i < numFaceEdges; i++) {
       const uint32_t vertexIndex = static_cast<uint32_t>(curFacet[i]);
-      EBGEOMETRY_EXPECT(vertexIndex < vertices.size());
+      EBGEOMETRY_EXPECT(vertexIndex < a_mesh.numVertices());
 
-      edges.emplace_back(vertexIndex);
-      vertices[vertexIndex].setEdge(firstEdgeIndex + i);
+      a_mesh.addEdge(Edge(vertexIndex));
+      a_mesh.getVertex(vertexIndex).setEdge(firstEdgeIndex + i);
     }
 
-    for (uint32_t i = 0; i < numEdges; i++) {
-      edges[firstEdgeIndex + i].setNextEdge(firstEdgeIndex + (i + 1) % numEdges);
+    for (uint32_t i = 0; i < numFaceEdges; i++) {
+      a_mesh.getEdge(firstEdgeIndex + i).setNextEdge(firstEdgeIndex + (i + 1) % numFaceEdges);
     }
 
-    const uint32_t faceIndex = static_cast<uint32_t>(faces.size());
-    faces.emplace_back(firstEdgeIndex);
+    const uint32_t faceIndex = a_mesh.numFaces();
+    a_mesh.addFace(Face(firstEdgeIndex));
 
-    for (uint32_t i = 0; i < numEdges; i++) {
-      edges[firstEdgeIndex + i].setFace(faceIndex);
+    for (uint32_t i = 0; i < numFaceEdges; i++) {
+      a_mesh.getEdge(firstEdgeIndex + i).setFace(faceIndex);
     }
   }
 
@@ -222,38 +230,38 @@ Soup::reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh) noexcept
 
   using Edge = EBGeometry::DCEL::EdgeT<T, Meta>;
 
-  std::vector<Edge>& edges       = a_mesh.getEdges();
-  const size_t       numVertices = a_mesh.getVertices().size();
+  const uint32_t numEdges    = a_mesh.numEdges();
+  const uint32_t numVertices = a_mesh.numVertices();
 
   // Local, transient bookkeeping (NOT stored on VertexT, which keeps only a single outgoing-edge
   // index -- see its class-level note): which half-edges start at each vertex, so the search below
   // stays O(V + E) instead of an O(E^2) scan over every edge pair.
   std::vector<std::vector<uint32_t>> edgesStartingAtVertex(numVertices);
-  for (uint32_t i = 0; i < edges.size(); i++) {
-    const uint32_t v = edges[i].getVertexIndex();
+  for (uint32_t i = 0; i < numEdges; i++) {
+    const uint32_t v = a_mesh.getEdge(i).getVertexIndex();
 
     EBGEOMETRY_EXPECT(v < numVertices);
 
     edgesStartingAtVertex[v].push_back(i);
   }
 
-  for (uint32_t curIndex = 0; curIndex < edges.size(); curIndex++) {
-    Edge& curEdge = edges[curIndex];
+  for (uint32_t curIndex = 0; curIndex < numEdges; curIndex++) {
+    Edge& curEdge = a_mesh.getEdge(curIndex);
 
     const uint32_t nextIndex = curEdge.getNextEdgeIndex();
     EBGEOMETRY_EXPECT(nextIndex != UINT32_MAX);
 
     const uint32_t vertexStart = curEdge.getVertexIndex();
-    const uint32_t vertexEnd   = edges[nextIndex].getVertexIndex();
+    const uint32_t vertexEnd   = a_mesh.getEdge(nextIndex).getVertexIndex();
 
     // The pair edge starts where this edge ends, and ends where this edge starts.
     for (const uint32_t candIndex : edgesStartingAtVertex[vertexEnd]) {
-      Edge&          candEdge      = edges[candIndex];
+      Edge&          candEdge      = a_mesh.getEdge(candIndex);
       const uint32_t candNextIndex = candEdge.getNextEdgeIndex();
 
       EBGEOMETRY_EXPECT(candNextIndex != UINT32_MAX);
 
-      if (edges[candNextIndex].getVertexIndex() == vertexStart) { // Found the pair edge
+      if (a_mesh.getEdge(candNextIndex).getVertexIndex() == vertexStart) { // Found the pair edge
         curEdge.setPairEdge(candIndex);
         candEdge.setPairEdge(curIndex);
 

--- a/Source/EBGeometry_VTK.hpp
+++ b/Source/EBGeometry_VTK.hpp
@@ -21,6 +21,7 @@
 
 // Our includes
 #include "EBGeometry_DCEL.hpp"
+#include "EBGeometry_Pool.hpp"
 #include "EBGeometry_Vec.hpp"
 
 namespace EBGeometry {
@@ -178,11 +179,12 @@ public:
    * @details This call does not populate any meta-data in the DCEL mesh structures. If you need to also populate
    * the meta-data on vertices and faces, you should not use this function but supply your own constructor.
    * @tparam Meta Metadata type attached to DCEL vertices, edges, and faces.
+   * @param[in,out] a_pool Pool to reserve the constructed mesh's vertex/edge/face storage from.
    * @return Shared pointer to the constructed DCEL mesh.
    */
   template <typename Meta>
   [[nodiscard]] std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-  convertToDCEL() const noexcept;
+  convertToDCEL(Pool& a_pool) const noexcept;
 
 protected:
   /**

--- a/Source/EBGeometry_VTKImplem.hpp
+++ b/Source/EBGeometry_VTKImplem.hpp
@@ -119,7 +119,7 @@ VTK<T>::setCellDataScalars(const std::string a_name, std::vector<T> a_data)
 template <typename T>
 template <typename Meta>
 std::shared_ptr<EBGeometry::DCEL::MeshT<T, Meta>>
-VTK<T>::convertToDCEL() const noexcept
+VTK<T>::convertToDCEL(Pool& a_pool) const noexcept
 {
   // Do a deep copy of the vertices and facets since they might need to be compressed.
   std::vector<Vec3T<T>>            vertices = m_vertexCoordinates;
@@ -129,7 +129,7 @@ VTK<T>::convertToDCEL() const noexcept
     std::cerr << "VTK::convertToDCEL - VTK contains degenerate faces\n";
   }
 
-  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>();
+  auto mesh = std::make_shared<EBGeometry::DCEL::MeshT<T, Meta>>(a_pool);
 
   Soup::compress(vertices, facets);
   Soup::soupToDCEL(*mesh, vertices, facets, m_id);

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -156,21 +156,25 @@ instantiateFunctionTemplates()
   (void)Parser::readVTK<T>(file);
   (void)Parser::readVTK<T>(files);
 
-  (void)Parser::readIntoDCEL<T, Meta>(file);
-  (void)Parser::readIntoDCEL<T, Meta>(files);
-  (void)Parser::readIntoMesh<T, Meta>(file);
-  (void)Parser::readIntoMesh<T, Meta>(files);
-  (void)Parser::readIntoPackedBVH<T, Meta>(file);
-  (void)Parser::readIntoPackedBVH<T, Meta>(files);
-  (void)Parser::readIntoTriangles<T, Meta>(file);
-  (void)Parser::readIntoTriangles<T, Meta>(files);
-  (void)Parser::readIntoTriangleBVH<T, Meta>(file);
-  (void)Parser::readIntoTriangleBVH<T, Meta>(files);
+  // A second, unfrozen Pool for every DCEL-mesh-building entry point below (the one above is
+  // frozen by this point, and MeshT reservations are forbidden against a frozen Pool).
+  Pool meshPool(hostMemoryResource());
 
-  (void)STL<T>().template convertToDCEL<Meta>();
-  (void)PLY<T>().template convertToDCEL<Meta>();
-  (void)VTK<T>().template convertToDCEL<Meta>();
-  (void)OBJ<T>().template convertToDCEL<Meta>();
+  (void)Parser::readIntoDCEL<T, Meta>(file, meshPool);
+  (void)Parser::readIntoDCEL<T, Meta>(files, meshPool);
+  (void)Parser::readIntoMesh<T, Meta>(file, meshPool);
+  (void)Parser::readIntoMesh<T, Meta>(files, meshPool);
+  (void)Parser::readIntoPackedBVH<T, Meta>(file, meshPool);
+  (void)Parser::readIntoPackedBVH<T, Meta>(files, meshPool);
+  (void)Parser::readIntoTriangles<T, Meta>(file, meshPool);
+  (void)Parser::readIntoTriangles<T, Meta>(files, meshPool);
+  (void)Parser::readIntoTriangleBVH<T, Meta>(file, meshPool);
+  (void)Parser::readIntoTriangleBVH<T, Meta>(files, meshPool);
+
+  (void)STL<T>().template convertToDCEL<Meta>(meshPool);
+  (void)PLY<T>().template convertToDCEL<Meta>(meshPool);
+  (void)VTK<T>().template convertToDCEL<Meta>(meshPool);
+  (void)OBJ<T>().template convertToDCEL<Meta>(meshPool);
 }
 
 template void

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -83,19 +83,21 @@ TEMPLATE_TEST_CASE("Dodecahedron: all four file formats parse into an identical,
 {
   using T = TestType;
 
-  const auto meshSTL = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
-  const auto meshPLY = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.ply"));
-  const auto meshOBJ = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.obj"));
-  const auto meshVTK = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.vtk"));
+  Pool pool(hostMemoryResource());
+
+  const auto meshSTL = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
+  const auto meshPLY = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.ply"), pool);
+  const auto meshOBJ = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.obj"), pool);
+  const auto meshVTK = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.vtk"), pool);
 
   for (const auto& mesh : {meshSTL, meshPLY, meshOBJ, meshVTK}) {
     REQUIRE(mesh != nullptr);
-    REQUIRE(mesh->getVertices().size() == 20);
-    REQUIRE(mesh->getFaces().size() == 36);
-    REQUIRE(mesh->getEdges().size() == 108); // 54 undirected edges * 2 half-edges each.
+    REQUIRE(mesh->numVertices() == 20);
+    REQUIRE(mesh->numFaces() == 36);
+    REQUIRE(mesh->numEdges() == 108); // 54 undirected edges * 2 half-edges each.
 
-    for (const auto& e : mesh->getEdges()) {
-      REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
+    for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+      REQUIRE(mesh->getEdge(i).getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
     }
   }
 
@@ -119,13 +121,15 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
 
   constexpr size_t K = 4;
 
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.obj"));
+  Pool       pool(hostMemoryResource());
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.obj"), pool);
   REQUIRE(mesh != nullptr);
 
   using Face = DCEL::FaceT<T, Meta>;
 
   BVH::PrimAndBVList<Face, AABB> primsAndBVs;
-  for (const auto& f : mesh->getFaces()) {
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    const auto& f = mesh->getFace(i);
     primsAndBVs.emplace_back(std::make_shared<const Face>(f), AABB(f.getAllVertexCoordinates(*mesh)));
   }
   REQUIRE(primsAndBVs.size() == 36);
@@ -201,7 +205,8 @@ TEMPLATE_TEST_CASE("MeshSDF: signedDistance agrees with FlatMeshSDF for every BV
 
   constexpr size_t K = 4;
 
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
+  Pool       pool(hostMemoryResource());
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
   REQUIRE(mesh != nullptr);
 
   const FlatMeshSDF<T, Meta> flat(mesh);
@@ -224,7 +229,8 @@ TEMPLATE_TEST_CASE("TriMeshSDF: signedDistance agrees with FlatMeshSDF and MeshS
   constexpr size_t K = 4;
   constexpr size_t W = 4;
 
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.ply"));
+  Pool       pool(hostMemoryResource());
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.ply"), pool);
   REQUIRE(mesh != nullptr);
 
   const FlatMeshSDF<T, Meta> flat(mesh);
@@ -248,7 +254,8 @@ TEMPLATE_TEST_CASE("MeshSDF::getClosestFaces returns the correct number of candi
 
   constexpr size_t K = 4;
 
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.vtk"));
+  Pool       pool(hostMemoryResource());
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.vtk"), pool);
   REQUIRE(mesh != nullptr);
 
   const MeshSDF<T, Meta, K> packed(mesh, BVH::Build::SAH);
@@ -631,11 +638,12 @@ TEMPLATE_TEST_CASE("Parser::readIntoPackedBVH matches MeshSDF built directly fro
 
   constexpr size_t K = 4;
 
-  const auto direct = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
+  Pool       pool(hostMemoryResource());
+  const auto direct = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
   REQUIRE(direct != nullptr);
 
   const MeshSDF<T, Meta, K> expected(direct, BVH::Build::SAH);
-  const auto                fromFile = Parser::readIntoPackedBVH<T, Meta, K>(dataPath("dodecahedron.stl"));
+  const auto                fromFile = Parser::readIntoPackedBVH<T, Meta, K>(dataPath("dodecahedron.stl"), pool);
 
   REQUIRE(fromFile != nullptr);
 
@@ -658,15 +666,17 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
   // loop, not some kind of multi-mesh merge.
   const std::vector<std::string> files = {dataPath("dodecahedron.stl"), dataPath("dodecahedron.ply")};
 
+  Pool pool(hostMemoryResource());
+
   SECTION("readIntoDCEL")
   {
-    const auto meshes = Parser::readIntoDCEL<T, Meta>(files);
+    const auto meshes = Parser::readIntoDCEL<T, Meta>(files, pool);
     REQUIRE(meshes.size() == 2);
 
     for (size_t i = 0; i < files.size(); i++) {
-      const auto single = Parser::readIntoDCEL<T, Meta>(files[i]);
-      REQUIRE(meshes[i]->getVertices().size() == single->getVertices().size());
-      REQUIRE(meshes[i]->getFaces().size() == single->getFaces().size());
+      const auto single = Parser::readIntoDCEL<T, Meta>(files[i], pool);
+      REQUIRE(meshes[i]->numVertices() == single->numVertices());
+      REQUIRE(meshes[i]->numFaces() == single->numFaces());
       for (const auto& p : queryPoints<T>()) {
         REQUIRE_THAT(meshes[i]->signedDistance(p), withinAbsT(single->signedDistance(p), formatMargin<T>()));
       }
@@ -675,11 +685,11 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
 
   SECTION("readIntoMesh")
   {
-    const auto flatSDFs = Parser::readIntoMesh<T, Meta>(files);
+    const auto flatSDFs = Parser::readIntoMesh<T, Meta>(files, pool);
     REQUIRE(flatSDFs.size() == 2);
 
     for (size_t i = 0; i < files.size(); i++) {
-      const auto single = Parser::readIntoMesh<T, Meta>(files[i]);
+      const auto single = Parser::readIntoMesh<T, Meta>(files[i], pool);
       for (const auto& p : queryPoints<T>()) {
         REQUIRE_THAT(flatSDFs[i]->signedDistance(p), withinAbsT(single->signedDistance(p), formatMargin<T>()));
       }
@@ -688,11 +698,11 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
 
   SECTION("readIntoPackedBVH")
   {
-    const auto packedSDFs = Parser::readIntoPackedBVH<T, Meta, K>(files);
+    const auto packedSDFs = Parser::readIntoPackedBVH<T, Meta, K>(files, pool);
     REQUIRE(packedSDFs.size() == 2);
 
     for (size_t i = 0; i < files.size(); i++) {
-      const auto single = Parser::readIntoPackedBVH<T, Meta, K>(files[i]);
+      const auto single = Parser::readIntoPackedBVH<T, Meta, K>(files[i], pool);
       for (const auto& p : queryPoints<T>()) {
         REQUIRE_THAT(packedSDFs[i]->signedDistance(p), withinAbsT(single->signedDistance(p), formatMargin<T>()));
       }
@@ -701,11 +711,11 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
 
   SECTION("readIntoTriangleBVH")
   {
-    const auto triSDFs = Parser::readIntoTriangleBVH<T, Meta>(files);
+    const auto triSDFs = Parser::readIntoTriangleBVH<T, Meta>(files, pool);
     REQUIRE(triSDFs.size() == 2);
 
     for (size_t i = 0; i < files.size(); i++) {
-      const auto single = Parser::readIntoTriangleBVH<T, Meta>(files[i]);
+      const auto single = Parser::readIntoTriangleBVH<T, Meta>(files[i], pool);
       for (const auto& p : queryPoints<T>()) {
         REQUIRE_THAT(triSDFs[i]->signedDistance(p), withinAbsT(single->signedDistance(p), formatMargin<T>()));
       }
@@ -977,7 +987,8 @@ TEMPLATE_TEST_CASE("TriMeshSDF: explicit BVH::SharedPtrStorage<TriAoSoA> agrees 
 
   using TriAoSoA = TriangleAoSoA<T, Meta, W>;
 
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
+  Pool       pool(hostMemoryResource());
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
   REQUIRE(mesh != nullptr);
 
   const TriMeshSDF<T, Meta, K, W>                                  defaultStorage(mesh, BVH::Build::SAH, 2);
@@ -999,9 +1010,10 @@ TEMPLATE_TEST_CASE("Parser::readIntoTriangleBVH accepts an explicit StoragePolic
 
   using TriAoSoA = TriangleAoSoA<T, Meta, W>;
 
-  const auto defaultTri = Parser::readIntoTriangleBVH<T, Meta, K, W>(dataPath("dodecahedron.stl"));
+  Pool       pool(hostMemoryResource());
+  const auto defaultTri = Parser::readIntoTriangleBVH<T, Meta, K, W>(dataPath("dodecahedron.stl"), pool);
   const auto sharedTri =
-    Parser::readIntoTriangleBVH<T, Meta, K, W, BVH::SharedPtrStorage<TriAoSoA>>(dataPath("dodecahedron.stl"));
+    Parser::readIntoTriangleBVH<T, Meta, K, W, BVH::SharedPtrStorage<TriAoSoA>>(dataPath("dodecahedron.stl"), pool);
 
   REQUIRE(defaultTri != nullptr);
   REQUIRE(sharedTri != nullptr);
@@ -1413,11 +1425,12 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
 
   constexpr size_t K = 4;
 
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("tetrahedron.stl"));
+  Pool       pool(hostMemoryResource());
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("tetrahedron.stl"), pool);
   REQUIRE(mesh != nullptr);
-  REQUIRE(mesh->getFaces().size() == 4);
+  REQUIRE(mesh->numFaces() == 4);
 
-  const auto triangles = Parser::readIntoTriangles<T, Meta>(dataPath("tetrahedron.stl"));
+  const auto triangles = Parser::readIntoTriangles<T, Meta>(dataPath("tetrahedron.stl"), pool);
   REQUIRE(triangles.size() == 4);
 
   const FlatMeshSDF<T, Meta> flat(mesh);
@@ -1886,8 +1899,9 @@ TEMPLATE_TEST_CASE("Nested BVH: a BVHUnion over several TriMeshSDF objects nests
   // Two distinct triangle meshes read from the in-repo fixtures. Each TriMeshSDF owns an inner
   // PackedBVH over SoA triangle groups (ValueStorage by default) -- these are the inner BVHs that
   // the outer union BVH nests over.
-  const auto dodec = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
-  const auto tetra = Parser::readIntoDCEL<T, Meta>(dataPath("tetrahedron.stl"));
+  Pool       pool(hostMemoryResource());
+  const auto dodec = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
+  const auto tetra = Parser::readIntoDCEL<T, Meta>(dataPath("tetrahedron.stl"), pool);
   REQUIRE(dodec != nullptr);
   REQUIRE(tetra != nullptr);
 
@@ -1945,11 +1959,13 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 
   constexpr size_t K = 4;
 
-  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"));
+  Pool       pool(hostMemoryResource());
+  const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
   REQUIRE(mesh != nullptr);
 
   BVH::PrimAndBVList<Face, AABB> primsAndBVs;
-  for (const auto& f : mesh->getFaces()) {
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    const auto& f = mesh->getFace(i);
     primsAndBVs.emplace_back(std::make_shared<const Face>(f), AABB(f.getAllVertexCoordinates(*mesh)));
   }
 

--- a/Tests/TestDCEL.cpp
+++ b/Tests/TestDCEL.cpp
@@ -29,9 +29,9 @@ static const std::string g_dataDir = EBGEOMETRY_TEST_DATA_DIR;
 
 template <class T>
 static std::shared_ptr<MeshT<T, DefaultMetaData>>
-loadTetrahedron()
+loadTetrahedron(Pool& a_pool)
 {
-  return Parser::readIntoDCEL<T>(g_dataDir + "/tetrahedron.stl");
+  return Parser::readIntoDCEL<T>(g_dataDir + "/tetrahedron.stl", a_pool);
 }
 
 // Build a tetrahedron DCEL mesh entirely from hard-coded data (no file I/O).
@@ -41,7 +41,7 @@ loadTetrahedron()
 // outside.
 template <class T>
 static std::shared_ptr<MeshT<T, DefaultMetaData>>
-buildTetrahedron()
+buildTetrahedron(Pool& a_pool)
 {
   std::vector<Vec3T<T>> verts = {
     {0.0, 0.0, 0.0}, // 0 = A
@@ -60,7 +60,7 @@ buildTetrahedron()
 
   Soup::compress(verts, facets);
 
-  auto mesh = std::make_shared<MeshT<T, DefaultMetaData>>();
+  auto mesh = std::make_shared<MeshT<T, DefaultMetaData>>(a_pool);
   Soup::soupToDCEL(*mesh, verts, facets, "tetrahedron-hard");
   mesh->reconcile();
 
@@ -343,13 +343,20 @@ TEMPLATE_TEST_CASE("EdgeT: flipNormal negates the normal vector", "[DCEL][Edge]"
 {
   using T = TestType;
 
-  TestMesh<T> mesh;
-  mesh.getFaces().emplace_back();
-  mesh.getFaces()[0].define(Vec3T<T>(0, 0, 1), UINT32_MAX);
-  mesh.getEdges().emplace_back();
-  mesh.getEdges()[0].setFace(0);
+  Pool        pool(hostMemoryResource());
+  TestMesh<T> mesh(pool);
+  mesh.reserveFaces(1);
+  mesh.reserveEdges(1);
 
-  auto& e = mesh.getEdges()[0];
+  TestFace<T> face;
+  face.define(Vec3T<T>(0, 0, 1), UINT32_MAX);
+  mesh.addFace(face);
+
+  TestEdge<T> edge;
+  edge.setFace(0);
+  mesh.addEdge(edge);
+
+  auto& e = mesh.getEdge(0);
   e.reconcile(mesh);
 
   REQUIRE(e.getNormal() == Vec3T<T>(0, 0, 1));
@@ -363,13 +370,20 @@ TEMPLATE_TEST_CASE("EdgeT: computeNormal with a single face returns that face's 
 {
   using T = TestType;
 
-  TestMesh<T> mesh;
-  mesh.getFaces().emplace_back();
-  mesh.getFaces()[0].define(Vec3T<T>(1, 0, 0), UINT32_MAX);
-  mesh.getEdges().emplace_back();
-  mesh.getEdges()[0].setFace(0);
+  Pool        pool(hostMemoryResource());
+  TestMesh<T> mesh(pool);
+  mesh.reserveFaces(1);
+  mesh.reserveEdges(1);
 
-  REQUIRE(mesh.getEdges()[0].computeNormal(mesh) == Vec3T<T>(1, 0, 0));
+  TestFace<T> face;
+  face.define(Vec3T<T>(1, 0, 0), UINT32_MAX);
+  mesh.addFace(face);
+
+  TestEdge<T> edge;
+  edge.setFace(0);
+  mesh.addEdge(edge);
+
+  REQUIRE(mesh.getEdge(0).computeNormal(mesh) == Vec3T<T>(1, 0, 0));
 }
 
 TEMPLATE_TEST_CASE("EdgeT: computeNormal averages both incident faces' normals",
@@ -378,24 +392,28 @@ TEMPLATE_TEST_CASE("EdgeT: computeNormal averages both incident faces' normals",
 {
   using T = TestType;
 
-  TestMesh<T> mesh;
-  auto&       faces = mesh.getFaces();
-  auto&       edges = mesh.getEdges();
+  Pool        pool(hostMemoryResource());
+  TestMesh<T> mesh(pool);
+  mesh.reserveFaces(2);
+  mesh.reserveEdges(2);
 
-  faces.emplace_back();
-  faces[0].define(Vec3T<T>(1, 0, 0), UINT32_MAX);
-  faces.emplace_back();
-  faces[1].define(Vec3T<T>(0, 1, 0), UINT32_MAX);
+  TestFace<T> face0;
+  face0.define(Vec3T<T>(1, 0, 0), UINT32_MAX);
+  mesh.addFace(face0);
 
-  edges.emplace_back(); // edge under test
-  edges.emplace_back(); // its pair edge
+  TestFace<T> face1;
+  face1.define(Vec3T<T>(0, 1, 0), UINT32_MAX);
+  mesh.addFace(face1);
 
-  edges[0].setFace(0);
-  edges[1].setFace(1);
-  edges[0].setPairEdge(1);
+  mesh.addEdge(TestEdge<T>()); // edge under test
+  mesh.addEdge(TestEdge<T>()); // its pair edge
+
+  mesh.getEdge(0).setFace(0);
+  mesh.getEdge(1).setFace(1);
+  mesh.getEdge(0).setPairEdge(1);
 
   const Vec3T<T> expected = Vec3T<T>(1, 1, 0) / Vec3T<T>(1, 1, 0).length();
-  const Vec3T<T> actual   = edges[0].computeNormal(mesh);
+  const Vec3T<T> actual   = mesh.getEdge(0).computeNormal(mesh);
 
   REQUIRE_THAT(actual[0], withinAbsT(expected[0], exactMargin<T>()));
   REQUIRE_THAT(actual[1], withinAbsT(expected[1], exactMargin<T>()));
@@ -406,13 +424,20 @@ TEMPLATE_TEST_CASE("EdgeT: reconcile stores computeNormal's result", "[DCEL][Edg
 {
   using T = TestType;
 
-  TestMesh<T> mesh;
-  mesh.getFaces().emplace_back();
-  mesh.getFaces()[0].define(Vec3T<T>(0, 1, 0), UINT32_MAX);
-  mesh.getEdges().emplace_back();
-  mesh.getEdges()[0].setFace(0);
+  Pool        pool(hostMemoryResource());
+  TestMesh<T> mesh(pool);
+  mesh.reserveFaces(1);
+  mesh.reserveEdges(1);
 
-  auto& e = mesh.getEdges()[0];
+  TestFace<T> face;
+  face.define(Vec3T<T>(0, 1, 0), UINT32_MAX);
+  mesh.addFace(face);
+
+  TestEdge<T> edge;
+  edge.setFace(0);
+  mesh.addEdge(edge);
+
+  auto& e = mesh.getEdge(0);
   e.reconcile(mesh);
 
   REQUIRE(e.getNormal() == Vec3T<T>(0, 1, 0));
@@ -424,35 +449,38 @@ TEMPLATE_TEST_CASE("EdgeT: signedDistance and unsignedDistance2 on a simple segm
 {
   using T = TestType;
 
-  TestMesh<T> mesh;
-  auto&       vertices = mesh.getVertices();
-  auto&       edges    = mesh.getEdges();
-  auto&       faces    = mesh.getFaces();
+  Pool        pool(hostMemoryResource());
+  TestMesh<T> mesh(pool);
+  mesh.reserveVertices(2);
+  mesh.reserveEdges(2);
+  mesh.reserveFaces(1);
 
   // Build a two-vertex chain: e0 (start v0) -> e1 (start v1), so e0's "other vertex" is v1.
-  vertices.emplace_back(Vec3T<T>(0, 0, 0));
-  vertices.emplace_back(Vec3T<T>(1, 0, 0));
+  mesh.addVertex(TestVertex<T>(Vec3T<T>(0, 0, 0)));
+  mesh.addVertex(TestVertex<T>(Vec3T<T>(1, 0, 0)));
 
-  edges.emplace_back(0u);
-  edges.emplace_back(1u);
-  edges[0].setNextEdge(1);
+  mesh.addEdge(TestEdge<T>(0u));
+  mesh.addEdge(TestEdge<T>(1u));
+  mesh.getEdge(0).setNextEdge(1);
 
   // Outward normal perpendicular to the edge, pointing +y.
-  faces.emplace_back();
-  faces[0].define(Vec3T<T>(0, 1, 0), UINT32_MAX);
-  edges[0].setFace(0);
-  edges[0].reconcile(mesh);
+  TestFace<T> face;
+  face.define(Vec3T<T>(0, 1, 0), UINT32_MAX);
+  mesh.addFace(face);
 
-  REQUIRE(edges[0].getOtherVertex(mesh).getPosition() == vertices[1].getPosition());
+  mesh.getEdge(0).setFace(0);
+  mesh.getEdge(0).reconcile(mesh);
+
+  REQUIRE(mesh.getEdge(0).getOtherVertex(mesh).getPosition() == mesh.getVertex(1).getPosition());
 
   // Point above the middle of the edge: on the normal side, distance 2.
-  REQUIRE_THAT(edges[0].signedDistance(Vec3T<T>(0.5, 2, 0), mesh), WithinRel(T(2.0)));
+  REQUIRE_THAT(mesh.getEdge(0).signedDistance(Vec3T<T>(0.5, 2, 0), mesh), WithinRel(T(2.0)));
 
   // Point below the middle of the edge: against the normal, negative distance.
-  REQUIRE_THAT(edges[0].signedDistance(Vec3T<T>(0.5, -2, 0), mesh), WithinRel(T(-2.0)));
+  REQUIRE_THAT(mesh.getEdge(0).signedDistance(Vec3T<T>(0.5, -2, 0), mesh), WithinRel(T(-2.0)));
 
   // unsignedDistance2 clamps the projection to the segment.
-  REQUIRE_THAT(edges[0].unsignedDistance2(Vec3T<T>(0.5, 3, 0), mesh), WithinRel(T(9.0)));
+  REQUIRE_THAT(mesh.getEdge(0).unsignedDistance2(Vec3T<T>(0.5, 3, 0), mesh), WithinRel(T(9.0)));
 }
 
 TEMPLATE_TEST_CASE("EdgeT: copy construction copies every member, including meta-data",
@@ -540,20 +568,21 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: iterating a face visits exactly its own half-
 {
   using T = TestType;
 
-  auto        mesh = buildTetrahedron<T>();
-  const auto& face = mesh->getFaces()[0];
+  Pool        pool(hostMemoryResource());
+  auto        mesh = buildTetrahedron<T>(pool);
+  const auto& face = mesh->getFace(0);
 
   std::vector<uint32_t> visited;
   for (TestEdgeIterator<T> it(*mesh, face); it.ok(); ++it) {
-    REQUIRE(mesh->getEdges()[it()].getFaceIndex() == 0);
+    REQUIRE(mesh->getEdge(it()).getFaceIndex() == 0);
     visited.push_back(it());
   }
 
   REQUIRE(visited.size() == 3); // Every face in a tetrahedron is a triangle.
   REQUIRE(visited[0] == face.getHalfEdgeIndex());
-  REQUIRE(mesh->getEdges()[visited[0]].getNextEdgeIndex() == visited[1]);
-  REQUIRE(mesh->getEdges()[visited[1]].getNextEdgeIndex() == visited[2]);
-  REQUIRE(mesh->getEdges()[visited[2]].getNextEdgeIndex() == visited[0]); // Loops back to the start.
+  REQUIRE(mesh->getEdge(visited[0]).getNextEdgeIndex() == visited[1]);
+  REQUIRE(mesh->getEdge(visited[1]).getNextEdgeIndex() == visited[2]);
+  REQUIRE(mesh->getEdge(visited[2]).getNextEdgeIndex() == visited[0]); // Loops back to the start.
 }
 
 TEMPLATE_TEST_CASE("EdgeIteratorT: constructing from an edge index directly matches constructing from its face",
@@ -562,8 +591,9 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: constructing from an edge index directly matc
 {
   using T = TestType;
 
-  auto        mesh = buildTetrahedron<T>();
-  const auto& face = mesh->getFaces()[0];
+  Pool        pool(hostMemoryResource());
+  auto        mesh = buildTetrahedron<T>(pool);
+  const auto& face = mesh->getFace(0);
 
   std::vector<uint32_t> fromFace;
   for (TestEdgeIterator<T> it(*mesh, face); it.ok(); ++it) {
@@ -584,7 +614,8 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: ok() is immediately false for an unset starti
 {
   using T = TestType;
 
-  TestMesh<T>         mesh;
+  Pool                pool(hostMemoryResource());
+  TestMesh<T>         mesh(pool);
   TestEdgeIterator<T> it(mesh, UINT32_MAX);
   REQUIRE_FALSE(it.ok());
 }
@@ -595,8 +626,9 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: reset returns the iterator to its starting ed
 {
   using T = TestType;
 
-  auto        mesh = buildTetrahedron<T>();
-  const auto& face = mesh->getFaces()[0];
+  Pool        pool(hostMemoryResource());
+  auto        mesh = buildTetrahedron<T>(pool);
+  const auto& face = mesh->getFace(0);
 
   TestEdgeIterator<T> it(*mesh, face);
   const auto          start = it();
@@ -616,8 +648,9 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: copy and move both preserve iteration state",
 {
   using T = TestType;
 
-  auto        mesh = buildTetrahedron<T>();
-  const auto& face = mesh->getFaces()[0];
+  Pool        pool(hostMemoryResource());
+  auto        mesh = buildTetrahedron<T>(pool);
+  const auto& face = mesh->getFace(0);
 
   TestEdgeIterator<T> src(*mesh, face);
   ++src;
@@ -644,14 +677,16 @@ TEMPLATE_TEST_CASE("EdgeIteratorT: copy and move both preserve iteration state",
 // MeshT tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-TEMPLATE_TEST_CASE("MeshT: default construction is empty", "[DCEL][Mesh]", EBGEOMETRY_TEST_PRECISIONS)
+TEMPLATE_TEST_CASE("MeshT: a freshly constructed mesh is empty", "[DCEL][Mesh]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
-  TestMesh<T> mesh;
 
-  REQUIRE(mesh.getVertices().empty());
-  REQUIRE(mesh.getEdges().empty());
-  REQUIRE(mesh.getFaces().empty());
+  Pool        pool(hostMemoryResource());
+  TestMesh<T> mesh(pool);
+
+  REQUIRE(mesh.numVertices() == 0);
+  REQUIRE(mesh.numEdges() == 0);
+  REQUIRE(mesh.numFaces() == 0);
   REQUIRE(mesh.getAllVertexCoordinates().empty());
 
   // An empty mesh has no faces to measure a distance to.
@@ -660,24 +695,31 @@ TEMPLATE_TEST_CASE("MeshT: default construction is empty", "[DCEL][Mesh]", EBGEO
   REQUIRE(mesh.unsignedDistance2(Vec3T<T>(0, 0, 0)) == inf);
 }
 
-TEMPLATE_TEST_CASE("MeshT: full constructor assigns vertices, edges, and faces",
-                   "[DCEL][Mesh]",
-                   EBGEOMETRY_TEST_PRECISIONS)
+TEMPLATE_TEST_CASE("MeshT: reserveX/addX/getX/numX populate the mesh", "[DCEL][Mesh]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;
 
-  std::vector<TestVertex<T>> verts = {TestVertex<T>(Vec3T<T>(1, 2, 3))};
-  std::vector<TestEdge<T>>   edges = {TestEdge<T>(0u)};
-  std::vector<TestFace<T>>   faces = {TestFace<T>(0u)};
+  Pool        pool(hostMemoryResource());
+  TestMesh<T> mesh(pool);
 
-  TestMesh<T> mesh(faces, edges, verts);
+  mesh.reserveVertices(1);
+  mesh.reserveEdges(1);
+  mesh.reserveFaces(1);
 
-  REQUIRE(mesh.getVertices().size() == 1);
-  REQUIRE(mesh.getEdges().size() == 1);
-  REQUIRE(mesh.getFaces().size() == 1);
-  REQUIRE(mesh.getVertices()[0].getPosition() == Vec3T<T>(1, 2, 3));
-  REQUIRE(mesh.getEdges()[0].getVertexIndex() == 0);
-  REQUIRE(mesh.getFaces()[0].getHalfEdgeIndex() == 0);
+  const uint32_t vIdx = mesh.addVertex(TestVertex<T>(Vec3T<T>(1, 2, 3)));
+  const uint32_t eIdx = mesh.addEdge(TestEdge<T>(0u));
+  const uint32_t fIdx = mesh.addFace(TestFace<T>(0u));
+
+  REQUIRE(vIdx == 0);
+  REQUIRE(eIdx == 0);
+  REQUIRE(fIdx == 0);
+
+  REQUIRE(mesh.numVertices() == 1);
+  REQUIRE(mesh.numEdges() == 1);
+  REQUIRE(mesh.numFaces() == 1);
+  REQUIRE(mesh.getVertex(0).getPosition() == Vec3T<T>(1, 2, 3));
+  REQUIRE(mesh.getEdge(0).getVertexIndex() == 0);
+  REQUIRE(mesh.getFace(0).getHalfEdgeIndex() == 0);
 }
 
 TEMPLATE_TEST_CASE("MeshT: copy is disallowed, move is allowed", "[DCEL][Mesh]", EBGEOMETRY_TEST_PRECISIONS)
@@ -695,30 +737,35 @@ TEMPLATE_TEST_CASE("MeshT: move construction and move assignment transfer owners
 {
   using T = TestType;
 
-  auto       moveCtorSrc = buildTetrahedron<T>();
-  const auto v0Position  = moveCtorSrc->getVertices()[0].getPosition();
+  Pool pool(hostMemoryResource());
+
+  auto       moveCtorSrc = buildTetrahedron<T>(pool);
+  const auto v0Position  = moveCtorSrc->getVertex(0).getPosition();
 
   TestMesh<T> moved(std::move(*moveCtorSrc));
-  REQUIRE(moved.getVertices().size() == 4);
-  REQUIRE(moved.getFaces().size() == 4);
-  REQUIRE(moved.getVertices()[0].getPosition() == v0Position);
+  REQUIRE(moved.numVertices() == 4);
+  REQUIRE(moved.numFaces() == 4);
+  REQUIRE(moved.getVertex(0).getPosition() == v0Position);
 
-  auto        moveAssignSrc = buildTetrahedron<T>();
-  const auto  v0PositionB   = moveAssignSrc->getVertices()[0].getPosition();
-  TestMesh<T> moveAssignDst;
+  auto        moveAssignSrc = buildTetrahedron<T>(pool);
+  const auto  v0PositionB   = moveAssignSrc->getVertex(0).getPosition();
+  TestMesh<T> moveAssignDst(pool);
   moveAssignDst = std::move(*moveAssignSrc);
-  REQUIRE(moveAssignDst.getVertices().size() == 4);
-  REQUIRE(moveAssignDst.getVertices()[0].getPosition() == v0PositionB);
+  REQUIRE(moveAssignDst.numVertices() == 4);
+  REQUIRE(moveAssignDst.getVertex(0).getPosition() == v0PositionB);
 }
 
 TEMPLATE_TEST_CASE("MeshT: reconcile computes positive face areas and unit-length normals",
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
 
-  for (const auto& f : mesh->getFaces()) {
+  Pool pool(hostMemoryResource());
+  auto mesh = buildTetrahedron<T>(pool);
+
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    const auto& f = mesh->getFace(i);
     REQUIRE(f.getArea() > T(0.0));
     REQUIRE_THAT(f.getNormal().length(), withinAbsT(T(1.0), exactMargin<T>()));
   }
@@ -726,30 +773,32 @@ TEMPLATE_TEST_CASE("MeshT: reconcile computes positive face areas and unit-lengt
 
 TEMPLATE_TEST_CASE("MeshT: flip negates all vertex, edge, and face normals", "[DCEL][Mesh]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = buildTetrahedron<T>(pool);
 
   std::vector<Vec3T<T>> vertexNormals, edgeNormals, faceNormals;
-  for (const auto& v : mesh->getVertices()) {
-    vertexNormals.push_back(v.getNormal());
+  for (uint32_t i = 0; i < mesh->numVertices(); i++) {
+    vertexNormals.push_back(mesh->getVertex(i).getNormal());
   }
-  for (const auto& e : mesh->getEdges()) {
-    edgeNormals.push_back(e.getNormal());
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    edgeNormals.push_back(mesh->getEdge(i).getNormal());
   }
-  for (const auto& f : mesh->getFaces()) {
-    faceNormals.push_back(f.getNormal());
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    faceNormals.push_back(mesh->getFace(i).getNormal());
   }
 
   mesh->flip();
 
-  for (size_t i = 0; i < mesh->getVertices().size(); i++) {
-    REQUIRE((mesh->getVertices()[i].getNormal() - (-vertexNormals[i])).length() < T(exactMargin<T>()));
+  for (uint32_t i = 0; i < mesh->numVertices(); i++) {
+    REQUIRE((mesh->getVertex(i).getNormal() - (-vertexNormals[i])).length() < T(exactMargin<T>()));
   }
-  for (size_t i = 0; i < mesh->getEdges().size(); i++) {
-    REQUIRE((mesh->getEdges()[i].getNormal() - (-edgeNormals[i])).length() < T(exactMargin<T>()));
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    REQUIRE((mesh->getEdge(i).getNormal() - (-edgeNormals[i])).length() < T(exactMargin<T>()));
   }
-  for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE((mesh->getFaces()[i].getNormal() - (-faceNormals[i])).length() < T(exactMargin<T>()));
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    REQUIRE((mesh->getFace(i).getNormal() - (-faceNormals[i])).length() < T(exactMargin<T>()));
   }
 }
 
@@ -757,8 +806,10 @@ TEMPLATE_TEST_CASE("MeshT: signedDistance agrees between Direct and Direct2 sear
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = buildTetrahedron<T>(pool);
 
   const std::vector<Vec3T<T>> queryPoints = {{0.1, 0.1, 0.1}, {2.0, 2.0, 2.0}, {-1.0, -1.0, -1.0}, {0.25, 0.25, 0.0}};
 
@@ -774,8 +825,10 @@ TEMPLATE_TEST_CASE("MeshT: setSearchAlgorithm changes the algorithm used by the 
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = buildTetrahedron<T>(pool);
 
   const Vec3T<T> p(0.1, 0.1, 0.1);
 
@@ -792,14 +845,16 @@ TEMPLATE_TEST_CASE("MeshT: getAllVertexCoordinates matches the vertex positions"
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = buildTetrahedron<T>(pool);
 
   const auto coords = mesh->getAllVertexCoordinates();
-  REQUIRE(coords.size() == mesh->getVertices().size());
+  REQUIRE(coords.size() == mesh->numVertices());
 
   for (size_t i = 0; i < coords.size(); i++) {
-    REQUIRE(coords[i] == mesh->getVertices()[i].getPosition());
+    REQUIRE(coords[i] == mesh->getVertex(static_cast<uint32_t>(i)).getPosition());
   }
 }
 
@@ -807,18 +862,22 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy produces an independent mesh with the same g
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
-  auto copy = mesh->deepCopy();
+  using T = TestType;
+
+  Pool srcPool(hostMemoryResource());
+  Pool dstPool(hostMemoryResource());
+
+  auto mesh = buildTetrahedron<T>(srcPool);
+  auto copy = mesh->deepCopy(dstPool);
 
   REQUIRE(copy != nullptr);
-  REQUIRE(copy->getVertices().size() == mesh->getVertices().size());
-  REQUIRE(copy->getEdges().size() == mesh->getEdges().size());
-  REQUIRE(copy->getFaces().size() == mesh->getFaces().size());
+  REQUIRE(copy->numVertices() == mesh->numVertices());
+  REQUIRE(copy->numEdges() == mesh->numEdges());
+  REQUIRE(copy->numFaces() == mesh->numFaces());
 
-  for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE((copy->getFaces()[i].getNormal() - mesh->getFaces()[i].getNormal()).length() < T(exactMargin<T>()));
-    REQUIRE_THAT(copy->getFaces()[i].getArea(), withinAbsT(mesh->getFaces()[i].getArea(), exactMargin<T>()));
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    REQUIRE((copy->getFace(i).getNormal() - mesh->getFace(i).getNormal()).length() < T(exactMargin<T>()));
+    REQUIRE_THAT(copy->getFace(i).getArea(), withinAbsT(mesh->getFace(i).getArea(), exactMargin<T>()));
   }
 
   // The copy must be usable for signed-distance queries (validates that the projection axes were
@@ -829,22 +888,26 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy produces an independent mesh with the same g
 
   // Mutating the copy must not affect the original -- this is the meaningful test of independence
   // now that vertices/edges/faces are plain values rather than shared_ptr-identified objects.
-  copy->getVertices()[0].setPosition(Vec3T<T>(999, 999, 999));
-  REQUIRE(mesh->getVertices()[0].getPosition() != Vec3T<T>(999, 999, 999));
+  copy->getVertex(0).setPosition(Vec3T<T>(999, 999, 999));
+  REQUIRE(mesh->getVertex(0).getPosition() != Vec3T<T>(999, 999, 999));
 }
 
 TEMPLATE_TEST_CASE("MeshT: deepCopy preserves a prior flip() instead of silently re-deriving normals",
                    "[DCEL][Mesh]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
+
+  Pool srcPool(hostMemoryResource());
+  Pool dstPool(hostMemoryResource());
+
+  auto mesh = buildTetrahedron<T>(srcPool);
   mesh->flip();
 
-  auto copy = mesh->deepCopy();
+  auto copy = mesh->deepCopy(dstPool);
 
-  for (size_t i = 0; i < mesh->getFaces().size(); i++) {
-    REQUIRE((copy->getFaces()[i].getNormal() - mesh->getFaces()[i].getNormal()).length() < T(exactMargin<T>()));
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    REQUIRE((copy->getFace(i).getNormal() - mesh->getFace(i).getNormal()).length() < T(exactMargin<T>()));
   }
 }
 
@@ -928,25 +991,28 @@ TEMPLATE_TEST_CASE("Soup::soupToDCEL builds correct vertex, edge, and face count
                    "[Soup]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
 
-  REQUIRE(mesh->getVertices().size() == 4);
-  REQUIRE(mesh->getFaces().size() == 4);
-  REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
+  Pool pool(hostMemoryResource());
+  auto mesh = buildTetrahedron<T>(pool);
+
+  REQUIRE(mesh->numVertices() == 4);
+  REQUIRE(mesh->numFaces() == 4);
+  REQUIRE(mesh->numEdges() == 12); // 4 triangular faces * 3 half-edges each.
 }
 
 TEMPLATE_TEST_CASE("Soup::soupToDCEL reconciles every half-edge's pair edge on a closed mesh",
                    "[Soup]",
                    EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = buildTetrahedron<T>();
+  using T = TestType;
 
-  const auto& edges = mesh->getEdges();
-  for (uint32_t i = 0; i < edges.size(); i++) {
-    REQUIRE(edges[i].getPairEdgeIndex() != UINT32_MAX);
-    REQUIRE(edges[edges[i].getPairEdgeIndex()].getPairEdgeIndex() == i); // Pairing must be symmetric.
+  Pool pool(hostMemoryResource());
+  auto mesh = buildTetrahedron<T>(pool);
+
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    REQUIRE(mesh->getEdge(i).getPairEdgeIndex() != UINT32_MAX);
+    REQUIRE(mesh->getEdge(mesh->getEdge(i).getPairEdgeIndex()).getPairEdgeIndex() == i); // Pairing must be symmetric.
   }
 }
 
@@ -956,63 +1022,75 @@ TEMPLATE_TEST_CASE("Soup::soupToDCEL reconciles every half-edge's pair edge on a
 
 TEMPLATE_TEST_CASE("DCEL: tetrahedron loads without error", "[DCEL]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = loadTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = loadTetrahedron<T>(pool);
   REQUIRE(mesh != nullptr);
 }
 
 TEMPLATE_TEST_CASE("DCEL: tetrahedron has correct face and vertex counts", "[DCEL]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = loadTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = loadTetrahedron<T>(pool);
   REQUIRE(mesh != nullptr);
 
   // A tetrahedron has 4 faces and 4 vertices
-  REQUIRE(mesh->getFaces().size() == 4);
-  REQUIRE(mesh->getVertices().size() == 4);
+  REQUIRE(mesh->numFaces() == 4);
+  REQUIRE(mesh->numVertices() == 4);
 
   // 4 faces × 3 half-edges each = 12 half-edges
-  REQUIRE(mesh->getEdges().size() == 12);
+  REQUIRE(mesh->numEdges() == 12);
 }
 
 TEMPLATE_TEST_CASE("DCEL: all faces have a half-edge", "[DCEL]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = loadTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = loadTetrahedron<T>(pool);
   REQUIRE(mesh != nullptr);
 
-  for (const auto& face : mesh->getFaces()) {
-    REQUIRE(face.getHalfEdgeIndex() != UINT32_MAX);
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    REQUIRE(mesh->getFace(i).getHalfEdgeIndex() != UINT32_MAX);
   }
 }
 
 TEMPLATE_TEST_CASE("DCEL: all half-edges have a pair and a face", "[DCEL]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = loadTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = loadTetrahedron<T>(pool);
   REQUIRE(mesh != nullptr);
 
-  for (const auto& edge : mesh->getEdges()) {
-    REQUIRE(edge.getPairEdgeIndex() != UINT32_MAX);
-    REQUIRE(edge.getFaceIndex() != UINT32_MAX);
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    REQUIRE(mesh->getEdge(i).getPairEdgeIndex() != UINT32_MAX);
+    REQUIRE(mesh->getEdge(i).getFaceIndex() != UINT32_MAX);
   }
 }
 
 TEMPLATE_TEST_CASE("DCEL: all face normals are unit-length", "[DCEL]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = loadTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = loadTetrahedron<T>(pool);
   REQUIRE(mesh != nullptr);
 
-  for (const auto& face : mesh->getFaces()) {
-    REQUIRE_THAT(face.getNormal().length(), withinAbsT(T(1.0), formulaMargin<T>()));
+  for (uint32_t i = 0; i < mesh->numFaces(); i++) {
+    REQUIRE_THAT(mesh->getFace(i).getNormal().length(), withinAbsT(T(1.0), formulaMargin<T>()));
   }
 }
 
 TEMPLATE_TEST_CASE("DCEL: sanityCheck completes without crashing", "[DCEL]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T   = TestType;
-  auto mesh = loadTetrahedron<T>();
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = loadTetrahedron<T>(pool);
   REQUIRE(mesh != nullptr);
 
   // sanityCheck() returns void; it prints to stderr only if the mesh has errors.
@@ -1030,7 +1108,8 @@ TEMPLATE_TEST_CASE("MeshSDF: tetrahedron signed distances", "[DCEL][MeshSDF]", E
   // Tetrahedron vertices: (0,0,0), (1,0,0), (0,1,0), (0,0,1).
   // Standard SDF convention: negative inside, positive outside.
 
-  auto mesh = loadTetrahedron<T>();
+  Pool pool(hostMemoryResource());
+  auto mesh = loadTetrahedron<T>(pool);
   REQUIRE(mesh != nullptr);
 
   TestMeshSDF<T> sdf(mesh, BVH::Build::SAH);
@@ -1063,8 +1142,10 @@ TEMPLATE_TEST_CASE("MeshSDF: tetrahedron signed distances", "[DCEL][MeshSDF]", E
 
 TEMPLATE_TEST_CASE("DCEL sign convention: exterior point has positive SDF", "[DCEL][sign]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T             = TestType;
-  auto           mesh = buildTetrahedron<T>();
+  using T = TestType;
+
+  Pool           pool(hostMemoryResource());
+  auto           mesh = buildTetrahedron<T>(pool);
   TestMeshSDF<T> sdf(mesh, BVH::Build::SAH);
 
   // Far outside: must be positive.
@@ -1077,8 +1158,10 @@ TEMPLATE_TEST_CASE("DCEL sign convention: exterior point has positive SDF", "[DC
 
 TEMPLATE_TEST_CASE("DCEL sign convention: interior point has negative SDF", "[DCEL][sign]", EBGEOMETRY_TEST_PRECISIONS)
 {
-  using T             = TestType;
-  auto           mesh = buildTetrahedron<T>();
+  using T = TestType;
+
+  Pool           pool(hostMemoryResource());
+  auto           mesh = buildTetrahedron<T>(pool);
   TestMeshSDF<T> sdf(mesh, BVH::Build::SAH);
 
   // Centroid of the tetrahedron is clearly inside.
@@ -1095,8 +1178,10 @@ TEMPLATE_TEST_CASE("FastTriMeshSDF: matches MeshSDF for tetrahedron",
 {
   using T                = TestType;
   const std::string path = g_dataDir + "/tetrahedron.stl";
-  auto              fast = Parser::readIntoTriangleBVH<T>(path);
-  auto              mesh = Parser::readIntoMesh<T>(path);
+
+  Pool pool(hostMemoryResource());
+  auto fast = Parser::readIntoTriangleBVH<T>(path, pool);
+  auto mesh = Parser::readIntoMesh<T>(path, pool);
 
   REQUIRE(fast != nullptr);
   REQUIRE(mesh != nullptr);

--- a/Tests/TestDCEL.cpp
+++ b/Tests/TestDCEL.cpp
@@ -1029,6 +1029,26 @@ TEMPLATE_TEST_CASE("DCEL: tetrahedron loads without error", "[DCEL]", EBGEOMETRY
   REQUIRE(mesh != nullptr);
 }
 
+TEMPLATE_TEST_CASE("Parser::readIntoDCEL returns a valid, empty mesh (not nullptr) for an "
+                   "unrecognized file extension",
+                   "[DCEL][Parser]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  Pool pool(hostMemoryResource());
+  auto mesh = Parser::readIntoDCEL<T>(g_dataDir + "/tetrahedron.unsupported-extension", pool);
+
+  REQUIRE(mesh != nullptr);
+  REQUIRE(mesh->numVertices() == 0);
+  REQUIRE(mesh->numEdges() == 0);
+  REQUIRE(mesh->numFaces() == 0);
+
+  const auto inf = std::numeric_limits<T>::infinity();
+  REQUIRE(mesh->signedDistance(Vec3T<T>(0, 0, 0)) == inf);
+  REQUIRE(mesh->unsignedDistance2(Vec3T<T>(0, 0, 0)) == inf);
+}
+
 TEMPLATE_TEST_CASE("DCEL: tetrahedron has correct face and vertex counts", "[DCEL]", EBGEOMETRY_TEST_PRECISIONS)
 {
   using T = TestType;

--- a/Tests/TestOBJ.cpp
+++ b/Tests/TestOBJ.cpp
@@ -5,6 +5,7 @@
 #include "TestFloatingPointUtils.hpp"
 
 #include <array>
+#include <cstdint>
 #include <vector>
 
 #include <catch2/catch_template_test_macros.hpp>
@@ -126,14 +127,15 @@ TEMPLATE_TEST_CASE("OBJ: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(obj.getVertexCoordinates().size() == 12);
   REQUIRE(obj.getFacets().size() == 4);
 
-  auto mesh = obj.template convertToDCEL<DCEL::DefaultMetaData>();
+  Pool pool(hostMemoryResource());
+  auto mesh = obj.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
   REQUIRE(mesh != nullptr);
-  REQUIRE(mesh->getVertices().size() == 4); // Compressed down to the 4 unique corners.
-  REQUIRE(mesh->getFaces().size() == 4);
-  REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
+  REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.
+  REQUIRE(mesh->numFaces() == 4);
+  REQUIRE(mesh->numEdges() == 12); // 4 triangular faces * 3 half-edges each.
 
-  for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    REQUIRE(mesh->getEdge(i).getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestPLY.cpp
+++ b/Tests/TestPLY.cpp
@@ -5,6 +5,7 @@
 #include "TestFloatingPointUtils.hpp"
 
 #include <array>
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
@@ -156,14 +157,15 @@ TEMPLATE_TEST_CASE("PLY: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(ply.getVertexCoordinates().size() == 12);
   REQUIRE(ply.getFacets().size() == 4);
 
-  auto mesh = ply.template convertToDCEL<DCEL::DefaultMetaData>();
+  Pool pool(hostMemoryResource());
+  auto mesh = ply.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
   REQUIRE(mesh != nullptr);
-  REQUIRE(mesh->getVertices().size() == 4); // Compressed down to the 4 unique corners.
-  REQUIRE(mesh->getFaces().size() == 4);
-  REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
+  REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.
+  REQUIRE(mesh->numFaces() == 4);
+  REQUIRE(mesh->numEdges() == 12); // 4 triangular faces * 3 half-edges each.
 
-  for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    REQUIRE(mesh->getEdge(i).getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestPolygon2D.cpp
+++ b/Tests/TestPolygon2D.cpp
@@ -58,40 +58,51 @@ castIsPointInsideFace(DCEL::FaceT<T, DCEL::DefaultMetaData>&       a_face,
 template <class T>
 struct BuiltFace
 {
-  using Meta = DCEL::DefaultMetaData;
-  using Mesh = DCEL::MeshT<T, Meta>;
+  using Meta   = DCEL::DefaultMetaData;
+  using Mesh   = DCEL::MeshT<T, Meta>;
+  using Vertex = DCEL::VertexT<T, Meta>;
+  using Edge   = DCEL::EdgeT<T, Meta>;
+  using Face   = DCEL::FaceT<T, Meta>;
 
+  // m_mesh holds a raw Pool* pointing at m_pool (see MeshT's class-level note), so BuiltFace is not
+  // safe to copy or move -- a moved-to object's m_mesh would keep pointing at the moved-FROM
+  // object's m_pool. Every use site relies on C++17's guaranteed copy elision for prvalue returns
+  // (e.g. `return BuiltFace<T>(...)`), which needs no copy/move constructor at all.
+  Pool m_pool;
   Mesh m_mesh;
 
-  explicit BuiltFace(const std::vector<Vec3T<T>>& a_positions)
+  explicit BuiltFace(const std::vector<Vec3T<T>>& a_positions) : m_pool(hostMemoryResource()), m_mesh(m_pool)
   {
     const uint32_t N = static_cast<uint32_t>(a_positions.size());
 
-    auto& vertices = m_mesh.getVertices();
-    auto& edges    = m_mesh.getEdges();
-    auto& faces    = m_mesh.getFaces();
+    m_mesh.reserveVertices(N);
+    m_mesh.reserveEdges(N);
+    m_mesh.reserveFaces(1);
 
     for (const auto& p : a_positions) {
-      vertices.emplace_back(p);
+      m_mesh.addVertex(Vertex(p));
     }
 
     for (uint32_t i = 0; i < N; i++) {
-      edges.emplace_back(i); // half-edge i starts at vertex i
+      m_mesh.addEdge(Edge(i)); // half-edge i starts at vertex i
     }
 
     for (uint32_t i = 0; i < N; i++) {
-      edges[i].setNextEdge((i + 1) % N);
-      edges[i].setFace(0);
+      m_mesh.getEdge(i).setNextEdge((i + 1) % N);
+      m_mesh.getEdge(i).setFace(0);
     }
 
-    faces.emplace_back(0u); // half-edge index 0
-    faces[0].reconcile(m_mesh);
+    m_mesh.addFace(Face(0u)); // half-edge index 0
+    m_mesh.getFace(0).reconcile(m_mesh);
   }
+
+  BuiltFace(const BuiltFace&) = delete;
+  BuiltFace(BuiltFace&&)      = delete;
 
   [[nodiscard]] bool
   isPointInside(const Vec3T<T>& a_point, DCEL::InsideOutsideAlgorithm a_algorithm)
   {
-    auto& face = m_mesh.getFaces()[0];
+    auto& face = m_mesh.getFace(0);
 
     face.setInsideOutsideAlgorithm(a_algorithm);
 

--- a/Tests/TestSTL.cpp
+++ b/Tests/TestSTL.cpp
@@ -5,6 +5,7 @@
 #include "TestFloatingPointUtils.hpp"
 
 #include <array>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -130,12 +131,13 @@ TEMPLATE_TEST_CASE("STL: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(stl.getVertexCoordinates().size() == 12);
   REQUIRE(stl.getFacets().size() == 4);
 
-  auto mesh = stl.template convertToDCEL<DCEL::DefaultMetaData>();
+  Pool pool(hostMemoryResource());
+  auto mesh = stl.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
   REQUIRE(mesh != nullptr);
-  REQUIRE(mesh->getVertices().size() == 4); // Compressed down to the 4 unique corners.
-  REQUIRE(mesh->getFaces().size() == 4);
-  REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
+  REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.
+  REQUIRE(mesh->numFaces() == 4);
+  REQUIRE(mesh->numEdges() == 12); // 4 triangular faces * 3 half-edges each.
 
   // convertToDCEL() must not mutate the STL object's own (uncompressed) data.
   REQUIRE(stl.getVertexCoordinates().size() == 12);
@@ -163,15 +165,17 @@ TEMPLATE_TEST_CASE("Parser::readSTL + convertToDCEL round-trips into a valid, wa
 {
   using T = TestType;
 
-  auto stl  = Parser::readSTL<T>(g_dataDir + "/tetrahedron.stl");
-  auto mesh = stl.template convertToDCEL<DCEL::DefaultMetaData>();
+  auto stl = Parser::readSTL<T>(g_dataDir + "/tetrahedron.stl");
+
+  Pool pool(hostMemoryResource());
+  auto mesh = stl.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
   REQUIRE(mesh != nullptr);
-  REQUIRE(mesh->getVertices().size() == 4);
-  REQUIRE(mesh->getFaces().size() == 4);
-  REQUIRE(mesh->getEdges().size() == 12);
+  REQUIRE(mesh->numVertices() == 4);
+  REQUIRE(mesh->numFaces() == 4);
+  REQUIRE(mesh->numEdges() == 12);
 
-  for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    REQUIRE(mesh->getEdge(i).getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }

--- a/Tests/TestVTK.cpp
+++ b/Tests/TestVTK.cpp
@@ -5,6 +5,7 @@
 #include "TestFloatingPointUtils.hpp"
 
 #include <array>
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
@@ -156,14 +157,15 @@ TEMPLATE_TEST_CASE("VTK: convertToDCEL builds a mesh with the correct compressed
   REQUIRE(vtk.getVertexCoordinates().size() == 12);
   REQUIRE(vtk.getFacets().size() == 4);
 
-  auto mesh = vtk.template convertToDCEL<DCEL::DefaultMetaData>();
+  Pool pool(hostMemoryResource());
+  auto mesh = vtk.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
   REQUIRE(mesh != nullptr);
-  REQUIRE(mesh->getVertices().size() == 4); // Compressed down to the 4 unique corners.
-  REQUIRE(mesh->getFaces().size() == 4);
-  REQUIRE(mesh->getEdges().size() == 12); // 4 triangular faces * 3 half-edges each.
+  REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.
+  REQUIRE(mesh->numFaces() == 4);
+  REQUIRE(mesh->numEdges() == 12); // 4 triangular faces * 3 half-edges each.
 
-  for (const auto& e : mesh->getEdges()) {
-    REQUIRE(e.getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
+  for (uint32_t i = 0; i < mesh->numEdges(); i++) {
+    REQUIRE(mesh->getEdge(i).getPairEdgeIndex() != UINT32_MAX); // Watertight: every half-edge has a pair.
   }
 }


### PR DESCRIPTION
# Summary

### Background

This is PR 3 of the GPU-port DCEL migration, continuing on from #138 (index-based topology). `DCEL::MeshT<T, Meta>` still stored its vertices/edges/faces as three `std::vector`s -- fine for CPU-only use, but `std::vector` is not something that can be reserved into a shared arena, mirrored to a device, or laid out contiguously alongside other meshes, which is what the eventual GPU port needs.

### Solution

- `MeshT<T, Meta>` now takes an external, caller-owned `Pool&` at construction (`explicit MeshT(Pool& a_pool)`; the default constructor is deleted) and stores its vertices/edges/faces as `PODVector<T>` reserved from that Pool instead of `std::vector`.
- The old `getVertices()/getEdges()/getFaces()` container accessors are replaced by a two-phase build API: `reserveVertices/Edges/Faces(capacity)` followed by `addVertex/Edge/Face(value) -> uint32_t`, plus single-element `getVertex/Edge/Face(i)` (mutable + const) and `numVertices/Edges/Faces()`. `PODVector` never reallocates once reserved, so callers must know their counts up front.
- `deepCopy()` now takes an explicit destination `Pool& a_dstPool`.
- `Soup::soupToDCEL`/`reconcilePairEdgesDCEL` build meshes via the same reserve-then-add discipline.
- Every `Parser::readInto*` entry point (`readIntoDCEL`, `readIntoMesh`, `readIntoPackedBVH`, `readIntoTriangleBVH`, `readIntoTriangles`, single- and multi-file overloads) and every `convertToDCEL()` (`STL`/`PLY`/`OBJ`/`VTK`) now take an explicit `Pool&` -- no hidden default pool anywhere. One `Pool` can back many meshes, built one after another with their arrays laid out contiguously in the same block.
- `Pool` itself is unchanged in this PR: no partial-release/free functionality was added (a `Pool` is, and remains, a pure bump allocator -- explicitly out of scope, deferred to a later PR if ever needed).
- Threaded the new `Pool&` requirement through every consumer: `Examples/{CSGUnion,MeshSDF,NestedBVH}`, `Integrations/{AMReX,Chombo}/*` (each now owns a `shared_ptr<Pool>` member alongside its retained SDF, or a short-lived local `Pool` where the mesh isn't retained), and the full `Tests/` suite.

### Side-effects

- Source-breaking API change for anyone calling `MeshT`'s old constructors/accessors or any `Parser::readInto*`/`convertToDCEL` function directly: every such call site now needs an explicit `Pool` (see updated `Docs/Sphinx/source/Parsers.rst` for the new calling convention). `MeshT` gained a Pool-lifetime obligation: the Pool must outlive the mesh, and, transitively, any SDF wrapper (`FlatMeshSDF`, `MeshSDF`) that retains the mesh.
- No behavior change to signed-distance results, mesh topology, or any other observable output -- validated by a byte-for-byte comparison against `dev` (see test plan below).

### Alternative solutions

- Could have given `MeshT` an owned Pool member instead of an external, caller-managed one, but that would mean every mesh gets its own heap block rather than letting a caller share one Pool across many meshes (e.g. all faces of a CSG scene) -- an explicit design decision from earlier discussion in this session, kept here for consistency with the "user manages Pool lifetime" model established for the rest of the POD memory foundation.

### Reviewer checklist (to be completed by a human)

- [ ] The test suite compiles and runs to completion without warnings or errors.
- [ ] All relevant new features are documented in the user documentation (Sphinx).
- [ ] This contribution does not break existing sections in the user documentation. 
- [ ] All relevant APIs are documented in the doxygen documentation.
- [ ] Appropriate labels have been assigned to this PR.
- [ ] New or revised proper licensing and copyright information is in place.
- [ ] A PR review has been run using `@claude review`.
- [ ] The continuous integration and testing hooks at GitHub run to completion.
