### PR TITLE
Pool-resident objects resolve through their pool, not a cached base

### DIFF
--- a/Docs/Sphinx/source/ImplemDCEL.rst
+++ b/Docs/Sphinx/source/ImplemDCEL.rst
@@ -73,65 +73,70 @@ Memory model
 ------------
 
 See :ref:`Chap:MemoryModel` first for the generic ``Pool``/``PODVector``/``MemoryResource``
-foundation (build/freeze/query, mirroring, the ``at()``-vs-``bind()`` access-style choice) --
+foundation (the control block, mirroring, the ``at()``-vs-``bind()`` access-style choice) --
 this section covers only how ``MeshT`` specifically is built on top of it.
 
-``MeshT<T, Meta>``'s vertex/edge/face arrays are three ``PODVector``\ s, and its own accessors
-mirror the same two-style choice as ``PODVector`` itself:
+``MeshT<T, Meta>``'s vertex/edge/face arrays are three ``PODVector``\ s. The mesh attaches itself to
+a ``Pool`` on its first ``reserveVertices()``/``reserveEdges()``/``reserveFaces()`` call and resolves
+every access through that pool's control block from then on, so there is exactly one accessor of
+each kind (``getVertex(i)``, ``signedDistance(p)``, ...) and no binding, freezing, or base-passing
+step of any sort. A mesh is queryable as soon as it has data, including while the same pool is still
+being built into -- which is what lets ``Soup``/``Parser`` (:ref:`Chap:Parsers`) reconcile and sanity
+-check a mesh mid-build, and lets several meshes share one pool without coordinating.
 
-* an **explicit-base** overload (e.g. ``getVertex(void* a_base, uint32_t)``), which resolves fresh
-  against whatever base is passed in, valid even mid-build against a pool that has not been
-  frozen yet, and
-* a **bound**, no-argument convenience overload (e.g. ``getVertex(uint32_t)``), which resolves
-  against a base cached once via ``bind(const Pool&)`` -- itself ``EBGEOMETRY_EXPECT``-checked to
-  require a frozen pool, for exactly the reason given in :ref:`Chap:MemoryModel`.
+Build-phase mutators (``reserveVertices()``/``reserveEdges()``/``reserveFaces()``,
+``addVertex()``/``addEdge()``/``addFace()``) still take the ``Pool&`` explicitly, since they reserve
+from it. ``isAttachedTo(pool)`` reports whether a mesh's storage came from a given pool, which is how
+a caller holding both can confirm they belong together.
 
-A third accessor, ``boundView(a_base)``, bridges the two. ``VertexT``/``EdgeT``/``FaceT``'s
-``const MeshT&``-taking methods (``reconcile()``, ``getNextEdge()``,
-``computeVertexNormalAverage()``, ...) resolve their indices through the mesh's *bound* accessors,
-so they cannot be handed a mesh that has not been ``bind()``'d yet. ``boundView()`` returns a
-disposable copy of the mesh's descriptor -- all plain values, so trivially cheap -- with its cached
-base set to ``a_base``, which is safe to pass wherever a bound ``const MeshT&`` is required before
-the real mesh can be bound. This is how ``Soup``/``Parser`` (:ref:`Chap:Parsers`) reconcile a mesh
-whose ``Pool`` is still open for further building, and how ``TriMeshSDF``'s mesh-based constructor
-works without ever freezing or binding.
+Because ``MeshT`` stores nothing but ``PODVector``\ s and plain values, it -- like
+``VertexT``/``EdgeT``/``FaceT`` themselves -- is trivially copyable, so a mesh built and reconciled
+entirely on the host can cross into another address space by value.
+
+.. warning::
+
+   A reference handed back by ``getVertex(i)``/``getEdge(i)``/``getFace(i)`` is an address resolved
+   at the moment of the call, and any ``Pool::reserve()`` may free the block it points into. This is
+   the general rule of :ref:`Sec:ResolvedAddresses` applied to ``MeshT``: resolve, use, discard, and
+   carry elements across a ``reserve`` by value rather than by reference. Everything returning by
+   value -- ``signedDistance()``, ``getAllVertexCoordinates()``, and so on -- is unaffected.
 
 .. note::
 
-   ``boundView()`` returns ``const MeshT``, not ``MeshT``, deliberately: the base it is given is
-   usually a caller's ``const void*``, and a ``const`` return keeps that promise from being broken
-   by chaining a mutating call onto the temporary (``mesh.boundView(base).flip()`` does not
-   compile). Bind the result to a ``const MeshT``/``const MeshT&`` at the call site as well --
-   copying it into a non-``const`` local (``MeshT view = mesh.boundView(base);``) produces an
-   independent, fully mutable object and defeats the protection.
+   **One ``Pool`` backing many meshes is the normal case.** Building several meshes one after
+   another into the same pool is both safe and cheaper than giving each its own (see
+   :ref:`Chap:Parsers`): a ``grow()`` triggered while building the fifth mesh ``memcpy``\ s
+   everything reserved so far, including the first four, and every mesh keeps resolving correctly
+   against the new base without being told. The pool must simply outlive every mesh in it.
 
-Build-phase mutators (``reserveVertices()``/``reserveEdges()``/``reserveFaces()``,
-``addVertex()``/``addEdge()``/``addFace()``) always take the ``Pool&`` explicitly, since reserving
-can grow (and move) the pool's block -- there is no cached-base convenience form for these.
-Because ``MeshT`` never stores anything but ``PODVector``\ s, a plain value, and one resolved base
-pointer, it -- like ``VertexT``/``EdgeT``/``FaceT`` themselves -- is trivially copyable, and a mesh
-built and reconciled entirely on the host can be handed to ``Pool::mirror()`` and re-``bind()``'d
-against the mirrored, device-resident base with zero pointer patching.
+Crossing address spaces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
+``rebasedView(const Pool&)`` is the one sanctioned way to point a mesh at a
+`mirror <doxygen/html/classEBGeometry_1_1Pool.html#aa141bf4919e1aeb78aaee9667da8ebc3>`__ of its own
+pool. It copies only the descriptor -- the vertex/edge/face data is whatever the mirror already
+contains -- and since every cross-reference is a byte offset, nothing needs patching on either side:
 
-   **One ``Pool`` can safely back many meshes, but they all share one freeze point.** Building
-   several meshes one after another into the *same* still-open ``Pool`` is safe and cheaper than
-   giving each its own pool (see :ref:`Chap:Parsers`): a ``grow()`` triggered while building the
-   fifth mesh ``memcpy``\ s *everything* reserved so far, including the first four, and every
-   ``PODVector``'s offset stays correct against the new base regardless. But ``freeze()`` applies to
-   the whole pool, not to an individual mesh -- nobody sharing a pool can move to the query phase
-   (``bind()``, ``Pool::mirror()``) until *everyone* sharing it has finished building. If different
-   meshes need to become query-ready at different times, give them separate pools instead.
+.. code-block:: c++
 
-.. warning::
+   hostPool.freeze();
 
-   Do not call a bound (no-argument) accessor (``getVertex(i)``, ``signedDistance(p)``, ...) on a
-   mesh that has not been ``bind()``'d yet -- its cached base is null (or stale), and dereferencing
-   through it is undefined behaviour, not a checked error. This is exactly why the build-phase code
-   inside ``Soup``/``Parser`` (:ref:`Chap:Parsers`) uses the explicit-base overloads throughout: at
-   that point the owning ``Pool`` may still be open for more meshes and is not guaranteed frozen
-   yet.
+   EBGeometry::Pool devicePool = EBGeometry::Pool::mirror(hostPool, EBGeometry::deviceMemoryResource());
+   const auto       deviceMesh = mesh->rebasedView(devicePool);   // rebase on the host ...
+
+   myKernel<<<blocks, threads>>>(deviceMesh, ...);                // ... then copy by value
+
+How the returned view resolves follows from the pool it is given, not from a separate choice by the
+caller. A device-accessible target (``Device``, ``Managed``, ``Mapped``) yields a view holding a
+plain base address, since a kernel cannot follow a host control block; such a view must not be
+dereferenced on the host. A host-only target (``Host``, ``Pinned``) yields a view holding that
+pool's control block, so it stays growth-immune exactly like the original mesh -- this is what makes
+a host-to-host mirror usable, and testable without a GPU.
+
+``rebasedView`` checks that the pool it is handed really is a mirror of the mesh's own pool
+(directly, or through any number of intermediate mirrors) and that the mesh's arrays fit inside it,
+which catches the realistic mistakes: the wrong pool, or a pool mirrored before the mesh's last
+``reserve``. See :ref:`Sec:Assertions` for when those checks are compiled in.
 
 .. _Chap:BVHIntegration:
 

--- a/Docs/Sphinx/source/MemoryModel.rst
+++ b/Docs/Sphinx/source/MemoryModel.rst
@@ -5,7 +5,7 @@ Memory model
 
 Underneath the DCEL mesh representation (:ref:`Chap:ImplemDCEL`), and progressively the rest of
 the library, sits a small, self-contained memory foundation: a placement policy
-(`MemoryResource <doxygen/html/classEBGeometry_1_1MemoryResource.html>`__), a build-then-freeze
+(`MemoryResource <doxygen/html/classEBGeometry_1_1MemoryResource.html>`__), a bump-allocating
 arena over it (`Pool <doxygen/html/classEBGeometry_1_1Pool.html>`__), and a placement-independent
 array descriptor stored inside it
 (`PODVector <doxygen/html/structEBGeometry_1_1PODVector.html>`__/
@@ -38,8 +38,8 @@ patching pass required.
 .. important::
 
    The recurring idea across every class on this page is: **store an offset, not a pointer; the
-   base is supplied by the caller.** Everything else -- ``Pool``'s two phases, ``PODVector``'s two
-   access styles, ``mirror()`` -- follows from that one decision.
+   base is supplied by the caller.** Everything else -- ``Pool``'s control block, ``PODVector``'s
+   two access styles, ``mirror()`` -- follows from that one decision.
 
 ``MemoryResource``: where bytes live
 --------------------------------------
@@ -93,71 +93,118 @@ ever stores in a pool, including SIMD-width SoA blocks.
    *same* resource share a placement), and copying an allocator has no meaning. Pass it by
    reference, and it must outlive every ``Pool`` built over it.
 
-``Pool``: the build/freeze/query arena
+``Pool``: the arena
 ------------------------------------------
 
 A `Pool <doxygen/html/classEBGeometry_1_1Pool.html>`__ is a single contiguous byte block obtained
-from a ``MemoryResource``. It has exactly two phases, and moving between them is a one-way
-operation:
+from a ``MemoryResource``.
+`reserve(count, elemSize, alignment) <doxygen/html/classEBGeometry_1_1Pool.html#a0c1f5b771e29cce6ae10fae19b766fb7>`__
+bump-allocates a sub-region and returns its byte offset from
+`base() <doxygen/html/classEBGeometry_1_1Pool.html#a049dfaa90b3aa55a410ce19b358fc583>`__. Nothing is
+ever individually freed. If the block is too small, ``reserve`` transparently grows it: it allocates
+a new, larger block (geometric doubling), ``memcpy``\ s every byte currently in use into it, and
+**frees the old block** -- so ``base()`` can change on any ``reserve()`` call.
 
-#. **Build.**
-   `reserve(count, elemSize, alignment) <doxygen/html/classEBGeometry_1_1Pool.html#a0c1f5b771e29cce6ae10fae19b766fb7>`__
-   bump-allocates a sub-region and returns its byte offset from
-   `base() <doxygen/html/classEBGeometry_1_1Pool.html#a049dfaa90b3aa55a410ce19b358fc583>`__.
-   Nothing is ever individually freed. If the block is too small, ``reserve`` transparently grows
-   it: it allocates a new, larger block (geometric doubling), ``memcpy``\ s every byte currently in
-   use into it, and frees the old block -- so ``base()`` can change on *any* ``reserve()`` call
-   during this phase.
-#. **Query.**
-   `freeze() <doxygen/html/classEBGeometry_1_1Pool.html#a7c5696404d11babfad42fc7d99b37ebd>`__ is
-   the single synchronization point between the two phases: afterwards, ``reserve()`` is forbidden
-   (an ``EBGEOMETRY_EXPECT``-checked precondition, see :ref:`Sec:Assertions`), ``base()`` is
-   guaranteed stable for the remaining lifetime of the pool, and
-   `mirror() <doxygen/html/classEBGeometry_1_1Pool.html#aa141bf4919e1aeb78aaee9667da8ebc3>`__
-   becomes available.
+Building and querying are not separate phases. A pool-resident object is usable from the moment its
+storage is reserved, including while the same pool keeps being built into, because it does not
+remember an address: it holds a pointer to the pool's *control block*
+(`PoolControl <doxygen/html/structEBGeometry_1_1PoolControl.html>`__), a small heap-resident record
+holding the current base, and re-reads the base through it on every access. ``grow()`` publishes the
+new base there, so a block move is invisible to every object resolving through it.
 
 .. code-block:: c++
 
    EBGeometry::Pool pool(EBGeometry::hostMemoryResource());
 
-   // Build phase: reserve()/push_back()-style calls, offsets resolved against a freshly-read
-   // pool.base() every time -- never a cached pointer.
-   ...
+   auto first  = EBGeometry::Parser::readIntoMesh<T>("a.stl", pool);
+   const T d   = first->signedDistance(x);      // queryable immediately
 
-   pool.freeze();                 // one-way: no unfreeze().
-   void* base = pool.base();      // now guaranteed stable.
+   auto second = EBGeometry::Parser::readIntoMesh<T>("b.stl", pool);   // may grow and move the block
 
-``mirror(src, dstResource)`` copies a *frozen* source pool's entire block, byte-for-byte, into a
-fresh block from ``dstResource`` (a plain ``memcpy`` for a host-to-host copy, or a
-``GPU::memcpy`` for a host/device transfer), and returns the result already frozen. Because every
-offset stored inside the block is relative rather than absolute, the copy is immediately usable
-against its own (possibly device-resident) ``base()`` -- this is the host-to-device upload, and,
-used host-to-host, an exact independent copy.
+   const T same = first->signedDistance(x);     // ... which changes nothing here
+
+The control block is also why a ``Pool`` can be moved freely -- into a container, into a class
+member, out of a factory -- without disturbing anything built into it. A move transfers ownership of
+the control block, whose address does not change. What a pool-resident object cannot survive is the
+pool being *destroyed*: the block dies with it, so the pool must outlive everything reserved from
+it.
+
+``freeze()``: the mirror precondition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`freeze() <doxygen/html/classEBGeometry_1_1Pool.html#a7c5696404d11babfad42fc7d99b37ebd>`__ seals a
+pool: ``reserve()`` is forbidden afterwards (an ``EBGEOMETRY_EXPECT``-checked precondition, see
+:ref:`Sec:Assertions`) and ``base()`` can no longer move. It exists for exactly one reason -- it is
+the precondition for
+`mirror() <doxygen/html/classEBGeometry_1_1Pool.html#aa141bf4919e1aeb78aaee9667da8ebc3>`__, since
+you cannot take a byte-for-byte copy of a block that might still be reallocated. Freezing is *not*
+required to query anything.
+
+``mirror(src, dstResource)`` copies a frozen source pool's entire block, byte-for-byte, into a fresh
+block from ``dstResource`` (a plain ``memcpy`` for a host-to-host copy, or a ``GPU::memcpy`` for a
+host/device transfer), and returns the result already frozen. Because every offset stored inside the
+block is relative rather than absolute, the copy is immediately usable against its own (possibly
+device-resident) ``base()`` -- this is the host-to-device upload, and, used host-to-host, an exact
+independent copy. A mirror records the identity of the pool it ultimately came from
+(``mirrorOf()``), which is what lets an object built in the original pool verify that it is being
+rebased onto a faithful copy of its own storage; mirroring through intermediate pools (host to
+pinned staging to device) preserves that identity across every hop.
 
 .. warning::
 
-   ``freeze()`` has no inverse. Once a pool is frozen it can never be reserved into again, even to
-   append more of the same kind of data. If you need to build several batches of data (e.g. several
-   mesh files) into one shared pool, do all of the building *before* the first ``freeze()`` call --
-   see the pitfalls in :ref:`Sec:DCELMemoryModel` for what this means in practice for
-   ``DCEL::MeshT``.
+   ``freeze()`` has no inverse. Once a pool is frozen it can never be reserved into again. Since
+   freezing is only needed in order to mirror, the practical rule is simply to do it last.
 
-.. warning::
+.. _Sec:ResolvedAddresses:
 
-   Never cache the result of ``base()`` across a call that might trigger another ``reserve()``
-   (directly, or indirectly through anything still in its build phase). A block move during
-   ``grow()`` silently invalidates any pointer computed against the old base; there is no way to
-   detect this after the fact; the failure mode is a wild pointer, not a diagnosable error. Always
-   re-read ``base()`` immediately before using it, and treat it as disposable in between.
+Resolved addresses do not survive a ``reserve``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The control block protects anything that *re-resolves*. It cannot protect an address that has
+already been resolved, and a ``reserve`` that grows the pool deallocates the block such an address
+points into:
+
+.. code-block:: c++
+
+   auto& e = mesh->getEdge(3);      // a raw address, resolved right now
+   mesh->reserveFaces(pool, n);     // may grow -- the old block is freed
+   e.setFace(7);                    // undefined behaviour: write into freed memory
+
+The hazard is intermittent (a grow only happens when a request exceeds the current capacity) and its
+quiet form is worse than a crash: if the freed block is still mapped, the write lands in the
+abandoned copy and is silently lost, while the object itself now reads from the new block.
+
+.. important::
+
+   **Resolve, use, discard.** A pointer, reference or ``PODSpan`` obtained from pool storage must
+   not outlive the next ``reserve()`` on that pool. To carry data across a ``reserve``, carry it by
+   *value* and write it back through a fresh resolution:
+
+   .. code-block:: c++
+
+      Edge e = mesh->getEdge(3);      // snapshot, independent of any base
+      mesh->reserveFaces(pool, n);    // may grow
+      e.setFace(7);
+      mesh->getEdge(3) = e;           // fresh resolution against the current base
+
+   Everything that returns *by value* -- ``signedDistance()``, ``getAllVertexCoordinates()``, and so
+   on -- is unaffected, which is the overwhelming majority of the query surface.
 
 .. note::
 
-   ``Pool`` is move-only, RAII, and deliberately *not* trivially copyable -- it owns a block and a
-   ``MemoryResource*`` with real lifetime semantics. This is by design: it is one of only two
-   non-trivial types anywhere in this memory model (``MemoryResource`` is the other). Everything
-   *stored inside* a ``Pool`` -- every ``PODVector``, and every structure built entirely from
-   ``PODVector``\ s and plain values -- is trivially copyable POD; the ``Pool`` itself never is,
-   and is never mirrored to a device or passed to device code directly.
+   For the same reason, querying an object while another thread reserves from the same pool is a
+   data race: the reader may observe a base being republished, or have the block reallocated
+   underneath it. Pools are not internally synchronized. Finish building before sharing a pool
+   across threads, or serialize the reserves.
+
+.. note::
+
+   ``Pool`` is move-only, RAII, and deliberately *not* trivially copyable -- it owns a block, a
+   control block and a ``MemoryResource*`` with real lifetime semantics. This is by design: it is
+   one of only two non-trivial types anywhere in this memory model (``MemoryResource`` is the
+   other). Everything *stored inside* a ``Pool`` -- every ``PODVector``, and every structure built
+   entirely from ``PODVector``\ s and plain values -- is trivially copyable POD; the ``Pool`` itself
+   never is, and is never mirrored to a device or passed to device code directly.
 
 ``PODVector`` and ``PODSpan``: placement-independent storage
 ------------------------------------------------------------------
@@ -171,7 +218,7 @@ copyable, since it is device-visible storage.
 
    EBGeometry::PODVector<MyPodType> vec;
 
-   vec.reserveFrom(pool, 128);              // build phase, must not be frozen
+   vec.reserveFrom(pool, 128);              // must not be frozen
    vec.push_back(pool.base(), someValue);   // never reallocates -- capacity is fixed at reserveFrom()
 
 Two access styles are provided, and choosing between them is the main day-to-day decision this
@@ -186,23 +233,22 @@ memory model asks of a caller:
      - When to use it
    * - Resolve every call
      - ``at(base, i)``, ``data(base)``
-     - The default. Resolves ``base + offset`` fresh on every call, so it is correct during the
-       build phase, after ``freeze()``, and against any base you have in hand -- host or (mirrored)
-       device. Costs one extra addition per access.
+     - The default. Resolves ``base + offset`` fresh on every call, so it is correct while the pool
+       is still being built into, after ``freeze()``, and against any base you have in hand -- host
+       or (mirrored) device. Costs one extra addition per access.
    * - Bind once
      - ``bind(base) -> PODSpan<T>``
      - A raw ``pointer + size`` pair for a genuinely hot inner loop (SIMD traversal, a tight BVH
-       query), where re-deriving the pointer every iteration is measurable overhead. Only valid
-       against a **frozen** pool -- the freeze contract is exactly what makes a captured raw
-       pointer safe here.
+       query), where re-deriving the pointer every iteration is measurable overhead. Safe only for
+       as long as no further ``reserve()`` happens on the pool.
 
 .. important::
 
-   ``PODSpan<T>`` (returned by ``bind()``) captures a raw pointer. It is only ever safe to take
-   against a frozen (or already-mirrored) pool, whose base cannot move again -- taking it during
-   the build phase and holding it across a later ``reserve()``/``grow()`` reproduces exactly the
-   dangling-pointer hazard described above for ``base()`` itself, just one level removed. Prefer
-   ``at()``/``data()`` unless you have measured that the resolve-every-call cost actually matters.
+   ``PODSpan<T>`` (returned by ``bind()``) captures a raw pointer, so it is exactly the
+   resolved-address hazard of :ref:`Sec:ResolvedAddresses` in container form: it must not outlive
+   the next ``reserve()``. Taking one against a frozen (or already-mirrored) pool removes the
+   question entirely, since such a pool can never be reserved into again. Prefer ``at()``/``data()``
+   unless you have measured that the resolve-every-call cost actually matters.
 
 .. code-block:: c++
 

--- a/Docs/Sphinx/source/Parsers.rst
+++ b/Docs/Sphinx/source/Parsers.rst
@@ -29,8 +29,7 @@ caller-owned and caller-managed -- EBGeometry never constructs one for you -- so
 every mesh (or SDF wrapper retaining one, see :ref:`Chap:MeshSDFClasses`) built into it. One Pool
 can back many meshes, built one after another with their arrays laid out contiguously in the same
 block, which is cheaper than giving every mesh its own Pool -- see :ref:`Chap:MemoryModel` for how
-this works internally, and the pitfalls in :ref:`Sec:DCELMemoryModel` for what it means in practice
-(in particular, everyone sharing a Pool must finish building before anyone can freeze it). If you
+this works internally, and :ref:`Sec:DCELMemoryModel` for what it means in practice. If you
 have one or multiple mesh files, the quickest way to turn them into BVH-accelerated signed
 distance fields is
 
@@ -127,12 +126,9 @@ Note that this will only expose the DCEL mesh, but not include any signed distan
 
 .. note::
 
-   ``readIntoDCEL`` never freezes or ``bind()``\ s ``pool`` (it may still be shared with more
-   files -- see :ref:`Chap:MemoryModel`), so the returned mesh is not yet queryable through its
-   no-argument accessors (``mesh->getVertex(i)``, ``mesh->signedDistance(p)``, ...). Freeze
-   ``pool`` and call ``mesh->bind(pool)`` yourself if you want to query a raw ``readIntoDCEL``
-   result directly; every other ``readInto*`` function below does this for you as part of building
-   its SDF wrapper.
+   The returned mesh is queryable immediately (``mesh->getVertex(i)``, ``mesh->signedDistance(p)``,
+   ...), and stays queryable as further meshes are built into the same ``pool``. Nothing has to be
+   frozen first -- see :ref:`Chap:MemoryModel`.
 
 DCEL mesh SDF
 _____________
@@ -141,17 +137,8 @@ To read one or multiple files and also turn it into a bare (BVH-free) signed dis
 representation, use ``readIntoMesh<T, Meta>(filename, pool)``, returning a
 ``shared_ptr<FlatMeshSDF<T, Meta>>`` (or a vector thereof for the multi-file overload). The
 returned ``FlatMeshSDF`` retains the mesh (see :ref:`Chap:MeshSDFClasses`), so ``pool`` must
-outlive it.
-
-.. warning::
-
-   ``FlatMeshSDF``'s constructor freezes ``pool`` (see :ref:`Chap:MemoryModel`): once a call to
-   ``readIntoMesh`` (or a direct ``FlatMeshSDF`` construction) has run, no more meshes can be built
-   into that same ``pool`` -- including from a second, separate ``readIntoMesh`` call. The
-   multi-file overload handles this correctly internally (it builds every file's mesh before
-   wrapping any of them); if you need several *independent* ``readIntoMesh`` calls sharing one
-   file's worth of build work, use the multi-file overload rather than chaining single-file calls
-   by hand, or give each single-file call its own ``Pool``.
+outlive it. Repeated calls can share one ``pool`` freely, in any combination with the other
+``readInto*`` functions.
 
 .. _Chap:PackedBVHParser:
 
@@ -164,11 +151,6 @@ a vector thereof). It supports any polygon, not just triangles; the BVH branchin
 defaults to 4 and the build strategy ``a_build`` defaults to ``BVH::Build::SAH``. The returned
 ``MeshSDF`` retains the mesh, so ``pool`` must outlive it. For maximum throughput on
 triangle-only meshes, prefer ``readIntoTriangleBVH`` below.
-
-.. warning::
-
-   ``MeshSDF``'s constructor freezes ``pool`` too, for the same reason as ``FlatMeshSDF`` above --
-   the same caution about chaining single-file calls by hand applies here.
 
 Triangle meshes with PackedBVH
 ________________________________
@@ -240,11 +222,9 @@ in namespace ``EBGeometry::Soup``:
   :math:`v \to u`), and runs a mesh sanity check. This also computes the vertex and edge normal
   vectors. ``mesh`` can be freshly default-constructed (``DCEL::MeshT<T, Meta> mesh;``, no ``Pool``
   needed at construction); ``soupToDCEL`` reserves its vertex/edge/half-edge storage from ``pool``
-  itself, sized from ``vertices``/``facets``. Since ``pool`` may still be shared with more meshes
-  after this call, ``soupToDCEL`` never freezes/binds it -- see :ref:`Chap:MemoryModel` and
-  :ref:`Sec:DCELMemoryModel` -- so ``mesh`` is not yet queryable through its no-argument accessors
-  at this point; freeze and ``bind()`` it yourself once you are done building into ``pool``, the
-  same way :ref:`Chap:MeshSDFClasses`'s constructors do.
+  itself, sized from ``vertices``/``facets``. ``mesh`` is attached to ``pool`` by that first reserve
+  and is queryable as soon as ``soupToDCEL`` returns, whether or not ``pool`` is shared with further
+  meshes -- see :ref:`Chap:MemoryModel` and :ref:`Sec:DCELMemoryModel`.
 
 .. note::
 

--- a/Examples/MeshSDF/main.cpp
+++ b/Examples/MeshSDF/main.cpp
@@ -52,19 +52,17 @@ main(int argc, char* argv[])
   // Note that this reads the mesh and builds the BVH tree independently for each
   // representation. There are converters that avoid this, but users will almost always
   // only use one of these representations.
-  // Each representation gets its own Pool: FlatMeshSDF's and MeshSDF's constructors freeze the
-  // Pool they are given (the point at which a mesh commits to long-term querying -- see
-  // EBGeometry_MeshDistanceFunctions.hpp and the Memory model docs page), so three independent
-  // parses cannot share one Pool the way they could when nothing about a Pool was ever frozen.
-  // dcelSDF and meshSDF retain their mesh for its lifetime (see FlatMeshSDF/MeshSDF's docs), so
-  // each Pool must outlive its corresponding SDF -- keeping them in main()'s scope satisfies that.
-  EBGeometry::Pool dcelPool(EBGeometry::hostMemoryResource());
-  EBGeometry::Pool meshPool(EBGeometry::hostMemoryResource());
-  EBGeometry::Pool triPool(EBGeometry::hostMemoryResource());
+  // All three share one Pool. Each parse keeps reserving from it, growing (and moving) its block as
+  // it goes, which is invisible to the meshes already built: a mesh resolves its storage through
+  // the Pool's control block on every access rather than caching an address, so there is no point
+  // at which the Pool has to be sealed off. dcelSDF and meshSDF retain their mesh for their whole
+  // lifetime (see FlatMeshSDF/MeshSDF's docs), so the Pool must outlive them -- keeping it in
+  // main()'s scope satisfies that.
+  EBGeometry::Pool pool(EBGeometry::hostMemoryResource());
 
-  const auto dcelSDF = EBGeometry::Parser::readIntoMesh<T, Meta>(file, dcelPool);
-  const auto meshSDF = EBGeometry::Parser::readIntoPackedBVH<T, Meta, K>(file, meshPool);
-  const auto triSDF  = EBGeometry::Parser::readIntoTriangleBVH<T, Meta>(file, triPool, 4, BVH::Build::SAH);
+  const auto dcelSDF = EBGeometry::Parser::readIntoMesh<T, Meta>(file, pool);
+  const auto meshSDF = EBGeometry::Parser::readIntoPackedBVH<T, Meta, K>(file, pool);
+  const auto triSDF  = EBGeometry::Parser::readIntoTriangleBVH<T, Meta>(file, pool, 4, BVH::Build::SAH);
 
   // Sample some random points around the object.
   constexpr size_t Nsamp = 1000;

--- a/Integrations/AMReX/PaintEB/main.cpp
+++ b/Integrations/AMReX/PaintEB/main.cpp
@@ -41,13 +41,6 @@ public:
 
     auto mesh = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_filename, *m_pool);
 
-    // readIntoDCEL never freezes/binds m_pool (it may still be shared with more meshes), so the
-    // mesh isn't queryable through its no-argument accessors yet -- freeze and bind it before
-    // touching faces by index below. MeshSDF's own constructor freeze is idempotent, so doing it
-    // here first is safe.
-    m_pool->freeze();
-    mesh->bind(*m_pool);
-
     // Set the meta-data for all facets to their "index", i.e. position in the list of facets
     for (uint32_t i = 0; i < mesh->numFaces(); i++) {
       mesh->getFace(i).getMetaData() = 1.0 * i;

--- a/PLAN.md
+++ b/PLAN.md
@@ -36,45 +36,127 @@ Rejected alternatives, and why:
 A pool-resident type carries **both** pointers:
 
 ```cpp
-Pool* m_pool = nullptr;   // host-only. null in a device view.
-void* m_base = nullptr;   // resolved base. authoritative on device.
+const PoolControl* m_control = nullptr;   // host-only. null in, and only in, a device view.
+void*              m_base    = nullptr;   // set on the host by rebasedView; read only on device.
 
 EBGEOMETRY_HOST_DEVICE const void* base() const noexcept
 {
 #if defined(EBGEOMETRY_DEVICE_COMPILE)
-  EBGEOMETRY_EXPECT(m_pool == nullptr);   // a host descriptor reached a kernel without deviceView
+  EBGEOMETRY_EXPECT(m_control == nullptr);   // a host descriptor reached a kernel without rebasedView
   return m_base;
 #else
-  EBGEOMETRY_EXPECT(m_pool == nullptr || m_pool->base() != nullptr);   // moved-from pool
-  return m_pool != nullptr ? m_pool->base() : m_base;
+  EBGEOMETRY_EXPECT(m_control != nullptr);   // a device view is being dereferenced on the host
+  return m_control->m_base;
 #endif
 }
 ```
 
 The two are not redundant: `m_base` points *into the data block*, which `mirror()` copies, so it
-has a device counterpart and can be rebased. `m_pool` points at *host bookkeeping* that is never
-mirrored and has no device counterpart. Host resolution goes through the pool and is therefore
-immune to growth; device resolution uses the rebased base.
+has a device counterpart. `m_control` points at *host bookkeeping* that is never mirrored and has no
+device counterpart. Host resolution always goes through the control block and is therefore immune to
+growth; device resolution uses the snapshot base, because a kernel cannot follow a control block.
+
+Both assertions are exact, not best-effort, because `rebasedView` (below) is the only producer of a
+null `m_control` and it produces one *only* for a device-accessible target. So `m_control == nullptr`
+means "device view" and nothing else, in both directions:
+
+- On device, a non-null `m_control` means a host descriptor was copied into a kernel directly.
+- On host, a null `m_control` means either a device view being dereferenced on the host, or a
+  default-constructed mesh nobody ever reserved into. Both are errors, caught at the point of use.
+
+Note the consequence for `m_base`: on the host it is **write-only**. Nothing reads it until the
+descriptor has been byte-copied into a device address space, which makes it look dead to a host-only
+reader and needs saying on the field itself.
 
 The type stays trivially copyable (two raw pointers plus `PODVector`s), so every existing
 `static_assert` and `Meta` requirement holds unchanged.
 
+### Why a control block rather than a `Pool*`
+
+The obvious form of the above stores `Pool* m_pool` and resolves through `m_pool->base()`. It works,
+but it regresses a property the code has today. `MeshT::m_base` currently holds the address of the
+*block*, and `Pool`'s move constructor steals that pointer verbatim (`PoolImplem.hpp:58-68`) — the
+block does not move, only its owner does — so a bound mesh survives its pool being moved. Storing a
+`Pool*` points the mesh at precisely the thing a move relocates:
+
+```cpp
+std::vector<Pool> pools;                  // one pool per geometry
+pools.emplace_back(hostMemoryResource());
+auto mesh = Parser::readIntoMesh<T, Meta>(file, pools[0]);
+pools.emplace_back(hostMemoryResource()); // reallocates: pools[0] is moved, then destroyed
+mesh->signedDistance(p);                  // reads freed vector storage
+```
+
+That snippet is correct against today's code and would silently break — as would a pool held as a
+class member (move the owner and every mesh inside it dangles), and any factory returning a pool
+alongside the geometry built into it. The moved-from-pool `EXPECT` does not cover these: it fires
+only while the moved-from object is still *alive*, and `EBGEOMETRY_EXPECT` compiles to `((void)0)`
+in the release presets. This is not a new way for users to get lifetimes wrong; it is a pattern that
+works today and stops working, with nothing in the diff to draw a reviewer's eye to it.
+
+The fix is to point at something a move cannot relocate:
+
+```cpp
+struct PoolControl
+{
+  void*    m_base = nullptr;   // written by grow(); read by every descriptor
+  uint64_t m_id   = 0;         // pool identity, for rebasedView's lineage check
+};
+```
+
+`Pool` holds `std::unique_ptr<PoolControl> m_control` and **drops its own `m_base` field** — one
+source of truth, nothing to keep in sync. Moving a `Pool` moves the `unique_ptr`; the pointee's
+address is unchanged, so every descriptor keeps resolving. `grow()` writes the new base into the
+control block, which is what delivers the growth-immunity this PR exists for.
+
+Touched sites in `Pool`, all mechanical:
+
+- `base()` — `return m_control != nullptr ? m_control->m_base : nullptr;`
+- `grow()` — reads `m_control->m_base` for the `memcpy`/`deallocate`, then writes the new base back.
+- `~Pool()` and move assignment — deallocate via `m_control->m_base`.
+- Both constructors (the public one and the private `MirrorTag` one) — allocate the control block.
+- Move constructor — moves the `unique_ptr` and needs no base fixup at all. A moved-from pool has
+  `m_control == nullptr`, so `base()` returns null and the destructor frees nothing: the same
+  observable behaviour as today's `a_other.m_base = nullptr`, so the existing `TestPool` move
+  expectations hold unchanged.
+
+`m_size`, `m_capacity`, `m_frozen`, `m_resource` and `m_mirrorOf` stay on the `Pool` itself —
+nothing that resolves a descriptor needs them, and `rebasedView` reads them through the `const Pool&`
+it is handed. `m_id` lives in the control block because a descriptor must be able to name its own
+source pool for the lineage check without holding a `Pool*`.
+
+Cost: one small heap allocation per pool (against a block that is normally megabytes), and exactly
+the one indirection `m_pool->base()` would have cost. `Pool` stays movable, which it must be —
+`mirror()` returns by value.
+
+What this does **not** buy is use-after-*destroy* detection: destroying a pool frees its block, so
+its descriptors dangle. That is unchanged from today's contract — the pool must outlive its meshes
+either way — so it is parity, not a regression. Making it detectable would require the control
+block to outlive the pool (a registry, or a deliberate leak), which is out of scope here.
+
 ### What this deletes
 
 - `MeshT::bind()` — there is nothing to bind. **There is no "unbound" state any more**: a host mesh
-  has `m_pool` from its first `reserveX(pool, …)`, a device view has `m_base` from `deviceView()`,
+  has `m_control` from its first `reserveX(pool, …)`, a device view has `m_base` from `rebasedView()`,
   and the only state with neither is a default-constructed mesh nobody reserved into (caught by an
   `EBGEOMETRY_EXPECT` in `base()`).
-- **Every explicit-base overload.** `getVertex(base, i)`, `signedDistance(base, p)`,
-  `unsignedDistance2(base, p)`, `getAllVertexCoordinates(base)`, `reconcile(base, …)`,
-  `reconcileFaces(base)`, `reconcileVertices(base, …)` exist solely to resolve mid-build before
-  `bind()` was legal. With `m_pool` captured, the no-argument forms are always correct, so
+- **Every explicit-base overload.** Public: `getVertex/getEdge/getFace(base, i)` (mutable and const),
+  `signedDistance(base, p)` (both forms), `unsignedDistance2(base, p)`, `getAllVertexCoordinates(base)`,
+  `reconcile(base, …)`, `sanityCheck(base, id)`, `setInsideOutsideAlgorithm(base, alg)`, `flip(base)`.
+  Protected: `reconcileFaces/reconcileEdges/reconcileVertices(base, …)`,
+  `flipFaceNormals/flipEdgeNormals/flipVertexNormals(base)`,
+  `DirectSignedDistance/DirectSignedDistance2(base, p)`. They exist solely to resolve mid-build
+  before `bind()` was legal. With `m_control` captured, the no-argument forms are always correct, so
   `MeshT`'s accessor surface roughly halves. The `FaceT`/`EdgeT`/`VertexT` methods that take a
   `const Mesh&` are untouched — the mesh they receive always resolves, which is precisely what
   `boundView` existed to fake.
-- `boundView()` in its **host** role. Every host call site passes `a_pool.base()`
-  (`MeshDistanceFunctionsImplem.hpp:445`, `ParserImplem.hpp:1860`), i.e. the pool's own current
-  base, which is exactly what `m_pool->base()` already returns. Those calls become no-ops.
+- `boundView()` in its **host** role, which is entangled with the bullet above rather than separable
+  from it. The two *external* call sites do pass `a_pool.base()`
+  (`MeshDistanceFunctionsImplem.hpp:446`, `ParserImplem.hpp:1861`), i.e. the pool's own current base,
+  which is exactly what `m_control->m_base` already holds, so those become no-ops. But there are also
+  seven *internal* uses in `DCEL_MeshImplem.hpp` (`:158,463,475,487,617,695,726`) that pass a
+  parameter base — they disappear only as a consequence of deleting the explicit-base family, so the
+  two deletions land together or not at all.
 - The freeze-before-query rule, and with it the three-pool workaround in `Examples/MeshSDF` and
   the two-pass dance in `Parser::readIntoMesh`.
 - `deepCopy(srcBase, dstPool)` → `deepCopy(dstPool)`; the source base is known.
@@ -83,44 +165,127 @@ The type stays trivially copyable (two raw pointers plus `PODVector`s), so every
 `freeze()` survives, required **only** before `mirror()` — a rule that justifies itself ("you
 cannot copy a block that might still move") rather than being a precondition on asking a question.
 
+### What replaces the freeze rule: resolved references die at the next `reserve`
+
+Deleting freeze-before-query deletes a structural guarantee, and it has to come back as a documented
+rule. Today the ergonomic accessors require a frozen pool, and `reserve()` after `freeze()` is
+forbidden (`PoolImplem.hpp:98`), so a reference into pool memory cannot outlive a base move — the
+state machine makes it unreachable. Once a mesh can be queried mid-build, it becomes reachable:
+
+```cpp
+Edge& e = mesh.getEdge(3);      // resolved once: a raw address into the current block
+mesh.reserveFaces(pool, n);     // may grow — grow() deallocates the old block (PoolImplem.hpp:133)
+e.setFace(7);                   // write to freed memory
+```
+
+The `PODVector` is fine (it stores an offset, not an address) and the edge data is fine (`memcpy`'d
+to the same offset in the new block). What is stale is the address `getEdge(3)` already computed.
+The failure is intermittent — `reserve` only grows when `need > m_capacity` — and its quiet form is
+worse than a crash: if the freed page is still mapped, the write lands in the abandoned copy, and
+the mesh, now reading from the new block, silently reports the old value.
+
+The rule is: **resolve, use, discard — a resolved address must not outlive the next `reserve` on
+that pool.** Holding data across a `reserve` means holding it *by value*:
+
+```cpp
+Edge e = mesh.getEdge(3);       // snapshot, independent of any base
+mesh.reserveFaces(pool, n);
+e.setFace(7);
+mesh.getEdge(3) = e;            // fresh resolution against the current base
+```
+
+The exposure is exactly the reference-returning accessors (`getVertex`/`getEdge`/`getFace`) plus
+`PODVector::bind()`; everything returning by value (`signedDistance`, `getAllVertexCoordinates`) is
+unaffected. Note that `PODVector`'s class documentation already states this correctly, but only for
+`bind`/`PODSpan` — the `T&` returned by `at()` carries the identical restriction and says nothing.
+
+Documented in the same PR, in four places:
+
+1. **`Pool::reserve`'s Doxygen** — its `@details` currently frames growth as an allocation detail
+   ("May grow the block"). It must say that a grow deallocates the old block and invalidates every
+   previously-resolved pointer, reference and `PODSpan` into it, while leaving every `PODVector`
+   valid.
+2. **`PODVector`'s class-level block** — generalize the existing `bind`/`PODSpan` caveat to cover
+   anything resolved, including `at()`'s return, and show the snapshot-and-write-back pattern.
+3. **`MeshT`'s `getVertex`/`getEdge`/`getFace` Doxygen** — the one-liner plus a pointer to the rule.
+4. **`MemoryModel.rst`** — as prominently as the freeze rule it replaces.
+
 ### The one sanctioned crossing
 
 ```cpp
 EBGEOMETRY_HOST
 Mesh
-MeshT<T, Meta>::deviceView(const Pool& a_devicePool) const noexcept
+MeshT<T, Meta>::rebasedView(const Pool& a_pool) const noexcept
 {
-  EBGEOMETRY_EXPECT(a_devicePool.resource().isDeviceAccessible());    // reachable from a kernel
-  EBGEOMETRY_EXPECT(a_devicePool.isFrozen());                         // a real, sealed mirror
-  EBGEOMETRY_EXPECT(a_devicePool.mirrorOf() == m_pool->id());         // a mirror of *our* pool
-  EBGEOMETRY_EXPECT(m_vertices.endByte() <= a_devicePool.usedBytes());// our arrays fit inside it
-  EBGEOMETRY_EXPECT(m_edges.endByte()    <= a_devicePool.usedBytes());
-  EBGEOMETRY_EXPECT(m_faces.endByte()    <= a_devicePool.usedBytes());
+  EBGEOMETRY_EXPECT(m_control != nullptr);                       // not already a view
+  EBGEOMETRY_EXPECT(a_pool.mirrorOf() == m_control->m_id);       // a mirror of *our* pool
+  EBGEOMETRY_EXPECT(m_vertices.endByte() <= a_pool.usedBytes()); // our arrays fit inside it
+  EBGEOMETRY_EXPECT(m_edges.endByte()    <= a_pool.usedBytes());
+  EBGEOMETRY_EXPECT(m_faces.endByte()    <= a_pool.usedBytes());
 
-  Mesh view   = *this;
-  view.m_pool = nullptr;
-  view.m_base = a_devicePool.base();
+  Mesh view = *this;
+
+  if (a_pool.resource().isDeviceAccessible()) {
+    EBGEOMETRY_EXPECT(a_pool.isFrozen());   // snapshotting a base: it must not move
+    view.m_control = nullptr;               // a kernel cannot follow a control block
+    view.m_base    = a_pool.base();
+  }
+  else {
+    view.m_control = a_pool.control();      // growth-immune, exactly like the original
+    view.m_base    = nullptr;
+  }
+
   return view;
 }
 ```
 
-Taking the `Pool&` rather than a `void*` is what makes the checks possible. `isDeviceAccessible()`
-already exists on all five resources and is the correct predicate — `Managed`/`Mapped` are both
-host- and device-accessible, `Pinned` is host-accessible but **not** device-reachable. The bounds
-and lineage checks catch the realistic mistakes (wrong pool, mirrored before the last `reserve`),
-which a bare base pointer cannot detect at all.
+Taking the `Pool&` rather than a `void*` is what makes the checks possible. The bounds and lineage
+checks catch the realistic mistakes (wrong pool, mirrored before the last `reserve`), which a bare
+base pointer cannot detect at all.
 
-`deviceView` is `EBGEOMETRY_HOST` — `Pool` is host-only, and building a kernel argument is a host
+**One function, not two, and `isDeviceAccessible()` is the discriminator rather than an assertion.**
+Rebasing onto a host-to-host mirror must be supported: `Pool::mirror` explicitly offers it ("and,
+host-to-host, an exact independent copy", `Pool.hpp:178-179`), and `Tests/TestPoolRebase.cpp` is
+built on it precisely because it exercises the rebase invariant *without a GPU* — the only way that
+invariant executes in CI at all, since the CI runners have no device. Asserting device-accessibility
+would have made a `MeshT`-level version of that test impossible to write. Making the predicate select
+the branch instead means the caller states their intent by which pool they hand over, with no second
+function to choose between: `Managed`/`Mapped` are device-accessible and correctly take the snapshot
+branch, `Pinned` and `Host` take the control-block branch.
+
+The host branch is the reason `base()`'s assertions above can be exact. Following the target's
+control block rather than snapshotting its base means a host rebase leaves `m_control` non-null, so
+a null `m_control` is unambiguously a device view — no residency flag needed to tell the two apart.
+
+`EXPECT(isFrozen())` on the device branch never actually binds: the lineage check already restricts
+the target to a mirror of our pool, `mirror()` returns frozen pools, there is no unfreeze, and
+`grow()` refuses non-host-accessible resources outright (`PoolImplem.hpp:119`). It is kept as a
+cheap guard on the one place a raw base is captured, not because a live path can violate it. The
+host branch needs no such guard at all — that is what the control block buys.
+
+`rebasedView` is `EBGEOMETRY_HOST` — `Pool` is host-only, and building a kernel argument is a host
 activity. The old `HOST_DEVICE` on `boundView` was justified by a device-side rebase that nothing
 uses.
 
 ### Supporting changes
 
-- **`Pool`**: add `uint64_t m_id` (monotonic, assigned at construction) and `uint64_t m_mirrorOf`
-  (set by `mirror()` to the source's id, 0 otherwise), with `id()` / `mirrorOf()` accessors.
+- **`Pool`**: replace `void* m_base` with `std::unique_ptr<PoolControl> m_control` (see above), and
+  add a `control()` accessor returning `const PoolControl*`. `m_id` (monotonic, assigned at
+  construction) lives *in the control block*; `uint64_t m_mirrorOf` stays on the `Pool`, with
+  `id()` / `mirrorOf()` accessors. The id counter must be an `inline std::atomic<uint64_t>` — the
+  library is header-only and pools may be constructed on several threads.
+- **`mirrorOf` names the root, not the immediate source**: `mirror()` sets
+  `m_mirrorOf = a_src.m_mirrorOf != 0 ? a_src.m_mirrorOf : a_src.id()`, and 0 means "not a mirror".
+  Without this, a chain (host → pinned staging → device, which is most of why a `Pinned` resource
+  exists) leaves the final pool naming the staging pool, so `rebasedView`'s lineage check fails on a
+  correct sequence — the block is a faithful copy and every offset resolves, only the bookkeeping
+  disagrees. Carrying the root forward makes the check transitive for chains of any length while
+  still rejecting a genuinely unrelated pool.
 - **`PODVector`**: add `endByte()` = `m_offset + m_capacity * sizeof(T)` for the bounds checks.
-- **`MeshT`**: `m_pool` is captured on the first `reserveVertices/Edges/Faces(pool, …)`, with an
-  `EBGEOMETRY_EXPECT` that later reserves pass the same pool.
+  Deliberately capacity, not size: it bounds the *reserved* region against the mirrored block.
+- **`MeshT`**: `m_control` is captured (from `a_pool.control()`) on the first
+  `reserveVertices/Edges/Faces(pool, …)`, with an `EBGEOMETRY_EXPECT` that later reserves pass the
+  same pool.
 - **Parsers**: `readInto*` no longer freeze; the multi-file overloads become plain loops.
 - **SDF wrappers**: `FlatMeshSDF`/`MeshSDF` stop freezing and binding, matching what
   `TriMeshSDF`'s mesh constructor already does.
@@ -128,25 +293,49 @@ uses.
 
 ### Pattern reuse
 
-`PackedBVH` needs the same two fields, accessor, and `deviceView`. Duplicate them rather than
-introducing a CRTP mixin — it is ~15 lines, and a base class complicates the trivial-copyability
-`static_assert`s for no real saving. Document the convention once in `PORTING.md`.
+`PackedBVH` needs the same two fields (`m_control`, `m_base`), the same `base()`, and its own
+`rebasedView`. Duplicate them rather than introducing a CRTP mixin — it is ~15 lines, and a base
+class complicates the trivial-copyability `static_assert`s for no real saving. Document the
+convention once in `PORTING.md`.
 
 ### Risks
 
-- **`Pool` is movable** (`mirror()` returns by value), so moving one leaves descriptors pointing at
-  a moved-from object. A moved-from pool has `m_base == nullptr`, caught by the `EXPECT` in
-  `base()`.
+- **Pool lifetime.** Moves are safe (the control block does not relocate), but *destroying* a pool
+  still invalidates every descriptor into it, since the block dies with it. Unchanged from today,
+  and not detectable without a registry outliving the pool.
+- **Resolved references.** See the section above: the freeze state machine used to make a live
+  reference across a base move structurally impossible, and now only documentation and review do.
+- **Query-during-build is not thread-safe.** With freeze gone as a precondition, a query on one
+  thread races a `reserve()` on another against the same pool — a data race on the control block's
+  base, and possibly a `grow()` under the reader's feet. Today that is structurally impossible.
+  Needs a sentence in `MemoryModel.rst`; the library is used from OpenMP codes.
 - **Weakened invariant.** #140 made "mirror a host descriptor, dereference on device" structurally
-  impossible; it becomes possible-but-asserted. Every realistic error path is now caught on the
-  *host* at the point of the mistake, which is a more useful place than a garbage kernel result,
-  but it is a debug-time guarantee rather than a type-level one.
+  impossible; it becomes possible-but-asserted. The assertions are exact rather than heuristic (see
+  "The rule"), and every realistic error path is caught at the point of the mistake rather than as a
+  garbage kernel result — but `EBGEOMETRY_EXPECT` compiles to `((void)0)` in the release presets, so
+  this is a debug-time guarantee, not a type-level one. Recovering the type-level version means a
+  distinct view type, which is not "two types and an API break" as the rejected-alternatives list
+  above says, but two types *plus* templating every `FaceT`/`EdgeT`/`VertexT` method that takes a
+  `const Mesh&`. That cost is the actual reason to accept this trade, and it should be recorded as
+  such.
 
 ### Docs
 
 `MemoryModel.rst` needs its central framing rewritten: build/freeze/query becomes build-and-query,
-with freeze as a mirror precondition. `ImplemDCEL.rst`'s memory-model section loses the
-explicit-base/bound accessor split and the `boundView` note added in #140.
+with freeze as a mirror precondition. It gains, in freeze's place, the resolved-reference rule and
+the note that querying during a build is not thread-safe against a concurrent `reserve`.
+`ImplemDCEL.rst`'s memory-model section loses the explicit-base/bound accessor split and the
+`boundView` note added in #140.
+
+Header Doxygen is not optional here and is listed with the four documentation sites in the
+resolved-reference section above: `Pool::reserve`, `PODVector`'s class block, and `MeshT`'s
+reference-returning accessors. `Pool`'s own file-level block also describes the two-phase contract
+in its current form and needs the same rewrite as `MemoryModel.rst`.
+
+`PORTING.md` is part of this PR too, not a follow-up: its "one rule" section shows
+`mesh->boundView(devicePool.base())` as *the* sanctioned crossing, and its "Porting a class" recipe
+and DCEL row both describe the accessor-pair convention this PR removes. It is accurate today, so it
+must change in the same commit that makes it wrong.
 
 ## PR 2 — the BVH port
 
@@ -207,7 +396,7 @@ so only the containers change.
 Every construction entry point gains a `Pool&`: `pack(Pool&)`, `packWith(Pool&, converter)`, the
 direct `primsAndBVs` constructors, and the protected constructor `PointCloudBVH` uses. `MeshSDF`
 already takes a `Pool&`, so its signature is unchanged and the mesh and its BVH land in one pool —
-one `mirror()`, one base, one `deviceView`.
+one `mirror()`, one base, one `rebasedView`.
 
 `TreeBVH` stays host-only and unchanged. It is the builder; static geometry builds on the host.
 
@@ -241,7 +430,7 @@ nothing yet needs moving geometry to stay resident on the device.
 1. Traversal refactor + real scalar path. Host-only, no API change, fully covered by `TestBVH`.
    Also a CPU speedup for any (T,K) with no compiled ISA path.
 2. `IndexStorage` + the `get(stored, base)` signature.
-3. Arrays onto `Pool`/`PODVector`; `Pool&` on the constructors; `m_pool`/`m_base`/`deviceView`.
+3. Arrays onto `Pool`/`PODVector`; `Pool&` on the constructors; `m_control`/`m_base`/`rebasedView`.
 4. `[gpu]` case in `TestBVH.cpp`; add `TestBVH` to `EBGEOMETRY_GPU_TESTS`.
 5. `TriMeshSDF` on device, then `MeshSDF`.
 
@@ -266,5 +455,19 @@ Both PRs: full debug suite, plus `cmake --preset cuda -DCMAKE_CUDA_ARCHITECTURES
 `ctest -L gpu-device` on the local RTX 3080 Ti. CI compiles both backends but has no GPU, so a
 green GPU lane means "it compiles" and nothing more.
 
-PR 1 specifically needs a new test that would have been impossible before: query an object, force
-the pool to grow, query again, and require the same answer.
+PR 1 specifically needs new tests that would have been impossible before:
+
+- Query an object, force the pool to grow, query again, require the same answer.
+- Move the owning `Pool` — including through a `std::vector<Pool>` reallocation, which destroys the
+  moved-from object rather than merely emptying it — and require every descriptor to keep resolving.
+  This is the control block's whole reason for existing, and the `Pool*` design fails it.
+- Cover the *reference* path, not just the value path. The grow test above passes green while the
+  dangling-reference hazard is wide open, so add a case that snapshots by value across a grow and
+  writes back, i.e. the pattern the docs will prescribe.
+- A `deepCopy` into the *same* pool, which currently reserves three times against a cached
+  `a_srcBase` (`DCEL_MeshImplem.hpp:66-95`) and is a latent use-after-free that this PR removes by
+  construction.
+- A `MeshT`-level host-to-host `rebasedView`: build a mesh, `mirror()` its pool into a second host
+  pool, rebase, and require identical query results against both — `TestPoolRebase.cpp`'s proof
+  applied to real geometry rather than a synthetic `Scene`. This runs in CI, which has no GPU, and
+  is the reason `isDeviceAccessible()` is a discriminator rather than an assertion.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,270 @@
+# Plan: pool ergonomics, then the BVH port
+
+Two PRs. PR 1 removes the freeze/bind burden from users and is a prerequisite for PR 2, which
+ports the BVH. The BVH design is settled below so PR 1 does not paint us into a corner.
+
+> **This is a working document with a finite life.** It exists so the design decisions behind these
+> two PRs are reviewable before any code is written. When both have landed, fold whatever is still
+> true into `PORTING.md` and delete this file — a plan that outlives its work becomes a second,
+> stale source of truth.
+
+## Background: the problem PR 1 solves
+
+`Pool::reserve` can grow, which moves the base, which invalidates any cached base. Today that is
+handled by `freeze()`: seal the pool, then `bind()` each object. The cost is that **an object
+cannot be queried until the whole pool is sealed**, so any workflow that keeps building — read ten
+STLs, deep-copy one, translate a few, read another — collides with a lifecycle decision that was
+only ever about pointer hygiene. The workarounds are already visible in the tree:
+`Examples/MeshSDF` uses three pools because `FlatMeshSDF`/`MeshSDF` constructors freeze, and
+`Parser::readIntoMesh(files, pool)` is "deliberately not a loop over the single-file overload" for
+the same reason.
+
+Rejected alternatives, and why:
+
+- **Handle/descriptor split** (host handle owns `Pool&`, POD descriptor crosses): works, but two
+  types and a visible API break.
+- **Reserve address space up front so the base never moves**: users legitimately want several
+  pools (a work pool and a final pool), and pools get created ad hoc deep inside third-party code.
+  A guarantee that holds only when someone sized the pool correctly is not a guarantee.
+- **Leave it, document a user-side `EBGEOMETRY_EXPECT(pool.base() == sdf.base())`**: only fires
+  where someone remembered to write it. The library can do this check itself.
+
+## PR 1 — pool-resident objects resolve through their pool
+
+### The rule
+
+A pool-resident type carries **both** pointers:
+
+```cpp
+Pool* m_pool = nullptr;   // host-only. null in a device view.
+void* m_base = nullptr;   // resolved base. authoritative on device.
+
+EBGEOMETRY_HOST_DEVICE const void* base() const noexcept
+{
+#if defined(EBGEOMETRY_DEVICE_COMPILE)
+  EBGEOMETRY_EXPECT(m_pool == nullptr);   // a host descriptor reached a kernel without deviceView
+  return m_base;
+#else
+  EBGEOMETRY_EXPECT(m_pool == nullptr || m_pool->base() != nullptr);   // moved-from pool
+  return m_pool != nullptr ? m_pool->base() : m_base;
+#endif
+}
+```
+
+The two are not redundant: `m_base` points *into the data block*, which `mirror()` copies, so it
+has a device counterpart and can be rebased. `m_pool` points at *host bookkeeping* that is never
+mirrored and has no device counterpart. Host resolution goes through the pool and is therefore
+immune to growth; device resolution uses the rebased base.
+
+The type stays trivially copyable (two raw pointers plus `PODVector`s), so every existing
+`static_assert` and `Meta` requirement holds unchanged.
+
+### What this deletes
+
+- `MeshT::bind()` — there is nothing to bind. **There is no "unbound" state any more**: a host mesh
+  has `m_pool` from its first `reserveX(pool, …)`, a device view has `m_base` from `deviceView()`,
+  and the only state with neither is a default-constructed mesh nobody reserved into (caught by an
+  `EBGEOMETRY_EXPECT` in `base()`).
+- **Every explicit-base overload.** `getVertex(base, i)`, `signedDistance(base, p)`,
+  `unsignedDistance2(base, p)`, `getAllVertexCoordinates(base)`, `reconcile(base, …)`,
+  `reconcileFaces(base)`, `reconcileVertices(base, …)` exist solely to resolve mid-build before
+  `bind()` was legal. With `m_pool` captured, the no-argument forms are always correct, so
+  `MeshT`'s accessor surface roughly halves. The `FaceT`/`EdgeT`/`VertexT` methods that take a
+  `const Mesh&` are untouched — the mesh they receive always resolves, which is precisely what
+  `boundView` existed to fake.
+- `boundView()` in its **host** role. Every host call site passes `a_pool.base()`
+  (`MeshDistanceFunctionsImplem.hpp:445`, `ParserImplem.hpp:1860`), i.e. the pool's own current
+  base, which is exactly what `m_pool->base()` already returns. Those calls become no-ops.
+- The freeze-before-query rule, and with it the three-pool workaround in `Examples/MeshSDF` and
+  the two-pass dance in `Parser::readIntoMesh`.
+- `deepCopy(srcBase, dstPool)` → `deepCopy(dstPool)`; the source base is known.
+- `freeze()` calls in the `FlatMeshSDF`/`MeshSDF` constructors.
+
+`freeze()` survives, required **only** before `mirror()` — a rule that justifies itself ("you
+cannot copy a block that might still move") rather than being a precondition on asking a question.
+
+### The one sanctioned crossing
+
+```cpp
+EBGEOMETRY_HOST
+Mesh
+MeshT<T, Meta>::deviceView(const Pool& a_devicePool) const noexcept
+{
+  EBGEOMETRY_EXPECT(a_devicePool.resource().isDeviceAccessible());    // reachable from a kernel
+  EBGEOMETRY_EXPECT(a_devicePool.isFrozen());                         // a real, sealed mirror
+  EBGEOMETRY_EXPECT(a_devicePool.mirrorOf() == m_pool->id());         // a mirror of *our* pool
+  EBGEOMETRY_EXPECT(m_vertices.endByte() <= a_devicePool.usedBytes());// our arrays fit inside it
+  EBGEOMETRY_EXPECT(m_edges.endByte()    <= a_devicePool.usedBytes());
+  EBGEOMETRY_EXPECT(m_faces.endByte()    <= a_devicePool.usedBytes());
+
+  Mesh view   = *this;
+  view.m_pool = nullptr;
+  view.m_base = a_devicePool.base();
+  return view;
+}
+```
+
+Taking the `Pool&` rather than a `void*` is what makes the checks possible. `isDeviceAccessible()`
+already exists on all five resources and is the correct predicate — `Managed`/`Mapped` are both
+host- and device-accessible, `Pinned` is host-accessible but **not** device-reachable. The bounds
+and lineage checks catch the realistic mistakes (wrong pool, mirrored before the last `reserve`),
+which a bare base pointer cannot detect at all.
+
+`deviceView` is `EBGEOMETRY_HOST` — `Pool` is host-only, and building a kernel argument is a host
+activity. The old `HOST_DEVICE` on `boundView` was justified by a device-side rebase that nothing
+uses.
+
+### Supporting changes
+
+- **`Pool`**: add `uint64_t m_id` (monotonic, assigned at construction) and `uint64_t m_mirrorOf`
+  (set by `mirror()` to the source's id, 0 otherwise), with `id()` / `mirrorOf()` accessors.
+- **`PODVector`**: add `endByte()` = `m_offset + m_capacity * sizeof(T)` for the bounds checks.
+- **`MeshT`**: `m_pool` is captured on the first `reserveVertices/Edges/Faces(pool, …)`, with an
+  `EBGEOMETRY_EXPECT` that later reserves pass the same pool.
+- **Parsers**: `readInto*` no longer freeze; the multi-file overloads become plain loops.
+- **SDF wrappers**: `FlatMeshSDF`/`MeshSDF` stop freezing and binding, matching what
+  `TriMeshSDF`'s mesh constructor already does.
+- **`Examples/MeshSDF`**: collapse three pools into one.
+
+### Pattern reuse
+
+`PackedBVH` needs the same two fields, accessor, and `deviceView`. Duplicate them rather than
+introducing a CRTP mixin — it is ~15 lines, and a base class complicates the trivial-copyability
+`static_assert`s for no real saving. Document the convention once in `PORTING.md`.
+
+### Risks
+
+- **`Pool` is movable** (`mirror()` returns by value), so moving one leaves descriptors pointing at
+  a moved-from object. A moved-from pool has `m_base == nullptr`, caught by the `EXPECT` in
+  `base()`.
+- **Weakened invariant.** #140 made "mirror a host descriptor, dereference on device" structurally
+  impossible; it becomes possible-but-asserted. Every realistic error path is now caught on the
+  *host* at the point of the mistake, which is a more useful place than a garbage kernel result,
+  but it is a debug-time guarantee rather than a type-level one.
+
+### Docs
+
+`MemoryModel.rst` needs its central framing rewritten: build/freeze/query becomes build-and-query,
+with freeze as a mirror precondition. `ImplemDCEL.rst`'s memory-model section loses the
+explicit-base/bound accessor split and the `boundView` note added in #140.
+
+## PR 2 — the BVH port
+
+### Storage policies
+
+Keep the mechanism, but reduce it to two POD policies. `SharedPtrStorage` is **purged**.
+
+| Policy | Indirection | Dedup | Needs a canonical owner array | Crosses to device |
+|---|---|---|---|---|
+| `ValueStorage` | none | no | — | yes |
+| `IndexStorage` *(new)* | index | yes | yes | yes |
+
+`IndexStorage<P>` is `StorageType = uint32_t`, resolved as `static_cast<const P*>(base)[idx]`. It
+reproduces what `SharedPtrStorage` was actually wanted for — one primitive set shared by 1000
+translated copies, edited in one place — at 4 bytes instead of 16 plus a control block. What it
+cannot reproduce is **automatic lifetime**: the owning pool must outlive every copy, enforced by
+convention rather than refcount.
+
+`get()` gains a base parameter: `get(const StorageType&, const void* a_base)`. `Value` ignores it.
+Three call sites (`MeshDistanceFunctionsImplem.hpp:522,559`, `BVHImplem.hpp:1635`).
+
+Purging `SharedPtrStorage` is what keeps this clean: both remaining policies are trivially
+copyable, so `m_primitives` is a `PODVector` in every instantiation and `PackedBVH` needs no
+`std::vector` fallback backend. `TreeBVH` keeps its own `shared_ptr` storage — it is the host-only
+builder and is not policy-parameterised — so packing simply dereferences those into values (which
+`ValueStorage::appendTreeLeaf` already does: `a_dst.push_back(*p)`).
+
+What the purge breaks, all of which must be updated in the same PR:
+
+- `MeshSDF::getClosestFaces` returns `std::vector<std::pair<std::shared_ptr<const FaceT>, T>>`
+  (`MeshDistanceFunctionsImplem.hpp:309`). It should return `std::vector<std::pair<uint32_t, T>>` —
+  face indices, not copies. More useful than the pointers were, and it avoids copying ~80 B faces.
+- `MeshDistanceFunctions.hpp:144` ("its PackedBVH always uses BVH::SharedPtrStorage<Face>") and
+  `Parser.hpp:260` — doc rewrites.
+- `SharedPtrStorage::appendAliased`'s aliasing-constructor trick and the comment at
+  `BVHImplem.hpp:506` disappear with it.
+- `PrimitiveList<P>` (`std::vector<std::shared_ptr<const P>>`) survives as `TreeBVH`'s own storage;
+  it simply no longer flows into `PackedBVH`.
+
+**Open wrinkle — filling `IndexStorage` from a `TreeBVH`.** A tree holds `shared_ptr<const P>` with
+no notion of the owner's array index, so `appendTreeLeaf` cannot produce indices from it. Options:
+have `MeshSDF` build the tree over face indices directly (`TreeBVH<T, uint32_t, AABB, K>` with
+caller-supplied BVs — but that heap-allocates a `shared_ptr<const uint32_t>` per primitive), or
+give the packing path an explicit primitive→index mapping. `ValueStorage` has no such problem, so
+this only gates `IndexStorage`'s build path and can be settled inside PR 2.
+
+**Defaults**: `MeshSDF` → `ValueStorage` (matches today's semantics, minus ~one heap allocation
+per face, and gives a contiguous leaf scan because packing reorders primitives into leaf order).
+`IndexStorage` is the opt-in for large meshes where the ~80 B/face duplication is the binding
+constraint, trading locality for memory. `TriMeshSDF` stays on `ValueStorage`.
+
+### Pool-backed storage
+
+All three arrays become `PODVector`: `m_linearNodes`, `m_childAabbSoA`, `m_primitives`. `Node` and
+`ChildAABBSoA` are already trivially copyable (`AABBT<T>` + `uint32_t`s + `std::array<uint32_t,K>`),
+so only the containers change.
+
+Every construction entry point gains a `Pool&`: `pack(Pool&)`, `packWith(Pool&, converter)`, the
+direct `primsAndBVs` constructors, and the protected constructor `PointCloudBVH` uses. `MeshSDF`
+already takes a `Pool&`, so its signature is unchanged and the mesh and its BVH land in one pool —
+one `mirror()`, one base, one `deviceView`.
+
+`TreeBVH` stays host-only and unchanged. It is the builder; static geometry builds on the host.
+
+### Traversal
+
+`pruneTraverse` is currently 513 lines containing **seven** copies of the same branch-and-bound
+loop — six `if constexpr` SIMD specialisations plus a scalar fallback that has no implementation of
+its own (it builds four `std::function`s and delegates to `traverse()`, which runs on a heap
+`std::vector` stack). The GPU can only ever take that fallback.
+
+Factor the loop **once**, parameterised on a child-distance evaluator (`ChildDistSIMD<T,K>` /
+`ChildDistScalar<T,K>`), so each ISA block shrinks to the handful of intrinsics it actually
+contributes and the device path is an eighth evaluator rather than an eighth transcription. Give
+the scalar path a real implementation: fixed stack, hand-rolled insertion sort over the ≤K children
+(`std::sort` and `std::clamp` both drag in host-only libstdc++ helpers under hardened mode).
+
+**Stack depth** becomes a parameter differing by entry point: 256 on host, 64 on device.
+`StackEntry` is 16 B at `double`, so today's `[256]` is 4 KB/thread of local memory;
+`log_K(N)·K` says 64 covers a million primitives at K=4.
+
+**Callables on device**: we compile with `--expt-relaxed-constexpr` but not `--extended-lambda`, so
+device callers must pass functors, not lambdas. Keep the templated API for that, and additionally
+ship the two common queries (signed distance, closest point) as ready-made device entry points so
+ordinary users never write a callback.
+
+`refit()` stays host-only for now — it is a reverse sweep over `std::vector<BV>` scratch, and
+nothing yet needs moving geometry to stay resident on the device.
+
+### Sequence within PR 2
+
+1. Traversal refactor + real scalar path. Host-only, no API change, fully covered by `TestBVH`.
+   Also a CPU speedup for any (T,K) with no compiled ISA path.
+2. `IndexStorage` + the `get(stored, base)` signature.
+3. Arrays onto `Pool`/`PODVector`; `Pool&` on the constructors; `m_pool`/`m_base`/`deviceView`.
+4. `[gpu]` case in `TestBVH.cpp`; add `TestBVH` to `EBGEOMETRY_GPU_TESTS`.
+5. `TriMeshSDF` on device, then `MeshSDF`.
+
+If (1) makes the PR unwieldy it can be pulled out as a small host-only PR of its own — it is
+independent of everything else here.
+
+### Open questions
+
+- `MeshSDF`'s default policy. `Value` matches today's semantics and gives a contiguous leaf scan;
+  `Index` duplicates nothing at all, since the faces already live in the same pool. On the merits
+  it is a locality-vs-memory judgement that depends on mesh size, but `Value` wins for PR 2 on a
+  practical ground: its build path already works, while `Index`'s needs the primitive→index mapping
+  described above. `Index` can follow immediately after without touching any of the pool or
+  traversal work.
+- Whether the `getClosestFaces` signature change (to `std::vector<std::pair<uint32_t, T>>`) should
+  carry an index into the mesh's face array or into the BVH's own primitive array. The former is
+  more useful to a caller; the latter is what the traversal naturally produces.
+
+## Verification
+
+Both PRs: full debug suite, plus `cmake --preset cuda -DCMAKE_CUDA_ARCHITECTURES=86` and
+`ctest -L gpu-device` on the local RTX 3080 Ti. CI compiles both backends but has no GPU, so a
+green GPU lane means "it compiles" and nothing more.
+
+PR 1 specifically needs a new test that would have been impossible before: query an object, force
+the pool to grow, query again, and require the same answer.

--- a/PORTING.md
+++ b/PORTING.md
@@ -20,17 +20,22 @@ which makes the identical bit pattern resolve correctly against a host base *and
 with no pointer-patching pass after the copy.
 
 The practical consequence is that a portable structure has **at most one** address-space-specific
-field, and it is set at the moment of copying rather than being a property of the object. For
-`DCEL::MeshT` that field is `m_base`, and `MeshT::boundView(base)` is the sanctioned way to produce
-a copy bound to a different address space:
+field, and it is set at the moment of crossing rather than being a property of the object. For
+`DCEL::MeshT` that field is `m_base`, and `MeshT::rebasedView(pool)` is the sanctioned way to
+produce a copy that resolves in a different address space:
 
 ```cpp
 EBGeometry::Pool devicePool = EBGeometry::Pool::mirror(hostPool, EBGeometry::deviceMemoryResource());
-const auto       deviceMesh = mesh->boundView(devicePool.base());   // rebase on the host …
+const auto       deviceMesh = mesh->rebasedView(devicePool);        // rebase on the host …
 myKernel<<<blocks, threads>>>(deviceMesh, …);                       // … then copy by value
 ```
 
-Rebase, then copy — never copy a host-bound value and try to repair it afterwards.
+Rebase, then copy — never copy a host-resident value and try to repair it afterwards.
+
+A host-resident object does *not* hold a base at all: it holds a pointer to its `Pool`'s control
+block and re-reads the base through it on every access. That is what makes it immune to a
+`reserve()` that grows and moves the block, and what makes `m_control == nullptr` mean "device
+view" and nothing else — the assertion both `base()` branches rely on.
 
 ## Why the first attempt was rewound
 
@@ -92,18 +97,26 @@ Three layers, documented in full on the
 * **`MemoryResource`** — a runtime-virtual placement policy deciding *where* bytes live. Host,
   Device, Managed, Pinned and Mapped resources exist; the latter four require a CUDA/HIP build.
   Allocation is always a host-side operation, and every block is aligned to `PoolBaseAlign` (256 B).
-* **`Pool`** — one contiguous block from a resource, with two phases. **Build**: `reserve()`
-  bump-allocates and may grow (moving the base). **Query**: `freeze()` makes the base stable and
-  enables `mirror()`, which copies a whole frozen block into another resource — the host-to-device
-  upload, one `memcpy`, no patching. Move-only, host-only; never pass a `Pool` to a kernel.
+* **`Pool`** — one contiguous block from a resource. `reserve()` bump-allocates and may grow,
+  which reallocates and frees the old block; the current base is published through a heap-resident
+  `PoolControl`, so pool-resident objects see the move and already-resolved addresses do not.
+  `freeze()` seals the pool and exists solely as the precondition for `mirror()`, which copies a
+  whole frozen block into another resource — the host-to-device upload, one `memcpy`, no patching.
+  Move-only (moving a `Pool` does not disturb its control block), host-only; never pass a `Pool` to
+  a kernel.
 * **`PODVector` / `PODSpan`** — array descriptors holding a byte offset plus size and capacity.
   Trivially copyable, resolved against a base supplied per call (`at(base, i)`) or bound once
   (`bind(base)`).
 
-Classes built on this expose two accessor families — an explicit-base overload valid mid-build, and
-a no-argument bound overload for a finished structure — plus `boundView()` where a bound
-`const Mesh&` is needed before the real object can be bound. `DCEL::MeshT` is the reference
-implementation of the pattern.
+Classes built on this expose **one** accessor per operation. They attach to a `Pool` on their first
+`reserve` and resolve through its control block from then on, so there is no bound/unbound
+distinction, no freeze-before-query rule, and no base parameter threaded through the API;
+`rebasedView(pool)` is the single crossing point. `DCEL::MeshT` is the reference implementation of
+the pattern.
+
+Two rules survive from this and must be documented on anything that adopts it: a resolved address
+(a reference, a `PODSpan`) must not outlive the next `reserve()` on its pool, and the pool must
+outlive every object reserved from it.
 
 ## What is ported
 
@@ -179,7 +192,8 @@ kernel and compares against the host:
 2. Move array storage onto `PODVector` reserved from a caller-supplied `Pool`. Build-phase mutators
    take the `Pool&` explicitly, since `reserve()` can move the base.
 3. Annotate: `EBGEOMETRY_HOST_DEVICE` for anything that resolves purely through values, indices and
-   other device-callable calls; `EBGEOMETRY_HOST` for anything touching a `Pool`, `std::vector`,
+   other device-callable calls; `EBGEOMETRY_HOST` for anything touching a `Pool` (including
+   `rebasedView`, which reads one), `std::vector`,
    `std::string`, `std::cerr` or `std::map`. Watch for standard-library helpers that look innocent —
    `std::clamp` pulls in a host-only assert handler under libstdc++ hardened mode and must be
    hand-rolled.

--- a/PORTING.md
+++ b/PORTING.md
@@ -131,6 +131,11 @@ kernel and compares against the host:
 
 ## Roadmap
 
+> While it exists, `PLAN.md` in this directory carries the agreed design for the next two PRs in
+> detail: a pool-ergonomics change that removes `freeze()`/`bind()` from user workflows, and the BVH
+> port (step 2 below), which depends on it. It settles several questions this page only lists.
+> `PLAN.md` is deleted once that work lands, at which point whatever is still true moves here.
+
 1. **DCEL reconcile chain.** `FaceT::computeCentroid`/`computeNormal`/`computeArea` rewritten as
    streaming half-edge walks (they currently open with `gatherVertexIndices()`, which materializes a
    `std::vector`), then device-resident CSR vertex→face adjacency, then
@@ -140,9 +145,10 @@ kernel and compares against the host:
 2. **BVH.** Give `pruneTraverse` a real scalar implementation (fixed stack, hand-rolled sort over
    the ≤K children); move `PackedBVH`'s three arrays onto `Pool`/`PODVector`; add a trivially-copyable
    view plus a `[gpu]` test; then `TriMeshSDF` and `MeshSDF`. `TreeBVH` stays host-only — it is the
-   builder, and static geometry builds on the host. Open decisions: whether to drop
-   `SharedPtrStorage` entirely, and the device stack depth (`[256]` is 4 KB/thread for `double`,
-   occupancy-hostile; 64 covers a million primitives at K=4).
+   builder, and static geometry builds on the host. Two questions this page previously left open are
+   settled in `PLAN.md`: `SharedPtrStorage` is dropped in favour of two POD policies (`Value` and a
+   new `Index`), and the traversal stack depth differs by entry point (256 host, 64 device — `[256]`
+   is 4 KB/thread at `double`, and `log_K(N)·K` says 64 covers a million primitives at K=4).
 3. **Point clouds.** Device-side `PointCloudBVH` build (Morton codes + radix sort) and a
    `PointCloudHashGrid` counterpart. Independent of 1–2.
 4. **Analytic SDF / transform / combiner traits.** Each primitive's formula moves into a trait as a

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -24,6 +24,7 @@ path = [
   "CLAUDE.md",
   "Scripts/CheckDocs.py",
   "Copyright.txt",
+  "PLAN.md",
   "PORTING.md",
   "README.md",
   "TODO.md",

--- a/Source/EBGeometry_DCEL_Mesh.hpp
+++ b/Source/EBGeometry_DCEL_Mesh.hpp
@@ -48,39 +48,48 @@ namespace DCEL {
  * which is why this class is almost always embedded into a bounding volume
  * hierarchy.
  * @note MeshT owns no resources: every member (three PODVectors, the
- * search-algorithm enum, and a resolved base pointer) is a plain value, so
- * MeshT is trivially copyable -- a bytewise copy is meaningful in any address
- * space, since it never needs to dereference anything beyond its own bytes.
- * This is what makes a mesh built and reconciled on the host mirror-safe: its
- * Pool can be mirrored to a device, and the mesh re-bound (see bind())
- * against the mirrored Pool's device base, with zero pointer patching inside
- * the mesh itself.
- * @details Two families of accessors resolve a PODVector offset into an
- * actual vertex/edge/face:
- * - An explicit-base overload (e.g. getVertex(void* a_base, uint32_t)),
- *   which resolves fresh against whatever base is passed in. Valid even
- *   against a Pool that is still being built into (mid-construction), as
- *   long as the base passed in is the Pool's *current* base at the time of
- *   the call -- this is what Soup/Parser use while building and reconciling
- *   a mesh, since the mesh cannot yet be bind()'d (its Pool may still be
- *   open for more meshes, and may not even be frozen).
- * - A no-argument overload (e.g. getVertex(uint32_t)), which resolves
- *   against a base cached once via bind(). This is the ergonomic path for
- *   querying a finished mesh -- see bind() for the contract.
- * Build-phase mutators (reserveVertices/Edges/Faces, addVertex/Edge/Face)
- * always take an explicit Pool&, since reserving can grow (and move) the
- * Pool's block; there is no cached-base convenience form for these, since
- * building only happens on the host, with a live Pool in hand.
- * @note Everything that resolves purely through m_base, the PODVectors, and VertexT/EdgeT/FaceT
+ * search-algorithm enum, a control-block pointer and a base pointer) is a
+ * plain value, so MeshT is trivially copyable -- a bytewise copy is
+ * meaningful in any address space, since it never needs to dereference
+ * anything beyond its own bytes. This is what makes a mesh built and
+ * reconciled on the host mirror-safe: its Pool can be mirrored to a device
+ * and the mesh rebased onto the mirror (see rebasedView()), with zero
+ * pointer patching inside the mesh itself.
+ * @details A mesh resolves its PODVector offsets through whichever of two
+ * pointers is set, and exactly one of them always is:
+ * - m_control, the stable control block of the Pool the mesh was reserved
+ *   from. Set on the first reserveVertices/Edges/Faces() call. Because the
+ *   base is re-read from the control block on every access, a mesh is
+ *   queryable at any point during the build, including across a
+ *   Pool::reserve that grows and moves the block -- there is no freeze,
+ *   and nothing to re-bind.
+ * - m_base, a plain base address, set only by rebasedView() and only for a
+ *   device-accessible target, since a kernel cannot follow a control block.
+ * A device view therefore has m_control == nullptr and nothing else does,
+ * which is what lets base() assert exactly, in both directions: a non-null
+ * m_control on device means a host descriptor was copied into a kernel
+ * without rebasedView(), and a null m_control on the host means either a
+ * device view being dereferenced on the host or a mesh nobody ever
+ * reserved into.
+ * @warning A reference returned by getVertex()/getEdge()/getFace() is a raw
+ * address resolved at the moment of the call, and Pool::reserve may
+ * deallocate the block it points into (see the warning on Pool::reserve).
+ * Resolve, use, discard: to carry an element across a reserve, copy it by
+ * value and write it back through a fresh accessor call.
+ * @details Build-phase mutators (reserveVertices/Edges/Faces,
+ * addVertex/Edge/Face) take an explicit Pool&, since reserving can grow
+ * (and move) the Pool's block; building only happens on the host, with a
+ * live Pool in hand.
+ * @note Everything that resolves purely through base(), the PODVectors, and VertexT/EdgeT/FaceT
  * methods that are themselves EBGEOMETRY_HOST_DEVICE (getVertex/getEdge/getFace, numVertices/
- * numEdges/numFaces, boundView, setSearchAlgorithm, setInsideOutsideAlgorithm, reconcileEdges,
+ * numEdges/numFaces, setSearchAlgorithm, setInsideOutsideAlgorithm, reconcileEdges,
  * flipFaceNormals/flipEdgeNormals/flipVertexNormals, flip, DirectSignedDistance/
  * DirectSignedDistance2, every signedDistance overload, unsignedDistance2) is annotated
  * EBGEOMETRY_HOST_DEVICE -- signedDistance's algorithm-selecting switch deliberately relies on
  * EBGEOMETRY_EXPECT() alone (not std::cerr) to flag a corrupted SearchAlgorithm, specifically so it
  * stays device-callable; see the implementation. The rest stays EBGEOMETRY_HOST because it touches a
- * Pool directly (bind, deepCopy, reserveVertices/Edges/Faces, addVertex/Edge/Face), returns a host
- * container (getAllVertexCoordinates), logs diagnostics to std::cerr (sanityCheck and its
+ * Pool directly (rebasedView, deepCopy, reserveVertices/Edges/Faces, addVertex/Edge/Face), returns a
+ * host container (getAllVertexCoordinates), logs diagnostics to std::cerr (sanityCheck and its
  * incrementWarning/printWarnings helpers), or delegates to a VertexT/EdgeT/FaceT method that itself
  * allocates a std::vector or can log a diagnostic the same way (reconcileFaces calls FaceT::reconcile;
  * reconcileVertices builds a transient per-vertex face list and can warn on a corrupted
@@ -132,12 +141,13 @@ public:
   using Mesh = MeshT<T, Meta>;
 
   /**
-   * @brief Default constructor. Leaves the mesh empty (no vertices, edges, faces) and unbound (see
-   * bind()).
+   * @brief Default constructor. Leaves the mesh empty (no vertices, edges, faces) and attached to
+   * no Pool, so it cannot yet resolve anything.
    * @details No Pool is needed at construction -- every build-phase method (reserveX/addX) takes
    * its Pool explicitly. Use reserveVertices()/reserveEdges()/reserveFaces() followed by
-   * addVertex()/addEdge()/addFace() to populate the mesh (a file parser normally does this), then
-   * bind() it to a frozen Pool for ergonomic, no-argument querying.
+   * addVertex()/addEdge()/addFace() to populate the mesh (a file parser normally does this); the
+   * first reserve attaches the mesh to that Pool, after which it is queryable immediately -- there
+   * is no separate binding or freezing step.
    */
   MeshT() noexcept = default;
 
@@ -185,43 +195,18 @@ public:
   operator=(Mesh&& a_otherMesh) noexcept = default;
 
   /**
-   * @brief Bind this mesh to a frozen Pool's base, enabling the no-argument query overloads
-   * (getVertex(i), signedDistance(p), ...).
-   * @details The bound base must remain valid (and unchanged) for as long as it is relied on: this
-   * requires a_pool to be frozen (EBGEOMETRY_EXPECT-checked), since Pool::reserve() can grow (move)
-   * the block, which would silently invalidate a base cached before the pool stopped changing. Safe
-   * to call again later (e.g. to re-bind against a mirrored Pool's device base before transporting
-   * this mesh to a device) -- rebinding is just overwriting one plain pointer value.
-   * @param[in] a_pool Frozen Pool this mesh's vertex/edge/face storage was reserved from (directly,
-   * or via the same Pool a source mesh was deepCopy()'d from).
-   */
-  EBGEOMETRY_HOST
-  inline void
-  bind(const Pool& a_pool) noexcept;
-
-  /**
    * @brief Create an independent, fully-decoupled copy of this mesh's data in another Pool.
    * @details Reserves fresh storage in a_dstPool and copies every vertex/edge/face by value; since
    * every cross-reference is an index rather than a pointer, the copy is already fully independent
    * and correctly linked -- no relinking pass is needed. Every field is preserved exactly (position,
    * normal vector, centroid, area, meta-data, search algorithm) rather than recomputed, so a mesh
    * that has had flipNormal()/flip() called on it and not yet been re-reconciled is copied
-   * faithfully rather than silently "un-flipped". The returned mesh is unbound (see bind()); unlike
-   * the copy/move constructors, this creates genuinely separate storage rather than sharing the
-   * source's.
-   * @param[in]     a_srcBase Base to resolve this mesh's own data against while reading it (this
-   * mesh's bound base if already bind()'d, or the building Pool's current base otherwise).
-   * @param[in,out] a_dstPool Pool to reserve the copy's storage from. May be the same Pool this
-   * mesh's data lives in, or a different one.
-   * @return A new mesh, independent of this one.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST
-  inline std::shared_ptr<Mesh>
-  deepCopy(const void* a_srcBase, Pool& a_dstPool) const;
-
-  /**
-   * @brief Create an independent, fully-decoupled copy of this mesh's data in another Pool, using
-   * this mesh's bound base (see bind()) to read from.
+   * faithfully rather than silently "un-flipped". Unlike the copy/move constructors, this creates
+   * genuinely separate storage rather than sharing the source's, and the returned mesh is attached
+   * to a_dstPool.
+   * @note a_dstPool may be the same Pool this mesh's data already lives in. That is safe even
+   * though the reserves below can grow (and move) the block, because both meshes re-resolve through
+   * the Pool's control block on every access rather than caching an address.
    * @param[in,out] a_dstPool Pool to reserve the copy's storage from.
    * @return A new mesh, independent of this one.
    */
@@ -230,20 +215,11 @@ public:
   deepCopy(Pool& a_dstPool) const;
 
   /**
-   * @brief Perform a sanity check, resolving against an explicitly-supplied base.
+   * @brief Perform a sanity check.
    * @details This will provide error messages if vertices are badly linked,
    * faces have no half-edge, and so on. These messages are logged by calling
    * incrementWarning() which identifies types of errors that can occur, and how
    * many of those errors have occurred.
-   * @param[in] a_base Base to resolve this mesh's data against.
-   * @param[in] a_id   Identifier when printing error messages (can be empty string).
-   */
-  EBGEOMETRY_HOST
-  inline void
-  sanityCheck(const void* a_base, const std::string a_id) const;
-
-  /**
-   * @brief Perform a sanity check, resolving against this mesh's bound base (see bind()).
    * @param[in] a_id Identifier when printing error messages (can be empty string).
    */
   EBGEOMETRY_HOST
@@ -260,20 +236,10 @@ public:
 
   /**
    * @brief Set the inside/outside algorithm to use when computing the signed distance to polygon
-   * faces, resolving against an explicitly-supplied base.
+   * faces.
    * @details Computing the signed distance to faces requires testing if a point
    * projected to a polygo face plane falls inside or outside the polygon face.
    * There are multiple algorithms to use here.
-   * @param[in] a_base      Base to resolve this mesh's data against.
-   * @param[in] a_algorithm Algorithm to use
-   */
-  EBGEOMETRY_HOST_DEVICE
-  inline void
-  setInsideOutsideAlgorithm(void* a_base, InsideOutsideAlgorithm a_algorithm) noexcept;
-
-  /**
-   * @brief Set the inside/outside algorithm to use when computing the signed distance to polygon
-   * faces, resolving against this mesh's bound base (see bind()).
    * @param[in] a_algorithm Algorithm to use
    */
   EBGEOMETRY_HOST_DEVICE
@@ -282,44 +248,19 @@ public:
 
   /**
    * @brief Reconcile function which computes the internal parameters in vertices, edges, and faces
-   * for use with signed distance functionality, resolving against an explicitly-supplied base.
-   * @param[in] a_base   Base to resolve this mesh's data against.
+   * for use with signed distance functionality.
    * @param[in] a_weight Vertex angle weighting function. Either
    * VertexNormalWeight::None for unweighted vertex normals or
    * VertexNormalWeight::Angle for the pseudonormal
    * @details This will reconcile faces, edges, and vertices, e.g. computing the
-   * area and normal vector for faces. This is the overload Soup/Parser use internally while
-   * building a mesh, since the mesh is not yet bind()'able at that point (see the class-level note).
-   */
-  EBGEOMETRY_HOST
-  inline void
-  reconcile(void* a_base, const DCEL::VertexNormalWeight a_weight = DCEL::VertexNormalWeight::Angle) noexcept;
-
-  /**
-   * @brief Reconcile function which computes the internal parameters in vertices, edges, and faces
-   * for use with signed distance functionality, resolving against this mesh's bound base (see
-   * bind()).
-   * @param[in] a_weight Vertex angle weighting function. Either
-   * VertexNormalWeight::None for unweighted vertex normals or
-   * VertexNormalWeight::Angle for the pseudonormal
+   * area and normal vector for faces.
    */
   EBGEOMETRY_HOST
   inline void
   reconcile(const DCEL::VertexNormalWeight a_weight = DCEL::VertexNormalWeight::Angle) noexcept;
 
   /**
-   * @brief Flip the mesh, making all the normals change direction, resolving against an
-   * explicitly-supplied base.
-   * @param[in] a_base Base to resolve this mesh's data against.
-   * @note Should be called AFTER all normals have been computed.
-   */
-  EBGEOMETRY_HOST_DEVICE
-  inline void
-  flip(void* a_base) noexcept;
-
-  /**
-   * @brief Flip the mesh, making all the normals change direction, resolving against this mesh's
-   * bound base (see bind()).
+   * @brief Flip the mesh, making all the normals change direction.
    * @note Should be called AFTER all normals have been computed.
    */
   EBGEOMETRY_HOST_DEVICE
@@ -390,27 +331,9 @@ public:
   addFace(Pool& a_pool, const Face& a_face);
 
   /**
-   * @brief Get modifiable vertex by index, resolving against an explicitly-supplied base.
-   * @param[in] a_base  Base to resolve this mesh's data against.
-   * @param[in] a_index Vertex index (must be < numVertices()).
-   * @return Reference to the vertex.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline Vertex&
-  getVertex(void* a_base, uint32_t a_index) noexcept;
-
-  /**
-   * @brief Get immutable vertex by index, resolving against an explicitly-supplied base.
-   * @param[in] a_base  Base to resolve this mesh's data against.
-   * @param[in] a_index Vertex index (must be < numVertices()).
-   * @return Const reference to the vertex.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline const Vertex&
-  getVertex(const void* a_base, uint32_t a_index) const noexcept;
-
-  /**
-   * @brief Get modifiable vertex by index, resolving against this mesh's bound base (see bind()).
+   * @brief Get modifiable vertex by index.
+   * @warning The returned reference is invalidated by any Pool::reserve on this mesh's Pool; see
+   * the class-level warning.
    * @param[in] a_index Vertex index (must be < numVertices()).
    * @return Reference to the vertex.
    */
@@ -419,7 +342,9 @@ public:
   getVertex(uint32_t a_index) noexcept;
 
   /**
-   * @brief Get immutable vertex by index, resolving against this mesh's bound base (see bind()).
+   * @brief Get immutable vertex by index.
+   * @warning The returned reference is invalidated by any Pool::reserve on this mesh's Pool; see
+   * the class-level warning.
    * @param[in] a_index Vertex index (must be < numVertices()).
    * @return Const reference to the vertex.
    */
@@ -428,28 +353,9 @@ public:
   getVertex(uint32_t a_index) const noexcept;
 
   /**
-   * @brief Get modifiable half-edge by index, resolving against an explicitly-supplied base.
-   * @param[in] a_base  Base to resolve this mesh's data against.
-   * @param[in] a_index Half-edge index (must be < numEdges()).
-   * @return Reference to the half-edge.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline Edge&
-  getEdge(void* a_base, uint32_t a_index) noexcept;
-
-  /**
-   * @brief Get immutable half-edge by index, resolving against an explicitly-supplied base.
-   * @param[in] a_base  Base to resolve this mesh's data against.
-   * @param[in] a_index Half-edge index (must be < numEdges()).
-   * @return Const reference to the half-edge.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline const Edge&
-  getEdge(const void* a_base, uint32_t a_index) const noexcept;
-
-  /**
-   * @brief Get modifiable half-edge by index, resolving against this mesh's bound base (see
-   * bind()).
+   * @brief Get modifiable half-edge by index.
+   * @warning The returned reference is invalidated by any Pool::reserve on this mesh's Pool; see
+   * the class-level warning.
    * @param[in] a_index Half-edge index (must be < numEdges()).
    * @return Reference to the half-edge.
    */
@@ -458,7 +364,9 @@ public:
   getEdge(uint32_t a_index) noexcept;
 
   /**
-   * @brief Get immutable half-edge by index, resolving against this mesh's bound base (see bind()).
+   * @brief Get immutable half-edge by index.
+   * @warning The returned reference is invalidated by any Pool::reserve on this mesh's Pool; see
+   * the class-level warning.
    * @param[in] a_index Half-edge index (must be < numEdges()).
    * @return Const reference to the half-edge.
    */
@@ -467,27 +375,9 @@ public:
   getEdge(uint32_t a_index) const noexcept;
 
   /**
-   * @brief Get modifiable face by index, resolving against an explicitly-supplied base.
-   * @param[in] a_base  Base to resolve this mesh's data against.
-   * @param[in] a_index Face index (must be < numFaces()).
-   * @return Reference to the face.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline Face&
-  getFace(void* a_base, uint32_t a_index) noexcept;
-
-  /**
-   * @brief Get immutable face by index, resolving against an explicitly-supplied base.
-   * @param[in] a_base  Base to resolve this mesh's data against.
-   * @param[in] a_index Face index (must be < numFaces()).
-   * @return Const reference to the face.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline const Face&
-  getFace(const void* a_base, uint32_t a_index) const noexcept;
-
-  /**
-   * @brief Get modifiable face by index, resolving against this mesh's bound base (see bind()).
+   * @brief Get modifiable face by index.
+   * @warning The returned reference is invalidated by any Pool::reserve on this mesh's Pool; see
+   * the class-level warning.
    * @param[in] a_index Face index (must be < numFaces()).
    * @return Reference to the face.
    */
@@ -496,13 +386,27 @@ public:
   getFace(uint32_t a_index) noexcept;
 
   /**
-   * @brief Get immutable face by index, resolving against this mesh's bound base (see bind()).
+   * @brief Get immutable face by index.
+   * @warning The returned reference is invalidated by any Pool::reserve on this mesh's Pool; see
+   * the class-level warning.
    * @param[in] a_index Face index (must be < numFaces()).
    * @return Const reference to the face.
    */
   [[nodiscard]] EBGEOMETRY_HOST_DEVICE
   inline const Face&
   getFace(uint32_t a_index) const noexcept;
+
+  /**
+   * @brief Whether this mesh's storage was reserved from a_pool.
+   * @details A mesh attaches to a Pool on its first reserveVertices/Edges/Faces() call and resolves
+   * everything through that Pool thereafter, so the Pool must outlive the mesh. This is the check a
+   * caller that holds both can make to confirm they belong together.
+   * @param[in] a_pool Pool to test against.
+   * @return True if this mesh resolves through a_pool.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST
+  inline bool
+  isAttachedTo(const Pool& a_pool) const noexcept;
 
   /**
    * @brief Number of vertices in this mesh.
@@ -529,18 +433,7 @@ public:
   numFaces() const noexcept;
 
   /**
-   * @brief Return all vertex coordinates in the mesh, resolving against an explicitly-supplied
-   * base.
-   * @param[in] a_base Base to resolve this mesh's data against.
-   * @return Vector of 3D coordinates of all vertices.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST
-  inline std::vector<Vec3T<T>>
-  getAllVertexCoordinates(const void* a_base) const noexcept;
-
-  /**
-   * @brief Return all vertex coordinates in the mesh, resolving against this mesh's bound base (see
-   * bind()).
+   * @brief Return all vertex coordinates in the mesh.
    * @return Vector of 3D coordinates of all vertices.
    */
   [[nodiscard]] EBGEOMETRY_HOST
@@ -548,10 +441,8 @@ public:
   getAllVertexCoordinates() const noexcept;
 
   /**
-   * @brief Compute the signed distance from a point to this mesh, resolving against an
-   * explicitly-supplied base.
-   * @param[in] a_base Base to resolve this mesh's data against.
-   * @param[in] a_x0   3D point in space.
+   * @brief Compute the signed distance from a point to this mesh.
+   * @param[in] a_x0 3D point in space.
    * @details This function will iterate through ALL faces in the mesh and return
    * the value with the smallest magnitude. This is horrendously slow, which is
    * why this function is almost never called. Rather, MeshT<T, Meta> can be embedded
@@ -562,41 +453,17 @@ public:
    */
   [[nodiscard]] EBGEOMETRY_HOST_DEVICE
   inline T
-  signedDistance(const void* a_base, const Vec3& a_x0) const noexcept;
-
-  /**
-   * @brief Compute the signed distance from a point to this mesh, resolving against this mesh's
-   * bound base (see bind()).
-   * @param[in] a_x0 3D point in space.
-   * @return Signed distance to the mesh; negative inside, positive outside. Returns +infinity if
-   * the mesh has no faces.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline T
   signedDistance(const Vec3& a_x0) const noexcept;
 
   /**
-   * @brief Compute the signed distance from a point to this mesh, resolving against an
-   * explicitly-supplied base.
-   * @param[in] a_base      Base to resolve this mesh's data against.
+   * @brief Compute the signed distance from a point to this mesh, using an explicit search
+   * algorithm.
    * @param[in] a_x0        3D point in space.
    * @param[in] a_algorithm Search algorithm
    * @details This function will iterate through ALL faces in the mesh and return
    * the value with the smallest magnitude. This is horrendously slow, which is
    * why this function is almost never called. Rather, MeshT<T, Meta> can be embedded
    * in a bounding volume hierarchy for faster access.
-   * @return Signed distance to the mesh; negative inside, positive outside. Returns +infinity if
-   * the mesh has no faces.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline T
-  signedDistance(const void* a_base, const Vec3& a_x0, SearchAlgorithm a_algorithm) const noexcept;
-
-  /**
-   * @brief Compute the signed distance from a point to this mesh, resolving against this mesh's
-   * bound base (see bind()).
-   * @param[in] a_x0        3D point in space.
-   * @param[in] a_algorithm Search algorithm
    * @return Signed distance to the mesh; negative inside, positive outside. Returns +infinity if
    * the mesh has no faces.
    */
@@ -605,10 +472,8 @@ public:
   signedDistance(const Vec3& a_x0, SearchAlgorithm a_algorithm) const noexcept;
 
   /**
-   * @brief Compute the unsigned square distance from a point to this mesh, resolving against an
-   * explicitly-supplied base.
-   * @param[in] a_base Base to resolve this mesh's data against.
-   * @param[in] a_x0   3D point in space.
+   * @brief Compute the unsigned square distance from a point to this mesh.
+   * @param[in] a_x0 3D point in space.
    * @details This function will iterate through ALL faces in the mesh and return
    * the value with the smallest magnitude. This is horrendously slow, which is
    * why this function is almost never called. Rather, MeshT<T, Meta> can be embedded
@@ -617,46 +482,55 @@ public:
    */
   [[nodiscard]] EBGEOMETRY_HOST_DEVICE
   inline T
-  unsignedDistance2(const void* a_base, const Vec3& a_x0) const noexcept;
-
-  /**
-   * @brief Compute the unsigned square distance from a point to this mesh, resolving against this
-   * mesh's bound base (see bind()).
-   * @param[in] a_x0 3D point in space.
-   * @return Squared unsigned distance to the nearest face, or +infinity if the mesh has no faces.
-   */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline T
   unsignedDistance2(const Vec3& a_x0) const noexcept;
 
   /**
-   * @brief Build a lightweight, stack-only, read-resolving view of this mesh bound to an
-   * explicitly-supplied base.
-   * @details VertexT/EdgeT/FaceT's `const Mesh&`-taking methods (reconcile(), gatherVertexIndices(),
-   * getNextEdge(), computeVertexNormalAverage(), ...) always resolve indices through the mesh's own
-   * no-argument (bound) accessors, so *this cannot be passed to them directly unless it is already
-   * bind()'d against the base being resolved with. boundView() bridges this: a disposable copy of
-   * this mesh's descriptor (all plain values, so trivially cheap) with m_base set to a_base, safe to
-   * pass wherever a bound `const Mesh&` is required before the real mesh can be bound (e.g.
-   * Soup/Parser building a mesh whose Pool isn't frozen yet, or TriMeshSDF's mesh-based constructor,
-   * which deliberately never binds/freezes -- see EBGeometry_MeshDistanceFunctions.hpp).
-   * @details a_base is frequently a caller's `const void*` (a promise not to mutate whatever it
-   * points to), so the returned view's own m_base is set via a const_cast internally; the return
-   * type is deliberately `const Mesh`, not `Mesh`, so that promise cannot be broken by chaining a
-   * mutating call directly onto the returned value (e.g. `mesh.boundView(constBase).flip()` fails to
-   * compile). Always bind the result to a `const Mesh`/`const Mesh&` at the call site too -- copying
-   * it into a non-const local (`Mesh view = ...`) produces an independent, fully mutable object and
-   * defeats this protection.
-   * @param[in] a_base Base to bind the returned view to.
-   * @return A mesh view sharing this mesh's data but bound to a_base.
+   * @brief Produce a copy of this mesh's descriptor that resolves against a mirror of this mesh's
+   * Pool, rather than against the Pool the mesh was built in.
+   * @details This is the one sanctioned way to move a mesh between address spaces. Only the
+   * descriptor is copied -- the vertex/edge/face data is whatever a_pool already contains, which
+   * Pool::mirror put there. Since every cross-reference is a byte offset rather than a pointer, no
+   * patching is needed on either side:
+   *
+   * @code
+   * hostPool.freeze();
+   * Pool       devicePool = Pool::mirror(hostPool, deviceMemoryResource());
+   * const Mesh deviceMesh = mesh->rebasedView(devicePool);   // rebase on the host ...
+   * myKernel<<<blocks, threads>>>(deviceMesh, ...);          // ... then copy by value
+   * @endcode
+   *
+   * How the returned view resolves depends on a_pool, not on a separate choice by the caller:
+   * - a device-accessible target (Device, Managed, Mapped) yields a view holding a plain base
+   *   address, since a kernel cannot follow a host control block. Such a view must not be
+   *   dereferenced on the host, which base() asserts.
+   * - a host-only target (Host, Pinned) yields a view holding that Pool's control block, so it is
+   *   growth-immune exactly like the original mesh.
+   * @note a_pool must be a mirror of the Pool this mesh was built in -- directly, or through any
+   * number of intermediate mirrors, since Pool::mirrorOf() names the root of the chain (so
+   * host -> pinned staging -> device works). It must also be large enough to contain this mesh's
+   * arrays, which catches a Pool mirrored before the mesh's last reserve. Both are
+   * EBGEOMETRY_EXPECT-checked.
+   * @param[in] a_pool Pool to rebase onto; a mirror of this mesh's own Pool.
+   * @return A mesh descriptor resolving against a_pool.
    */
-  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
-  inline const Mesh
-  boundView(const void* a_base) const noexcept;
+  [[nodiscard]] EBGEOMETRY_HOST
+  inline Mesh
+  rebasedView(const Pool& a_pool) const noexcept;
 
 protected:
   /**
-   * @brief Resolved base pointer, set via bind(). Null until bound.
+   * @brief Control block of the Pool this mesh was reserved from; null if, and only if, this is a
+   * device view produced by rebasedView().
+   * @details Host bookkeeping. Never mirrored, never dereferenced from device code. Re-reading the
+   * base through it on every access is what makes a mesh immune to a Pool::reserve that grows and
+   * moves the block.
+   */
+  const PoolControl* m_control = nullptr;
+
+  /**
+   * @brief Base address for a device view, set by rebasedView() and unused otherwise.
+   * @note Write-only on the host: nothing reads this until the descriptor has been byte-copied into
+   * a device address space, so it will look dead to a host-only reader.
    */
   void* m_base = nullptr;
 
@@ -681,68 +555,81 @@ protected:
   PODVector<Face> m_faces;
 
   /**
+   * @brief Resolve this mesh's current base address.
+   * @details Reads through m_control on the host (so a Pool::reserve that moves the block is
+   * invisible) and through m_base on device. Exactly one of the two is set; which one is asserted,
+   * since a mismatch means a descriptor crossed an address-space boundary the wrong way.
+   * @return Base address to resolve this mesh's PODVector offsets against.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
+  inline void*
+  base() const noexcept;
+
+  /**
+   * @brief Attach this mesh to a_pool, or check that it is already attached to it.
+   * @details Called by every reserveX(); a mesh's storage must come from exactly one Pool.
+   * @param[in] a_pool Pool being reserved from.
+   */
+  EBGEOMETRY_HOST
+  inline void
+  attachTo(const Pool& a_pool) noexcept;
+
+  /**
    * @brief Function which computes internal things for the polygon faces.
-   * @param[in] a_base Base to resolve this mesh's data against.
    * @note This calls DCEL::FaceT<T, Meta>::reconcile()
    */
   EBGEOMETRY_HOST
   inline void
-  reconcileFaces(void* a_base) noexcept;
+  reconcileFaces() noexcept;
 
   /**
    * @brief Function which computes internal things for the half-edges
-   * @param[in] a_base Base to resolve this mesh's data against.
    * @note This calls DCEL::EdgeT<T, Meta>::reconcile()
    */
   EBGEOMETRY_HOST_DEVICE
   inline void
-  reconcileEdges(void* a_base) noexcept;
+  reconcileEdges() noexcept;
 
   /**
    * @brief Function which computes internal things for the vertices
-   * @param[in] a_base   Base to resolve this mesh's data against.
    * @param[in] a_weight Vertex angle weighting
    * @note This calls DCEL::VertexT<T, Meta>::computeVertexNormalAverage() or
    * DCEL::VertexT<T, Meta>::computeVertexNormalAngleWeighted()
    */
   EBGEOMETRY_HOST
   inline void
-  reconcileVertices(void* a_base, const DCEL::VertexNormalWeight a_weight) noexcept;
+  reconcileVertices(const DCEL::VertexNormalWeight a_weight) noexcept;
 
   /**
    * @brief Flip all face normals
-   * @param[in] a_base Base to resolve this mesh's data against.
    */
   EBGEOMETRY_HOST_DEVICE
   inline void
-  flipFaceNormals(void* a_base) noexcept;
+  flipFaceNormals() noexcept;
 
   /**
    * @brief Flip all edge normals
-   * @param[in] a_base Base to resolve this mesh's data against.
    */
   EBGEOMETRY_HOST_DEVICE
   inline void
-  flipEdgeNormals(void* a_base) noexcept;
+  flipEdgeNormals() noexcept;
 
   /**
    * @brief Flip all vertex normals
-   * @param[in] a_base Base to resolve this mesh's data against.
    */
   EBGEOMETRY_HOST_DEVICE
   inline void
-  flipVertexNormals(void* a_base) noexcept;
+  flipVertexNormals() noexcept;
 
   /**
    * @brief Implementation of signed distance function which iterates through all
    * faces
-   * @param[in] a_base  Base to resolve this mesh's data against.
    * @param[in] a_point 3D point
    * @return Signed distance to the nearest face.
    */
   [[nodiscard]] EBGEOMETRY_HOST_DEVICE
   inline T
-  DirectSignedDistance(const void* a_base, const Vec3& a_point) const noexcept;
+  DirectSignedDistance(const Vec3& a_point) const noexcept;
 
   /**
    * @brief Implementation of squared signed distance function which iterates
@@ -750,13 +637,12 @@ protected:
    * @details This first find the face with the smallest unsigned square
    * distance, and the returns the signed distance to that face (more efficient
    * than the other version).
-   * @param[in] a_base  Base to resolve this mesh's data against.
    * @param[in] a_point 3D point
    * @return Signed distance to the nearest face.
    */
   [[nodiscard]] EBGEOMETRY_HOST_DEVICE
   inline T
-  DirectSignedDistance2(const void* a_base, const Vec3& a_point) const noexcept;
+  DirectSignedDistance2(const Vec3& a_point) const noexcept;
 
   /**
    * @brief Increment a warning. This is used in sanityCheck() for locating holes

--- a/Source/EBGeometry_DCEL_MeshImplem.hpp
+++ b/Source/EBGeometry_DCEL_MeshImplem.hpp
@@ -35,28 +35,66 @@ namespace EBGeometry {
 namespace DCEL {
 
 template <class T, class Meta>
-EBGEOMETRY_HOST
-inline void
-MeshT<T, Meta>::bind(const Pool& a_pool) noexcept
+EBGEOMETRY_HOST_DEVICE
+inline void*
+MeshT<T, Meta>::base() const noexcept
 {
-  EBGEOMETRY_EXPECT(a_pool.isFrozen());
+#if defined(EBGEOMETRY_DEVICE_COMPILE)
+  // A non-null control block here means a host descriptor was copied into a kernel directly,
+  // instead of going through rebasedView(). The pointer it holds is a host address.
+  EBGEOMETRY_EXPECT(m_control == nullptr);
 
-  m_base = a_pool.base();
+  return m_base;
+#else
+  // Null here means either a device view being dereferenced on the host, or a mesh nobody ever
+  // reserved into. rebasedView() is the only producer of a null control block, and only for a
+  // device-accessible target, so this test is exact rather than heuristic.
+  EBGEOMETRY_EXPECT(m_control != nullptr);
+
+  return m_control->m_base;
+#endif
 }
 
 template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline const MeshT<T, Meta>
-MeshT<T, Meta>::boundView(const void* a_base) const noexcept
+EBGEOMETRY_HOST
+inline void
+MeshT<T, Meta>::attachTo(const Pool& a_pool) noexcept
 {
+  // A mesh's three arrays must all live in the same Pool: they are resolved against a single base.
+  EBGEOMETRY_EXPECT(m_control == nullptr || m_control == a_pool.control());
+
+  m_control = a_pool.control();
+}
+
+template <class T, class Meta>
+EBGEOMETRY_HOST
+inline MeshT<T, Meta>
+MeshT<T, Meta>::rebasedView(const Pool& a_pool) const noexcept
+{
+  EBGEOMETRY_EXPECT(m_control != nullptr);                       // not already a view
+  EBGEOMETRY_EXPECT(a_pool.mirrorOf() == m_control->m_id);       // a mirror of *our* pool
+  EBGEOMETRY_EXPECT(m_vertices.endByte() <= a_pool.usedBytes()); // our arrays fit inside it
+  EBGEOMETRY_EXPECT(m_edges.endByte() <= a_pool.usedBytes());
+  EBGEOMETRY_EXPECT(m_faces.endByte() <= a_pool.usedBytes());
+
   Mesh view = *this;
 
-  // Mesh::m_base is void* (Pool::base() never hands back a const void*, and the same field
-  // resolves both mutable and immutable accessors), so a caller reaching us through a const-
-  // qualified explicit-base overload needs this cast. The `const Mesh` return type (see the
-  // declaration's doc comment) is what actually keeps this safe -- it stops a caller from writing
-  // through the const_cast'd base via a chained mutating call on the returned value.
-  view.m_base = const_cast<void*>(a_base);
+  if (a_pool.resource().isDeviceAccessible()) {
+    // A kernel cannot follow a host control block, so the base has to be captured by value. That is
+    // safe precisely here: a device-accessible pool can only come from Pool::mirror, which freezes
+    // it, and Pool::grow refuses a non-host-accessible resource outright -- the base cannot move.
+    EBGEOMETRY_EXPECT(a_pool.isFrozen());
+
+    view.m_control = nullptr;
+    view.m_base    = a_pool.base();
+  }
+  else {
+    // Host target: follow the destination's control block instead of snapshotting its base, so the
+    // rebased view is growth-immune exactly like the original mesh -- and so that a null control
+    // block keeps meaning "device view" and nothing else.
+    view.m_control = a_pool.control();
+    view.m_base    = nullptr;
+  }
 
   return view;
 }
@@ -64,7 +102,7 @@ MeshT<T, Meta>::boundView(const void* a_base) const noexcept
 template <class T, class Meta>
 EBGEOMETRY_HOST
 inline std::shared_ptr<MeshT<T, Meta>>
-MeshT<T, Meta>::deepCopy(const void* a_srcBase, Pool& a_dstPool) const
+MeshT<T, Meta>::deepCopy(Pool& a_dstPool) const
 {
   EBGEOMETRY_EXPECT(this->numVertices() > 0 || this->numEdges() > 0 || this->numFaces() > 0);
 
@@ -73,33 +111,28 @@ MeshT<T, Meta>::deepCopy(const void* a_srcBase, Pool& a_dstPool) const
   // independent, correctly-linked mesh -- no relinking pass is needed.
   auto newMesh = std::make_shared<Mesh>();
 
+  // Note that a_dstPool may be this mesh's own Pool. The reserves below can then grow (and move)
+  // the block out from under this mesh, which is harmless: every read here re-resolves through the
+  // control block rather than against an address captured before the reserves.
   newMesh->reserveVertices(a_dstPool, this->numVertices());
   newMesh->reserveEdges(a_dstPool, this->numEdges());
   newMesh->reserveFaces(a_dstPool, this->numFaces());
 
   for (uint32_t i = 0; i < this->numVertices(); i++) {
-    newMesh->addVertex(a_dstPool, this->getVertex(a_srcBase, i));
+    newMesh->addVertex(a_dstPool, this->getVertex(i));
   }
 
   for (uint32_t i = 0; i < this->numEdges(); i++) {
-    newMesh->addEdge(a_dstPool, this->getEdge(a_srcBase, i));
+    newMesh->addEdge(a_dstPool, this->getEdge(i));
   }
 
   for (uint32_t i = 0; i < this->numFaces(); i++) {
-    newMesh->addFace(a_dstPool, this->getFace(a_srcBase, i));
+    newMesh->addFace(a_dstPool, this->getFace(i));
   }
 
   newMesh->setSearchAlgorithm(m_algorithm);
 
   return newMesh;
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST
-inline std::shared_ptr<MeshT<T, Meta>>
-MeshT<T, Meta>::deepCopy(Pool& a_dstPool) const
-{
-  return this->deepCopy(m_base, a_dstPool);
 }
 
 template <class T, class Meta>
@@ -133,7 +166,7 @@ MeshT<T, Meta>::printWarnings(const std::map<std::string, size_t>& a_warnings, c
 template <class T, class Meta>
 EBGEOMETRY_HOST
 inline void
-MeshT<T, Meta>::sanityCheck(const void* a_base, const std::string a_id) const
+MeshT<T, Meta>::sanityCheck(const std::string a_id) const
 {
   const std::string f_noEdge     = "face with no edge";
   const std::string f_degenerate = "degenerate face";
@@ -155,17 +188,15 @@ MeshT<T, Meta>::sanityCheck(const void* a_base, const std::string a_id) const
                                             {e_noFace, 0},
                                             {v_noEdge, 0}};
 
-  const Mesh view = this->boundView(a_base);
-
   for (uint32_t i = 0; i < this->numFaces(); i++) {
-    const auto& f = this->getFace(a_base, i);
+    const auto& f = this->getFace(i);
 
     if (f.getHalfEdgeIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, f_noEdge);
       continue;
     }
 
-    auto vertices = f.gatherVertexIndices(view);
+    auto vertices = f.gatherVertexIndices(*this);
     std::sort(vertices.begin(), vertices.end());
     auto       it           = std::unique(vertices.begin(), vertices.end());
     const bool noDuplicates = (it == vertices.end());
@@ -175,12 +206,12 @@ MeshT<T, Meta>::sanityCheck(const void* a_base, const std::string a_id) const
   }
 
   for (uint32_t i = 0; i < this->numEdges(); i++) {
-    const auto& e = this->getEdge(a_base, i);
+    const auto& e = this->getEdge(i);
 
     if (e.getVertexIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, e_noOrigVert);
     }
-    else if (e.getNextEdgeIndex() != UINT32_MAX && e.getVertexIndex() == e.getNextEdge(view).getVertexIndex()) {
+    else if (e.getNextEdgeIndex() != UINT32_MAX && e.getVertexIndex() == e.getNextEdge(*this).getVertexIndex()) {
       this->incrementWarning(warnings, e_degenerate);
     }
 
@@ -197,20 +228,12 @@ MeshT<T, Meta>::sanityCheck(const void* a_base, const std::string a_id) const
 
   // Vertex check
   for (uint32_t i = 0; i < this->numVertices(); i++) {
-    if (this->getVertex(a_base, i).getOutgoingEdgeIndex() == UINT32_MAX) {
+    if (this->getVertex(i).getOutgoingEdgeIndex() == UINT32_MAX) {
       this->incrementWarning(warnings, v_noEdge);
     }
   }
 
   this->printWarnings(warnings, a_id);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST
-inline void
-MeshT<T, Meta>::sanityCheck(const std::string a_id) const
-{
-  this->sanityCheck(m_base, a_id);
 }
 
 template <class T, class Meta>
@@ -224,29 +247,11 @@ MeshT<T, Meta>::setSearchAlgorithm(const SearchAlgorithm a_algorithm) noexcept
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline void
-MeshT<T, Meta>::setInsideOutsideAlgorithm(void* a_base, InsideOutsideAlgorithm a_algorithm) noexcept
-{
-  for (uint32_t i = 0; i < this->numFaces(); i++) {
-    this->getFace(a_base, i).setInsideOutsideAlgorithm(a_algorithm);
-  }
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline void
 MeshT<T, Meta>::setInsideOutsideAlgorithm(InsideOutsideAlgorithm a_algorithm) noexcept
 {
-  this->setInsideOutsideAlgorithm(m_base, a_algorithm);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST
-inline void
-MeshT<T, Meta>::reconcile(void* a_base, const DCEL::VertexNormalWeight a_weight) noexcept
-{
-  this->reconcileFaces(a_base);
-  this->reconcileEdges(a_base);
-  this->reconcileVertices(a_base, a_weight);
+  for (uint32_t i = 0; i < this->numFaces(); i++) {
+    this->getFace(i).setInsideOutsideAlgorithm(a_algorithm);
+  }
 }
 
 template <class T, class Meta>
@@ -254,17 +259,9 @@ EBGEOMETRY_HOST
 inline void
 MeshT<T, Meta>::reconcile(const DCEL::VertexNormalWeight a_weight) noexcept
 {
-  this->reconcile(m_base, a_weight);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline void
-MeshT<T, Meta>::flip(void* a_base) noexcept
-{
-  this->flipFaceNormals(a_base);
-  this->flipEdgeNormals(a_base);
-  this->flipVertexNormals(a_base);
+  this->reconcileFaces();
+  this->reconcileEdges();
+  this->reconcileVertices(a_weight);
 }
 
 template <class T, class Meta>
@@ -272,7 +269,9 @@ EBGEOMETRY_HOST_DEVICE
 inline void
 MeshT<T, Meta>::flip() noexcept
 {
-  this->flip(m_base);
+  this->flipFaceNormals();
+  this->flipEdgeNormals();
+  this->flipVertexNormals();
 }
 
 template <class T, class Meta>
@@ -280,6 +279,8 @@ EBGEOMETRY_HOST
 inline void
 MeshT<T, Meta>::reserveVertices(Pool& a_pool, uint32_t a_capacity)
 {
+  this->attachTo(a_pool);
+
   m_vertices.reserveFrom(a_pool, a_capacity);
 }
 
@@ -288,6 +289,8 @@ EBGEOMETRY_HOST
 inline void
 MeshT<T, Meta>::reserveEdges(Pool& a_pool, uint32_t a_capacity)
 {
+  this->attachTo(a_pool);
+
   m_edges.reserveFrom(a_pool, a_capacity);
 }
 
@@ -296,6 +299,8 @@ EBGEOMETRY_HOST
 inline void
 MeshT<T, Meta>::reserveFaces(Pool& a_pool, uint32_t a_capacity)
 {
+  this->attachTo(a_pool);
+
   m_faces.reserveFrom(a_pool, a_capacity);
 }
 
@@ -338,25 +343,9 @@ MeshT<T, Meta>::addFace(Pool& a_pool, const Face& a_face)
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline VertexT<T, Meta>&
-MeshT<T, Meta>::getVertex(void* a_base, uint32_t a_index) noexcept
-{
-  return m_vertices.at(a_base, a_index);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline const VertexT<T, Meta>&
-MeshT<T, Meta>::getVertex(const void* a_base, uint32_t a_index) const noexcept
-{
-  return m_vertices.at(a_base, a_index);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline VertexT<T, Meta>&
 MeshT<T, Meta>::getVertex(uint32_t a_index) noexcept
 {
-  return this->getVertex(m_base, a_index);
+  return m_vertices.at(this->base(), a_index);
 }
 
 template <class T, class Meta>
@@ -364,23 +353,7 @@ EBGEOMETRY_HOST_DEVICE
 inline const VertexT<T, Meta>&
 MeshT<T, Meta>::getVertex(uint32_t a_index) const noexcept
 {
-  return this->getVertex(m_base, a_index);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline EdgeT<T, Meta>&
-MeshT<T, Meta>::getEdge(void* a_base, uint32_t a_index) noexcept
-{
-  return m_edges.at(a_base, a_index);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline const EdgeT<T, Meta>&
-MeshT<T, Meta>::getEdge(const void* a_base, uint32_t a_index) const noexcept
-{
-  return m_edges.at(a_base, a_index);
+  return m_vertices.at(this->base(), a_index);
 }
 
 template <class T, class Meta>
@@ -388,7 +361,7 @@ EBGEOMETRY_HOST_DEVICE
 inline EdgeT<T, Meta>&
 MeshT<T, Meta>::getEdge(uint32_t a_index) noexcept
 {
-  return this->getEdge(m_base, a_index);
+  return m_edges.at(this->base(), a_index);
 }
 
 template <class T, class Meta>
@@ -396,23 +369,7 @@ EBGEOMETRY_HOST_DEVICE
 inline const EdgeT<T, Meta>&
 MeshT<T, Meta>::getEdge(uint32_t a_index) const noexcept
 {
-  return this->getEdge(m_base, a_index);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline FaceT<T, Meta>&
-MeshT<T, Meta>::getFace(void* a_base, uint32_t a_index) noexcept
-{
-  return m_faces.at(a_base, a_index);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline const FaceT<T, Meta>&
-MeshT<T, Meta>::getFace(const void* a_base, uint32_t a_index) const noexcept
-{
-  return m_faces.at(a_base, a_index);
+  return m_edges.at(this->base(), a_index);
 }
 
 template <class T, class Meta>
@@ -420,7 +377,7 @@ EBGEOMETRY_HOST_DEVICE
 inline FaceT<T, Meta>&
 MeshT<T, Meta>::getFace(uint32_t a_index) noexcept
 {
-  return this->getFace(m_base, a_index);
+  return m_faces.at(this->base(), a_index);
 }
 
 template <class T, class Meta>
@@ -428,7 +385,15 @@ EBGEOMETRY_HOST_DEVICE
 inline const FaceT<T, Meta>&
 MeshT<T, Meta>::getFace(uint32_t a_index) const noexcept
 {
-  return this->getFace(m_base, a_index);
+  return m_faces.at(this->base(), a_index);
+}
+
+template <class T, class Meta>
+EBGEOMETRY_HOST
+inline bool
+MeshT<T, Meta>::isAttachedTo(const Pool& a_pool) const noexcept
+{
+  return m_control != nullptr && m_control == a_pool.control();
 }
 
 template <class T, class Meta>
@@ -458,34 +423,28 @@ MeshT<T, Meta>::numFaces() const noexcept
 template <class T, class Meta>
 EBGEOMETRY_HOST
 inline void
-MeshT<T, Meta>::reconcileFaces(void* a_base) noexcept
+MeshT<T, Meta>::reconcileFaces() noexcept
 {
-  const Mesh view = this->boundView(a_base);
-
   for (uint32_t i = 0; i < this->numFaces(); i++) {
-    this->getFace(a_base, i).reconcile(view);
+    this->getFace(i).reconcile(*this);
   }
 }
 
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline void
-MeshT<T, Meta>::reconcileEdges(void* a_base) noexcept
+MeshT<T, Meta>::reconcileEdges() noexcept
 {
-  const Mesh view = this->boundView(a_base);
-
   for (uint32_t i = 0; i < this->numEdges(); i++) {
-    this->getEdge(a_base, i).reconcile(view);
+    this->getEdge(i).reconcile(*this);
   }
 }
 
 template <class T, class Meta>
 EBGEOMETRY_HOST
 inline void
-MeshT<T, Meta>::reconcileVertices(void* a_base, const DCEL::VertexNormalWeight a_weight) noexcept
+MeshT<T, Meta>::reconcileVertices(const DCEL::VertexNormalWeight a_weight) noexcept
 {
-  const Mesh view = this->boundView(a_base);
-
   // Transient (not stored) adjacency: for each vertex, every face touching it, found by walking
   // each face's own boundary loop (nextEdge only -- no pair edge needed, so this works even on a
   // non-watertight/"dirty" mesh). Rebuilt here and discarded once vertex normals are computed;
@@ -493,7 +452,7 @@ MeshT<T, Meta>::reconcileVertices(void* a_base, const DCEL::VertexNormalWeight a
   std::vector<std::vector<uint32_t>> facesTouchingVertex(this->numVertices());
 
   for (uint32_t faceIndex = 0; faceIndex < this->numFaces(); faceIndex++) {
-    for (const uint32_t vertexIndex : this->getFace(a_base, faceIndex).gatherVertexIndices(view)) {
+    for (const uint32_t vertexIndex : this->getFace(faceIndex).gatherVertexIndices(*this)) {
       EBGEOMETRY_EXPECT(vertexIndex < facesTouchingVertex.size());
 
       facesTouchingVertex[vertexIndex].push_back(faceIndex);
@@ -501,17 +460,17 @@ MeshT<T, Meta>::reconcileVertices(void* a_base, const DCEL::VertexNormalWeight a
   }
 
   for (uint32_t vertexIndex = 0; vertexIndex < this->numVertices(); vertexIndex++) {
-    auto&       v           = this->getVertex(a_base, vertexIndex);
+    auto&       v           = this->getVertex(vertexIndex);
     const auto& faceIndices = facesTouchingVertex[vertexIndex];
 
     switch (a_weight) {
     case DCEL::VertexNormalWeight::None: {
-      v.computeVertexNormalAverage(faceIndices, view);
+      v.computeVertexNormalAverage(faceIndices, *this);
 
       break;
     }
     case DCEL::VertexNormalWeight::Angle: {
-      v.computeVertexNormalAngleWeighted(vertexIndex, faceIndices, view);
+      v.computeVertexNormalAngleWeighted(vertexIndex, faceIndices, *this);
 
       break;
     }
@@ -531,46 +490,31 @@ MeshT<T, Meta>::reconcileVertices(void* a_base, const DCEL::VertexNormalWeight a
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline void
-MeshT<T, Meta>::flipFaceNormals(void* a_base) noexcept
+MeshT<T, Meta>::flipFaceNormals() noexcept
 {
   for (uint32_t i = 0; i < this->numFaces(); i++) {
-    this->getFace(a_base, i).flipNormal();
+    this->getFace(i).flipNormal();
   }
 }
 
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline void
-MeshT<T, Meta>::flipEdgeNormals(void* a_base) noexcept
+MeshT<T, Meta>::flipEdgeNormals() noexcept
 {
   for (uint32_t i = 0; i < this->numEdges(); i++) {
-    this->getEdge(a_base, i).flipNormal();
+    this->getEdge(i).flipNormal();
   }
 }
 
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline void
-MeshT<T, Meta>::flipVertexNormals(void* a_base) noexcept
+MeshT<T, Meta>::flipVertexNormals() noexcept
 {
   for (uint32_t i = 0; i < this->numVertices(); i++) {
-    this->getVertex(a_base, i).flipNormal();
+    this->getVertex(i).flipNormal();
   }
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST
-inline std::vector<Vec3T<T>>
-MeshT<T, Meta>::getAllVertexCoordinates(const void* a_base) const noexcept
-{
-  std::vector<Vec3> vertexCoordinates;
-  vertexCoordinates.reserve(this->numVertices());
-
-  for (uint32_t i = 0; i < this->numVertices(); i++) {
-    vertexCoordinates.emplace_back(this->getVertex(a_base, i).getPosition());
-  }
-
-  return vertexCoordinates;
 }
 
 template <class T, class Meta>
@@ -578,19 +522,14 @@ EBGEOMETRY_HOST
 inline std::vector<Vec3T<T>>
 MeshT<T, Meta>::getAllVertexCoordinates() const noexcept
 {
-  return this->getAllVertexCoordinates(m_base);
-}
+  std::vector<Vec3> vertexCoordinates;
+  vertexCoordinates.reserve(this->numVertices());
 
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline T
-MeshT<T, Meta>::signedDistance(const void* a_base, const Vec3& a_point) const noexcept
-{
-  EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
-  EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
+  for (uint32_t i = 0; i < this->numVertices(); i++) {
+    vertexCoordinates.emplace_back(this->getVertex(i).getPosition());
+  }
 
-  return this->signedDistance(a_base, a_point, m_algorithm);
+  return vertexCoordinates;
 }
 
 template <class T, class Meta>
@@ -598,13 +537,17 @@ EBGEOMETRY_HOST_DEVICE
 inline T
 MeshT<T, Meta>::signedDistance(const Vec3& a_point) const noexcept
 {
-  return this->signedDistance(m_base, a_point);
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
+  EBGEOMETRY_EXPECT(std::isfinite(a_point[2]));
+
+  return this->signedDistance(a_point, m_algorithm);
 }
 
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline T
-MeshT<T, Meta>::unsignedDistance2(const void* a_base, const Vec3& a_point) const noexcept
+MeshT<T, Meta>::unsignedDistance2(const Vec3& a_point) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
@@ -614,12 +557,10 @@ MeshT<T, Meta>::unsignedDistance2(const void* a_base, const Vec3& a_point) const
     return std::numeric_limits<T>::infinity();
   }
 
-  const Mesh view = this->boundView(a_base);
-
   T minDist2 = std::numeric_limits<T>::max();
 
   for (uint32_t i = 0; i < this->numFaces(); i++) {
-    const T curDist2 = this->getFace(a_base, i).unsignedDistance2(a_point, view);
+    const T curDist2 = this->getFace(i).unsignedDistance2(a_point, *this);
 
     minDist2 = std::min(minDist2, curDist2);
   }
@@ -630,15 +571,7 @@ MeshT<T, Meta>::unsignedDistance2(const void* a_base, const Vec3& a_point) const
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline T
-MeshT<T, Meta>::unsignedDistance2(const Vec3& a_point) const noexcept
-{
-  return this->unsignedDistance2(m_base, a_point);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline T
-MeshT<T, Meta>::signedDistance(const void* a_base, const Vec3& a_point, SearchAlgorithm a_algorithm) const noexcept
+MeshT<T, Meta>::signedDistance(const Vec3& a_point, SearchAlgorithm a_algorithm) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
@@ -648,12 +581,12 @@ MeshT<T, Meta>::signedDistance(const void* a_base, const Vec3& a_point, SearchAl
 
   switch (a_algorithm) {
   case SearchAlgorithm::Direct: {
-    minDist = this->DirectSignedDistance(a_base, a_point);
+    minDist = this->DirectSignedDistance(a_point);
 
     break;
   }
   case SearchAlgorithm::Direct2: {
-    minDist = this->DirectSignedDistance2(a_base, a_point);
+    minDist = this->DirectSignedDistance2(a_point);
 
     break;
   }
@@ -674,15 +607,7 @@ MeshT<T, Meta>::signedDistance(const void* a_base, const Vec3& a_point, SearchAl
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline T
-MeshT<T, Meta>::signedDistance(const Vec3& a_point, SearchAlgorithm a_algorithm) const noexcept
-{
-  return this->signedDistance(m_base, a_point, a_algorithm);
-}
-
-template <class T, class Meta>
-EBGEOMETRY_HOST_DEVICE
-inline T
-MeshT<T, Meta>::DirectSignedDistance(const void* a_base, const Vec3& a_point) const noexcept
+MeshT<T, Meta>::DirectSignedDistance(const Vec3& a_point) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
@@ -692,13 +617,11 @@ MeshT<T, Meta>::DirectSignedDistance(const void* a_base, const Vec3& a_point) co
     return std::numeric_limits<T>::infinity();
   }
 
-  const Mesh view = this->boundView(a_base);
-
-  T minDist  = this->getFace(a_base, 0).signedDistance(a_point, view);
+  T minDist  = this->getFace(0).signedDistance(a_point, *this);
   T minDist2 = minDist * minDist;
 
   for (uint32_t i = 0; i < this->numFaces(); i++) {
-    const T curDist  = this->getFace(a_base, i).signedDistance(a_point, view);
+    const T curDist  = this->getFace(i).signedDistance(a_point, *this);
     const T curDist2 = curDist * curDist;
 
     if (curDist2 < minDist2) {
@@ -713,7 +636,7 @@ MeshT<T, Meta>::DirectSignedDistance(const void* a_base, const Vec3& a_point) co
 template <class T, class Meta>
 EBGEOMETRY_HOST_DEVICE
 inline T
-MeshT<T, Meta>::DirectSignedDistance2(const void* a_base, const Vec3& a_point) const noexcept
+MeshT<T, Meta>::DirectSignedDistance2(const Vec3& a_point) const noexcept
 {
   EBGEOMETRY_EXPECT(std::isfinite(a_point[0]));
   EBGEOMETRY_EXPECT(std::isfinite(a_point[1]));
@@ -723,13 +646,11 @@ MeshT<T, Meta>::DirectSignedDistance2(const void* a_base, const Vec3& a_point) c
     return std::numeric_limits<T>::infinity();
   }
 
-  const Mesh view = this->boundView(a_base);
-
   uint32_t closestIndex = 0;
-  T        minDist2     = this->getFace(a_base, closestIndex).unsignedDistance2(a_point, view);
+  T        minDist2     = this->getFace(closestIndex).unsignedDistance2(a_point, *this);
 
   for (uint32_t i = 0; i < this->numFaces(); i++) {
-    const T curDist2 = this->getFace(a_base, i).unsignedDistance2(a_point, view);
+    const T curDist2 = this->getFace(i).unsignedDistance2(a_point, *this);
 
     if (curDist2 < minDist2) {
       closestIndex = i;
@@ -737,7 +658,7 @@ MeshT<T, Meta>::DirectSignedDistance2(const void* a_base, const Vec3& a_point) c
     }
   }
 
-  return this->getFace(a_base, closestIndex).signedDistance(a_point, view);
+  return this->getFace(closestIndex).signedDistance(a_point, *this);
 }
 } // namespace DCEL
 

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -372,13 +372,10 @@ public:
    * @details No default arguments: this is a low-level constructor, and callers who excavate down
    * to it must consciously choose every parameter. Use Parser::readIntoTriangleBVH for sensible
    * defaults.
-   * @param[in]     a_mesh          DCEL mesh, built (but not necessarily bound) against a_pool.
+   * @param[in]     a_mesh          DCEL mesh built against a_pool.
    * @param[in,out] a_pool          Pool a_mesh's storage was reserved from. Unlike FlatMeshSDF/
    * MeshSDF, this constructor does not retain a_mesh -- it extracts flat Triangle values from it and
-   * discards it -- so it deliberately does not freeze a_pool either: doing so would forbid building
-   * any more meshes into a still-open, shared a_pool (see :ref:`Chap:MemoryModel`'s pitfalls), which
-   * this one-shot, non-retaining use has no need to impose on the caller. It reads a_pool's current
-   * base once, explicitly, instead.
+   * discards it -- so nothing here depends on a_pool outliving the returned object.
    * @param[in]     a_build         BVH build strategy. SAH (binned Surface Area Heuristic) produces
    * near-optimal traversal cost; TopDown (centroid median) is faster to build but yields deeper trees.
    * @param[in]     a_maxLeafGroups Maximum number of full W-sized TriangleSoA groups per BVH leaf; the

--- a/Source/EBGeometry_MeshDistanceFunctions.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctions.hpp
@@ -58,13 +58,14 @@ public:
 
   /**
    * @brief Full constructor.
-   * @details Freezes a_pool (idempotent -- safe even if already frozen by a sibling wrapper built
-   * from the same pool) and binds a_mesh to it, so the mesh is immediately queryable through its
-   * no-argument accessors. See EBGeometry_DCEL_Mesh.hpp's class-level note and
-   * :ref:`Chap:MemoryModel` for why this is the natural place for that to happen: retaining the
-   * mesh for long-term querying is exactly the point at which building must be considered finished.
-   * @param[in]     a_mesh Input mesh, built (but not necessarily bound) against a_pool.
-   * @param[in,out] a_pool Pool a_mesh's storage was reserved from.
+   * @details Nothing is frozen or bound: a_mesh resolves its storage through a_pool's control
+   * block on every access, so it is queryable the moment it has been built, and stays queryable
+   * across a Pool::reserve that grows and moves the block. See EBGeometry_DCEL_Mesh.hpp's
+   * class-level note for how that resolution works. a_pool is taken here only to assert that
+   * a_mesh really was reserved from it, and to make visible at the call site that it must outlive
+   * this object -- the mesh is retained, the pool is not.
+   * @param[in]     a_mesh Input mesh, built against a_pool.
+   * @param[in,out] a_pool Pool a_mesh's storage was reserved from. Must outlive this object.
    */
   FlatMeshSDF(const std::shared_ptr<Mesh>& a_mesh, Pool& a_pool) noexcept;
 
@@ -191,10 +192,11 @@ public:
    * @brief Full constructor. Takes the input mesh and creates the BVH.
    * @details No default arguments: this is a low-level constructor, and callers working at this
    * level must consciously choose a build strategy. Use Parser::readIntoPackedBVH for sensible
-   * defaults. Freezes a_pool (idempotent) and binds a_mesh to it before building the BVH, for the
-   * same reason given on FlatMeshSDF's constructor.
-   * @param[in]     a_mesh   Input mesh, built (but not necessarily bound) against a_pool.
-   * @param[in,out] a_pool   Pool a_mesh's storage was reserved from.
+   * defaults. Nothing is frozen or bound; see FlatMeshSDF's constructor. a_pool must outlive this
+   * object for the same reason given there, and additionally because the BVH built below holds DCEL
+   * faces whose indices are meaningful only against that same storage.
+   * @param[in]     a_mesh   Input mesh, built against a_pool.
+   * @param[in,out] a_pool   Pool a_mesh's storage was reserved from. Must outlive this object.
    * @param[in]     a_build  BVH build strategy. SAH (binned Surface Area Heuristic) is recommended.
    */
   MeshSDF(const std::shared_ptr<Mesh>& a_mesh, Pool& a_pool, const BVH::Build a_build);

--- a/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
+++ b/Source/EBGeometry_MeshDistanceFunctionsImplem.hpp
@@ -215,9 +215,12 @@ template <class T, class Meta>
 FlatMeshSDF<T, Meta>::FlatMeshSDF(const std::shared_ptr<Mesh>& a_mesh, Pool& a_pool) noexcept
 {
   EBGEOMETRY_EXPECT(a_mesh != nullptr);
+  EBGEOMETRY_EXPECT(a_mesh->isAttachedTo(a_pool));
 
-  a_pool.freeze();
-  a_mesh->bind(a_pool);
+  // This object retains a_mesh but not a_pool, and the mesh resolves everything through the pool,
+  // so a_pool must outlive this object. Taking it by reference here is what makes that requirement
+  // visible at the call site (and checkable above); nothing else is done with it.
+  (void)a_pool;
 
   m_mesh = a_mesh;
 }
@@ -257,9 +260,12 @@ template <class T, class Meta, size_t K>
 MeshSDF<T, Meta, K>::MeshSDF(const std::shared_ptr<Mesh>& a_mesh, Pool& a_pool, const BVH::Build a_build)
 {
   EBGEOMETRY_EXPECT(a_mesh != nullptr);
+  EBGEOMETRY_EXPECT(a_mesh->isAttachedTo(a_pool));
 
-  a_pool.freeze();
-  a_mesh->bind(a_pool);
+  // As in FlatMeshSDF: a_mesh is retained and resolves through a_pool, so a_pool must outlive this
+  // object. The BVH built below holds DCEL faces whose indices are meaningful only against that
+  // same storage, so the requirement covers m_bvh too.
+  (void)a_pool;
 
   using AABB     = EBGeometry::BoundingVolumes::AABBT<T>;
   const auto bvh = EBGeometry::MeshDistanceFunctionsDetail::buildDCELTreeBVH<T, Meta, AABB, K>(a_mesh, a_build);
@@ -439,19 +445,13 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>
 
   using AABB = EBGeometry::BoundingVolumes::AABBT<T>;
 
-  // Deliberately not frozen/bound here -- see this constructor's doc. a_mesh's data is resolved
-  // against a_pool's current base explicitly throughout, via the mesh-bound Mesh view below, since
-  // the mesh may still be unbound (or a_pool still open for more meshes) at this point.
-  void* const base     = a_pool.base();
-  const Mesh  meshView = a_mesh->boundView(base);
-
   std::vector<std::shared_ptr<Tri>> triangles;
 
   for (uint32_t faceIndex = 0; faceIndex < a_mesh->numFaces(); faceIndex++) {
-    const auto& f             = a_mesh->getFace(base, faceIndex);
+    const auto& f             = a_mesh->getFace(faceIndex);
     const auto  normal        = f.getNormal();
-    const auto  vertexIndices = f.gatherVertexIndices(meshView);
-    const auto  edgeIndices   = f.gatherEdgeIndices(meshView);
+    const auto  vertexIndices = f.gatherVertexIndices(*a_mesh);
+    const auto  edgeIndices   = f.gatherEdgeIndices(*a_mesh);
 
     EBGEOMETRY_EXPECT(vertexIndices.size() == 3);
     EBGEOMETRY_EXPECT(edgeIndices.size() == 3);
@@ -460,13 +460,13 @@ TriMeshSDF<T, Meta, K, W, StoragePolicy>::TriMeshSDF(const std::shared_ptr<Mesh>
       std::cerr << "TriMeshSDF -- mesh not triangulated!\n";
     }
 
-    const auto& v0 = a_mesh->getVertex(base, vertexIndices[0]);
-    const auto& v1 = a_mesh->getVertex(base, vertexIndices[1]);
-    const auto& v2 = a_mesh->getVertex(base, vertexIndices[2]);
+    const auto& v0 = a_mesh->getVertex(vertexIndices[0]);
+    const auto& v1 = a_mesh->getVertex(vertexIndices[1]);
+    const auto& v2 = a_mesh->getVertex(vertexIndices[2]);
 
-    const auto& e0 = a_mesh->getEdge(base, edgeIndices[0]);
-    const auto& e1 = a_mesh->getEdge(base, edgeIndices[1]);
-    const auto& e2 = a_mesh->getEdge(base, edgeIndices[2]);
+    const auto& e0 = a_mesh->getEdge(edgeIndices[0]);
+    const auto& e1 = a_mesh->getEdge(edgeIndices[1]);
+    const auto& e2 = a_mesh->getEdge(edgeIndices[2]);
 
     auto tri = std::make_shared<Tri>();
 

--- a/Source/EBGeometry_PODVector.hpp
+++ b/Source/EBGeometry_PODVector.hpp
@@ -207,6 +207,22 @@ struct PODVector
   }
 
   /**
+   * @brief One past the last byte this array occupies, measured from the pool base.
+   * @details Deliberately computed from @c m_capacity rather than @c m_size: it bounds the
+   *          @e reserved region, which is what a mirrored block must be large enough to contain.
+   *          Used to check that an array actually fits inside a pool it is being rebased onto (see
+   *          @ref EBGeometry::DCEL::MeshT::rebasedView), which catches the realistic mistake of
+   *          mirroring a pool before the last @ref Pool::reserve.
+   * @return @c m_offset + @c m_capacity * @c sizeof(T).
+   */
+  [[nodiscard]] EBGEOMETRY_HOST_DEVICE
+  uint64_t
+  endByte() const noexcept
+  {
+    return m_offset + static_cast<uint64_t>(m_capacity) * sizeof(T);
+  }
+
+  /**
    * @brief Whether the array is empty.
    * @return True if @c m_size == 0.
    */

--- a/Source/EBGeometry_ParserImplem.hpp
+++ b/Source/EBGeometry_ParserImplem.hpp
@@ -1833,16 +1833,12 @@ template <typename T, typename Meta>
 [[nodiscard]] inline std::vector<std::shared_ptr<FlatMeshSDF<T, Meta>>>
 Parser::readIntoMesh(const std::vector<std::string>& a_files, Pool& a_pool)
 {
-  // Deliberately not a loop over the single-file overload: FlatMeshSDF's constructor freezes
-  // a_pool, so every mesh sharing it must finish building first. Build all of them (still
-  // unbound), then wrap/freeze/bind each in a second pass.
-  const auto meshes = Parser::readIntoDCEL<T, Meta>(a_files, a_pool);
-
   std::vector<std::shared_ptr<FlatMeshSDF<T, Meta>>> implicitFunctions;
 
-  implicitFunctions.reserve(meshes.size());
-  for (const auto& mesh : meshes) {
-    implicitFunctions.emplace_back(std::make_shared<FlatMeshSDF<T, Meta>>(mesh, a_pool));
+  implicitFunctions.reserve(a_files.size());
+
+  for (const auto& file : a_files) {
+    implicitFunctions.emplace_back(Parser::readIntoMesh<T, Meta>(file, a_pool));
   }
 
   return implicitFunctions;
@@ -1854,28 +1850,22 @@ Parser::readIntoTriangles(const std::string a_filename, Pool& a_pool)
 {
   const auto mesh = Parser::readIntoDCEL<T, Meta>(a_filename, a_pool);
 
-  // mesh is not bind()'d (readIntoDCEL never freezes a_pool, since it may still be shared with
-  // more files, so its data is resolved against a_pool's current
-  // base explicitly throughout, via the mesh-bound Mesh view below.
-  void* const base     = a_pool.base();
-  const auto  meshView = mesh->boundView(base);
-
   std::vector<std::shared_ptr<Triangle<T, Meta>>> triangles;
 
   bool onlyTriangles = true;
 
   for (uint32_t i = 0; i < mesh->numFaces(); i++) {
-    const auto& f             = mesh->getFace(base, i);
+    const auto& f             = mesh->getFace(i);
     const auto  normal        = f.getNormal();
-    const auto  vertexIndices = f.gatherVertexIndices(meshView);
+    const auto  vertexIndices = f.gatherVertexIndices(*mesh);
 
     if (vertexIndices.size() != 3) {
       onlyTriangles = false;
     }
 
-    const auto& v0 = mesh->getVertex(base, vertexIndices[0]);
-    const auto& v1 = mesh->getVertex(base, vertexIndices[1]);
-    const auto& v2 = mesh->getVertex(base, vertexIndices[2]);
+    const auto& v0 = mesh->getVertex(vertexIndices[0]);
+    const auto& v1 = mesh->getVertex(vertexIndices[1]);
+    const auto& v2 = mesh->getVertex(vertexIndices[2]);
 
     // Create the triangle
     auto tri = std::make_shared<Triangle<T, Meta>>();
@@ -1963,16 +1953,12 @@ Parser::readIntoPackedBVH(const std::vector<std::string>& a_files, Pool& a_pool,
   static_assert(std::is_floating_point_v<T>, "Parser::readIntoPackedBVH requires T to be a floating-point type");
   static_assert(K > 0, "Parser::readIntoPackedBVH requires K > 0");
 
-  // Deliberately not a loop over the single-file overload: MeshSDF's constructor freezes a_pool,
-  // so every mesh sharing it must finish building first -- see :ref:`Chap:MemoryModel`'s pitfalls.
-  // Build all of them (still unbound), then wrap/freeze/bind each in a second pass.
-  const auto meshes = EBGeometry::Parser::readIntoDCEL<T, Meta>(a_files, a_pool);
-
   std::vector<std::shared_ptr<MeshSDF<T, Meta, K>>> implicitFunctions;
 
-  implicitFunctions.reserve(meshes.size());
-  for (const auto& mesh : meshes) {
-    implicitFunctions.emplace_back(std::make_shared<MeshSDF<T, Meta, K>>(mesh, a_pool, a_build));
+  implicitFunctions.reserve(a_files.size());
+
+  for (const auto& file : a_files) {
+    implicitFunctions.emplace_back(EBGeometry::Parser::readIntoPackedBVH<T, Meta, K>(file, a_pool, a_build));
   }
 
   return implicitFunctions;

--- a/Source/EBGeometry_Pool.hpp
+++ b/Source/EBGeometry_Pool.hpp
@@ -27,8 +27,10 @@
 #define EBGEOMETRY_POOL_HPP
 
 // Std includes
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 // Our includes
 #include "EBGeometry_GPU.hpp"
@@ -36,6 +38,30 @@
 #include "EBGeometry_MemoryResource.hpp"
 
 namespace EBGeometry {
+
+/**
+ * @brief Stable, heap-resident handle to a @ref Pool's current base address and identity.
+ * @details A pool-resident object (e.g. @ref EBGeometry::DCEL::MeshT) must be able to re-read its
+ * pool's base on every access, because @ref Pool::reserve may grow the block and move it. Pointing
+ * such an object at the @ref Pool itself would work until the pool is @e moved -- pools are
+ * move-only but movable (@ref Pool::mirror returns by value), and a @c Pool* would be left naming a
+ * relocated, possibly destroyed object. The control block solves this: it is heap-allocated,
+ * uniquely owned by the pool, and its @e address never changes for the lifetime of the pool,
+ * however many times the pool itself is moved.
+ *
+ * @note This is host bookkeeping. It is never mirrored to a device and must never be dereferenced
+ * from device code -- a device-bound view of a pool-resident object holds a plain base pointer
+ * instead. See @ref EBGeometry::DCEL::MeshT::rebasedView.
+ */
+struct PoolControl
+{
+  /// @brief Current base address of the owning pool's block. Rewritten whenever a
+  /// @ref Pool::reserve grows the block.
+  void* m_base = nullptr;
+
+  /// @brief Identity of the owning pool; see @ref Pool::id. Never zero for a live pool.
+  uint64_t m_id = 0;
+};
 
 /**
  * @brief Build-time-grow-then-freeze arena over a @ref MemoryResource.
@@ -97,6 +123,29 @@ public:
    * @brief Bump-reserve @p a_count * @p a_elemSize bytes aligned to @p a_alignment.
    * @details Returns the byte offset of the reserved sub-region from @ref base. May grow the
    *          block (on a host-accessible resource only). Forbidden after @ref freeze.
+   *
+   * @warning A grow does @b not extend the block in place: it allocates a new block, copies the
+   * live bytes into it, and @e deallocates the old one. Every address that was already resolved
+   * against the old base -- a raw pointer, a @c T& handed out by @ref PODVector::at or by a
+   * pool-resident container's accessor, a @ref PODSpan from @ref PODVector::bind -- is dangling
+   * afterwards. Every @ref PODVector is @e unaffected, because it stores a byte offset rather than
+   * an address, and so is anything that re-resolves through @ref PoolControl::m_base.
+   *
+   * The rule is therefore: @b resolve, @b use, @b discard. A resolved address must not outlive the
+   * next @ref reserve on the same pool. To carry data across a @ref reserve, carry it @e by value
+   * and write it back through a fresh resolution:
+   *
+   * @code
+   * Edge e = mesh.getEdge(3);      // snapshot; independent of any base
+   * mesh.reserveFaces(pool, n);    // may grow, moving the block
+   * e.setFace(7);
+   * mesh.getEdge(3) = e;           // fresh resolution against the current base
+   * @endcode
+   *
+   * Note that the hazard is intermittent -- a grow only happens when the request exceeds the
+   * current capacity -- and its quiet form is worse than a crash: if the freed block is still
+   * mapped, a write through a stale address lands in the abandoned copy and is silently lost.
+   *
    * @param[in] a_count     Number of elements.
    * @param[in] a_elemSize  Size of one element in bytes.
    * @param[in] a_alignment Required alignment of the sub-region (power of two, <= @ref PoolBaseAlign).
@@ -117,13 +166,59 @@ public:
 
   /**
    * @brief Base address of the block.
-   * @return Pointer to the first byte of the block (null if nothing has been reserved yet).
+   * @return Pointer to the first byte of the block (null if nothing has been reserved yet, or if
+   *         this pool has been moved from).
    */
   [[nodiscard]] EBGEOMETRY_HOST
   void*
   base() const noexcept
   {
-    return m_base;
+    return (m_control != nullptr) ? m_control->m_base : nullptr;
+  }
+
+  /**
+   * @brief This pool's stable control block, through which pool-resident objects re-resolve the
+   * base on every access.
+   * @details The returned address is fixed for the lifetime of the pool and survives every move of
+   * the pool object, which is precisely why pool-resident objects store this rather than a
+   * @c Pool*. It does @b not survive the pool's destruction: the pool must outlive every object
+   * reserved from it.
+   * @return Pointer to the control block (null only for a moved-from pool).
+   */
+  [[nodiscard]] EBGEOMETRY_HOST
+  const PoolControl*
+  control() const noexcept
+  {
+    return m_control.get();
+  }
+
+  /**
+   * @brief Identity of this pool, unique among all pools constructed in this process.
+   * @details Assigned at construction from a monotonic counter and never reused; a mirror gets its
+   *          own fresh identity. Used by @ref mirrorOf to record lineage.
+   * @return This pool's identity (zero only for a moved-from pool).
+   */
+  [[nodiscard]] EBGEOMETRY_HOST
+  uint64_t
+  id() const noexcept
+  {
+    return (m_control != nullptr) ? m_control->m_id : 0;
+  }
+
+  /**
+   * @brief Identity of the pool this one ultimately mirrors, or zero if it is not a mirror.
+   * @details This names the @e root of the mirror chain, not the immediate source: mirroring
+   *          host -> pinned staging -> device leaves the device pool naming the original host pool,
+   *          not the staging pool. That is what lets a pool-resident object built in the host pool
+   *          validate a rebase onto the device pool (see @ref EBGeometry::DCEL::MeshT::rebasedView)
+   *          without having to know how many hops the block travelled.
+   * @return Identity of the root source pool, or 0 if this pool is not a mirror.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST
+  uint64_t
+  mirrorOf() const noexcept
+  {
+    return m_mirrorOf;
   }
 
   /**
@@ -199,20 +294,43 @@ private:
    * @param[in] a_resource Backing resource (may be device-resident).
    */
   EBGEOMETRY_HOST
-  Pool(MemoryResource& a_resource, MirrorTag) noexcept : m_resource(&a_resource)
+  Pool(MemoryResource& a_resource, MirrorTag) : m_resource(&a_resource), m_control(makeControl())
   {}
+
+  /**
+   * @brief Allocate a fresh control block carrying the next pool identity.
+   * @details The counter is an atomic because EBGeometry is header-only and nothing prevents two
+   *          threads from constructing pools concurrently. Identities start at one, so zero is
+   *          available as the "not a mirror" / "moved-from" sentinel.
+   * @return Owning pointer to the new control block.
+   */
+  [[nodiscard]] EBGEOMETRY_HOST
+  static std::unique_ptr<PoolControl>
+  makeControl()
+  {
+    static std::atomic<uint64_t> s_nextID{1};
+
+    auto control = std::make_unique<PoolControl>();
+
+    control->m_id = s_nextID.fetch_add(1, std::memory_order_relaxed);
+
+    return control;
+  }
 
   /// @brief Backing memory resource (non-owning; must outlive the pool).
   MemoryResource* m_resource = nullptr;
 
-  /// @brief Base address of the block.
-  void* m_base = nullptr;
+  /// @brief Stable handle to the block's base address and this pool's identity. Null if moved from.
+  std::unique_ptr<PoolControl> m_control;
 
   /// @brief Bump cursor: bytes currently in use.
   size_t m_size = 0;
 
   /// @brief Bytes currently allocated.
   size_t m_capacity = 0;
+
+  /// @brief Identity of the root pool this one mirrors; 0 if this pool is not a mirror.
+  uint64_t m_mirrorOf = 0;
 
   /// @brief Whether the pool has been frozen.
   bool m_frozen = false;

--- a/Source/EBGeometry_PoolImplem.hpp
+++ b/Source/EBGeometry_PoolImplem.hpp
@@ -28,7 +28,7 @@
 
 namespace EBGeometry {
 
-inline Pool::Pool(MemoryResource& a_resource, size_t a_initialBytes) : m_resource(&a_resource)
+inline Pool::Pool(MemoryResource& a_resource, size_t a_initialBytes) : m_resource(&a_resource), m_control(makeControl())
 {
   // A build pool must be host-accessible: reserve()/push_back()/grow() write through base() with the
   // host CPU. Device-resident pools are produced only by mirror() (via the private MirrorTag
@@ -44,28 +44,32 @@ inline Pool::Pool(MemoryResource& a_resource, size_t a_initialBytes) : m_resourc
   if (a_initialBytes > 0) {
     const size_t rounded = (a_initialBytes + (PoolBaseAlign - 1)) & ~(PoolBaseAlign - 1);
 
-    m_base     = m_resource->allocate(rounded, PoolBaseAlign);
-    m_capacity = rounded;
+    m_control->m_base = m_resource->allocate(rounded, PoolBaseAlign);
+    m_capacity        = rounded;
   }
 }
 
 inline Pool::~Pool() noexcept
 {
-  if (m_base != nullptr) {
-    m_resource->deallocate(m_base, m_capacity, PoolBaseAlign);
+  if (m_control != nullptr && m_control->m_base != nullptr) {
+    m_resource->deallocate(m_control->m_base, m_capacity, PoolBaseAlign);
   }
 }
 
+// The move steals the control block itself, so the block's *address* is unchanged and every
+// pool-resident object pointing at it keeps resolving -- that is the control block's entire reason
+// for existing. Nothing about the base needs fixing up here.
 inline Pool::Pool(Pool&& a_other) noexcept
   : m_resource(a_other.m_resource),
-    m_base(a_other.m_base),
+    m_control(std::move(a_other.m_control)),
     m_size(a_other.m_size),
     m_capacity(a_other.m_capacity),
+    m_mirrorOf(a_other.m_mirrorOf),
     m_frozen(a_other.m_frozen)
 {
-  a_other.m_base     = nullptr;
   a_other.m_size     = 0;
   a_other.m_capacity = 0;
+  a_other.m_mirrorOf = 0;
   a_other.m_frozen   = false;
 }
 
@@ -73,19 +77,20 @@ inline Pool&
 Pool::operator=(Pool&& a_other) noexcept
 {
   if (this != &a_other) {
-    if (m_base != nullptr) {
-      m_resource->deallocate(m_base, m_capacity, PoolBaseAlign);
+    if (m_control != nullptr && m_control->m_base != nullptr) {
+      m_resource->deallocate(m_control->m_base, m_capacity, PoolBaseAlign);
     }
 
     m_resource = a_other.m_resource;
-    m_base     = a_other.m_base;
+    m_control  = std::move(a_other.m_control);
     m_size     = a_other.m_size;
     m_capacity = a_other.m_capacity;
+    m_mirrorOf = a_other.m_mirrorOf;
     m_frozen   = a_other.m_frozen;
 
-    a_other.m_base     = nullptr;
     a_other.m_size     = 0;
     a_other.m_capacity = 0;
+    a_other.m_mirrorOf = 0;
     a_other.m_frozen   = false;
   }
 
@@ -95,6 +100,14 @@ Pool::operator=(Pool&& a_other) noexcept
 inline uint64_t
 Pool::reserve(size_t a_count, size_t a_elemSize, size_t a_alignment)
 {
+  // Always-on, NOT EBGEOMETRY_EXPECT: a moved-from pool owns no control block, so every path below
+  // (and every base resolution by an object reserved here) would dereference null. Failing hard
+  // beats a release build wandering into undefined behaviour.
+  if (m_control == nullptr) {
+    std::fprintf(stderr, "EBGeometry::Pool::reserve: cannot reserve from a moved-from pool\n");
+    std::abort();
+  }
+
   EBGEOMETRY_EXPECT(!m_frozen);                              // no reserve after freeze
   EBGEOMETRY_EXPECT(a_alignment > 0);                        // 0 would underflow the mask below
   EBGEOMETRY_EXPECT(a_alignment <= PoolBaseAlign);           // base is 256-aligned; larger unsupported
@@ -128,13 +141,16 @@ Pool::grow(size_t a_need)
 
   void* newBase = m_resource->allocate(newCap, PoolBaseAlign);
 
-  if (m_base != nullptr) {
-    std::memcpy(newBase, m_base, m_size);
-    m_resource->deallocate(m_base, m_capacity, PoolBaseAlign);
+  if (m_control->m_base != nullptr) {
+    std::memcpy(newBase, m_control->m_base, m_size);
+    m_resource->deallocate(m_control->m_base, m_capacity, PoolBaseAlign);
   }
 
-  m_base     = newBase;
-  m_capacity = newCap;
+  // Publishing the new base through the control block is what makes pool-resident objects immune to
+  // a grow: they re-read it on every access. Addresses already resolved against the old base are
+  // dangling from here on -- see the warning on reserve().
+  m_control->m_base = newBase;
+  m_capacity        = newCap;
 }
 
 inline void
@@ -154,20 +170,23 @@ Pool::mirror(const Pool& a_src, MemoryResource& a_dstResource)
   Pool dst(a_dstResource, MirrorTag{});
 
   if (a_src.m_size > 0) {
-    dst.m_base = a_dstResource.allocate(a_src.m_size, PoolBaseAlign); // exact size, no slack
+    void* const srcBase = a_src.m_control->m_base;
+    void* const dstBase = a_dstResource.allocate(a_src.m_size, PoolBaseAlign); // exact size, no slack
+
+    dst.m_control->m_base = dstBase;
 
     const bool srcHost = a_src.m_resource->isHostAccessible();
     const bool dstHost = a_dstResource.isHostAccessible();
 
     if (srcHost && dstHost) {
-      std::memcpy(dst.m_base, a_src.m_base, a_src.m_size);
+      std::memcpy(dstBase, srcBase, a_src.m_size);
     }
 #if defined(EBGEOMETRY_CUDA) || defined(EBGEOMETRY_HIP)
     else if (srcHost && !dstHost) {
-      EBGEOMETRY_GPU_CHECK(GPU::memcpy(dst.m_base, a_src.m_base, a_src.m_size, GPU::MemcpyHostToDevice));
+      EBGEOMETRY_GPU_CHECK(GPU::memcpy(dstBase, srcBase, a_src.m_size, GPU::MemcpyHostToDevice));
     }
     else if (!srcHost && dstHost) {
-      EBGEOMETRY_GPU_CHECK(GPU::memcpy(dst.m_base, a_src.m_base, a_src.m_size, GPU::MemcpyDeviceToHost));
+      EBGEOMETRY_GPU_CHECK(GPU::memcpy(dstBase, srcBase, a_src.m_size, GPU::MemcpyDeviceToHost));
     }
     else {
       // Device-to-device is out of scope for the mirror (the foundation only builds on host and
@@ -190,6 +209,11 @@ Pool::mirror(const Pool& a_src, MemoryResource& a_dstResource)
   dst.m_capacity = a_src.m_size;
   dst.m_size     = a_src.m_size;
   dst.m_frozen   = true;
+
+  // Record the *root* of the mirror chain, not the immediate source: mirroring host -> pinned
+  // staging -> device must leave the device pool naming the original host pool, so that an object
+  // built in that host pool can still validate a rebase onto the device pool.
+  dst.m_mirrorOf = (a_src.m_mirrorOf != 0) ? a_src.m_mirrorOf : a_src.id();
 
   return dst;
 }

--- a/Source/EBGeometry_Soup.hpp
+++ b/Source/EBGeometry_Soup.hpp
@@ -56,10 +56,9 @@ compress(std::vector<EBGeometry::Vec3T<T>>& a_vertices, std::vector<std::vector<
 /**
  * @brief Convert a polygon soup into a DCEL half-edge mesh.
  * @details Builds vertices, half-edges, and faces from the input arrays, reconciles
- * pair edges, and runs a mesh sanity check. Everything here runs before a_mesh can be bind()'d
- * (a_pool may still be open for more meshes, see EBGeometry_DCEL_Mesh.hpp), so it resolves
- * a_mesh's data through a_pool's current base explicitly throughout, rather than through a_mesh's
- * own no-argument accessors.
+ * pair edges, and runs a mesh sanity check. a_mesh is attached to a_pool by the first reserve here
+ * and is queryable from that point on, including across the reserves that follow -- a_pool need not
+ * be frozen, and may stay open for further meshes.
  * @tparam T    Floating-point precision type for vertex coordinates.
  * @tparam Meta Metadata type attached to DCEL vertices, edges, and faces.
  * @param[out]    a_mesh     Output DCEL mesh populated by this call.
@@ -81,16 +80,15 @@ soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
  * @details For every half-edge (u→v) the function finds the corresponding reverse
  * half-edge (v→u) by circulating the half-edges around u (via pair/next edges of
  * whichever edges already have their pair set, falling back to a scan of u's
- * outgoing edges discovered so far) and sets the pair-edge index on both. Resolves a_mesh's data
- * against a_pool's current base explicitly (see soupToDCEL).
+ * outgoing edges discovered so far) and sets the pair-edge index on both.
  * @tparam T    Floating-point precision type.
  * @tparam Meta Metadata type attached to DCEL edges.
- * @param[in,out] a_mesh Mesh whose half-edges are reconciled in place.
- * @param[in,out] a_pool Pool a_mesh's half-edge storage was reserved from.
+ * @param[in,out] a_mesh Mesh whose half-edges are reconciled in place. Must already be attached to
+ * the Pool its storage was reserved from, which its first reserveX() call does.
  */
 template <typename T, typename Meta>
 inline static void
-reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh, Pool& a_pool) noexcept;
+reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh) noexcept;
 
 } // namespace Soup
 

--- a/Source/EBGeometry_SoupImplem.hpp
+++ b/Source/EBGeometry_SoupImplem.hpp
@@ -179,9 +179,9 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
   }
 
   // Now build the faces, appending each facet's half-edges directly into the mesh's own edge/face
-  // arrays and wiring them by index rather than by pointer. a_pool.base() is re-read on every use
-  // rather than cached across these calls, since addVertex/addEdge/addFace can grow (and move) the
-  // pool's block.
+  // arrays and wiring them by index rather than by pointer. The mesh re-resolves its base through
+  // a_pool's control block on every access, so a grow that moves the block mid-loop is invisible
+  // here -- but a reference obtained from getVertex/getEdge must still not be held across one.
   for (const auto& curFacet : a_facets) {
     if (curFacet.size() < 3) {
       std::cerr << "Parser::soupToDCEL -- not enough vertices in face, skipping it\n";
@@ -202,39 +202,37 @@ Soup::soupToDCEL(EBGeometry::DCEL::MeshT<T, Meta>&        a_mesh,
       EBGEOMETRY_EXPECT(vertexIndex < a_mesh.numVertices());
 
       a_mesh.addEdge(a_pool, Edge(vertexIndex));
-      a_mesh.getVertex(a_pool.base(), vertexIndex).setEdge(firstEdgeIndex + i);
+      a_mesh.getVertex(vertexIndex).setEdge(firstEdgeIndex + i);
     }
 
     for (uint32_t i = 0; i < numFaceEdges; i++) {
-      a_mesh.getEdge(a_pool.base(), firstEdgeIndex + i).setNextEdge(firstEdgeIndex + (i + 1) % numFaceEdges);
+      a_mesh.getEdge(firstEdgeIndex + i).setNextEdge(firstEdgeIndex + (i + 1) % numFaceEdges);
     }
 
     const uint32_t faceIndex = a_mesh.numFaces();
     a_mesh.addFace(a_pool, Face(firstEdgeIndex));
 
     for (uint32_t i = 0; i < numFaceEdges; i++) {
-      a_mesh.getEdge(a_pool.base(), firstEdgeIndex + i).setFace(faceIndex);
+      a_mesh.getEdge(firstEdgeIndex + i).setFace(faceIndex);
     }
   }
 
-  // Reconcile the pair edges and run a sanity check. Both run before a_mesh can be bind()'d (see
-  // soupToDCEL's own doc), so they resolve against a_pool's current base explicitly.
-  Soup::reconcilePairEdgesDCEL(a_mesh, a_pool);
+  // Reconcile the pair edges and run a sanity check. The mesh is queryable from its first reserve
+  // onwards, so these need no base of their own and a_pool need not be frozen.
+  Soup::reconcilePairEdgesDCEL(a_mesh);
 
-  a_mesh.sanityCheck(a_pool.base(), a_id);
+  a_mesh.sanityCheck(a_id);
 
-  a_mesh.reconcile(a_pool.base(), EBGeometry::DCEL::VertexNormalWeight::Angle);
+  a_mesh.reconcile(EBGeometry::DCEL::VertexNormalWeight::Angle);
 }
 
 template <typename T, typename Meta>
 inline void
-Soup::reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh, Pool& a_pool) noexcept
+Soup::reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh) noexcept
 {
   static_assert(std::is_floating_point_v<T>, "Soup::reconcilePairEdgesDCEL requires a floating-point T");
 
   using Edge = EBGeometry::DCEL::EdgeT<T, Meta>;
-
-  void* const base = a_pool.base();
 
   const uint32_t numEdges    = a_mesh.numEdges();
   const uint32_t numVertices = a_mesh.numVertices();
@@ -244,7 +242,7 @@ Soup::reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh, Pool& a_p
   // stays O(V + E) instead of an O(E^2) scan over every edge pair.
   std::vector<std::vector<uint32_t>> edgesStartingAtVertex(numVertices);
   for (uint32_t i = 0; i < numEdges; i++) {
-    const uint32_t v = a_mesh.getEdge(base, i).getVertexIndex();
+    const uint32_t v = a_mesh.getEdge(i).getVertexIndex();
 
     EBGEOMETRY_EXPECT(v < numVertices);
 
@@ -252,22 +250,22 @@ Soup::reconcilePairEdgesDCEL(EBGeometry::DCEL::MeshT<T, Meta>& a_mesh, Pool& a_p
   }
 
   for (uint32_t curIndex = 0; curIndex < numEdges; curIndex++) {
-    Edge& curEdge = a_mesh.getEdge(base, curIndex);
+    Edge& curEdge = a_mesh.getEdge(curIndex);
 
     const uint32_t nextIndex = curEdge.getNextEdgeIndex();
     EBGEOMETRY_EXPECT(nextIndex != UINT32_MAX);
 
     const uint32_t vertexStart = curEdge.getVertexIndex();
-    const uint32_t vertexEnd   = a_mesh.getEdge(base, nextIndex).getVertexIndex();
+    const uint32_t vertexEnd   = a_mesh.getEdge(nextIndex).getVertexIndex();
 
     // The pair edge starts where this edge ends, and ends where this edge starts.
     for (const uint32_t candIndex : edgesStartingAtVertex[vertexEnd]) {
-      Edge&          candEdge      = a_mesh.getEdge(base, candIndex);
+      Edge&          candEdge      = a_mesh.getEdge(candIndex);
       const uint32_t candNextIndex = candEdge.getNextEdgeIndex();
 
       EBGEOMETRY_EXPECT(candNextIndex != UINT32_MAX);
 
-      if (a_mesh.getEdge(base, candNextIndex).getVertexIndex() == vertexStart) { // Found the pair edge
+      if (a_mesh.getEdge(candNextIndex).getVertexIndex() == vertexStart) { // Found the pair edge
         curEdge.setPairEdge(candIndex);
         candEdge.setPairEdge(curIndex);
 

--- a/Tests/InstantiateAll.cpp
+++ b/Tests/InstantiateAll.cpp
@@ -142,9 +142,13 @@ instantiateFunctionTemplates()
     Pool mirrored = Pool::mirror(pool, resource);
 
     (void)mirrored.base();
+    (void)mirrored.mirrorOf();
     (void)pool.usedBytes();
     (void)pool.capacityBytes();
+    (void)pool.control();
+    (void)pool.id();
     (void)pool.resource().isDeviceAccessible();
+    (void)vec.endByte();
   }
 
   (void)Parser::readPLY<T>(file);

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -127,9 +127,6 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
   const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.obj"), pool);
   REQUIRE(mesh != nullptr);
 
-  // readIntoDCEL never freezes/binds pool itself, but mesh is queried via its no-argument
-  // accessors below (before any SDF wrapper would otherwise do this for us).
-
   using Face = DCEL::FaceT<T, Meta>;
 
   BVH::PrimAndBVList<Face, AABB> primsAndBVs;
@@ -643,15 +640,14 @@ TEMPLATE_TEST_CASE("Parser::readIntoPackedBVH matches MeshSDF built directly fro
 
   constexpr size_t K = 4;
 
-  // Two separate pools: MeshSDF's constructor freezes its pool, so it must not be the same pool
-  // readIntoPackedBVH below still needs to build its own (independent) mesh into.
-  Pool       directPool(hostMemoryResource());
-  Pool       filePool(hostMemoryResource());
-  const auto direct = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), directPool);
+  // One pool for both: the direct MeshSDF below and readIntoPackedBVH's own independent build
+  // share it, which is only sound because building one mesh no longer closes the pool to the next.
+  Pool       pool(hostMemoryResource());
+  const auto direct = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
   REQUIRE(direct != nullptr);
 
-  const MeshSDF<T, Meta, K> expected(direct, directPool, BVH::Build::SAH);
-  const auto                fromFile = Parser::readIntoPackedBVH<T, Meta, K>(dataPath("dodecahedron.stl"), filePool);
+  const MeshSDF<T, Meta, K> expected(direct, pool, BVH::Build::SAH);
+  const auto                fromFile = Parser::readIntoPackedBVH<T, Meta, K>(dataPath("dodecahedron.stl"), pool);
 
   REQUIRE(fromFile != nullptr);
 
@@ -681,9 +677,6 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
     const auto meshes = Parser::readIntoDCEL<T, Meta>(files, pool);
     REQUIRE(meshes.size() == 2);
 
-    // readIntoDCEL never freezes/binds pool itself, and every single-file mesh below must finish
-    // building before anyone binds -- see Chap:MemoryModel. Build all of them first, then
-    // freeze+bind once, then compare.
     std::vector<std::shared_ptr<DCEL::MeshT<T, Meta>>> singles;
     singles.reserve(files.size());
     for (const auto& file : files) {
@@ -706,10 +699,7 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
     REQUIRE(flatSDFs.size() == 2);
 
     for (size_t i = 0; i < files.size(); i++) {
-      // FlatMeshSDF's constructor (inside readIntoMesh) freezes its pool, so the per-file
-      // comparison below -- an independent build -- needs its own, separate pool.
-      Pool       singlePool(hostMemoryResource());
-      const auto single = Parser::readIntoMesh<T, Meta>(files[i], singlePool);
+      const auto single = Parser::readIntoMesh<T, Meta>(files[i], pool);
       for (const auto& p : queryPoints<T>()) {
         REQUIRE_THAT(flatSDFs[i]->signedDistance(p), withinAbsT(single->signedDistance(p), formatMargin<T>()));
       }
@@ -722,10 +712,7 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
     REQUIRE(packedSDFs.size() == 2);
 
     for (size_t i = 0; i < files.size(); i++) {
-      // MeshSDF's constructor (inside readIntoPackedBVH) freezes its pool -- see the readIntoMesh
-      // SECTION above.
-      Pool       singlePool(hostMemoryResource());
-      const auto single = Parser::readIntoPackedBVH<T, Meta, K>(files[i], singlePool);
+      const auto single = Parser::readIntoPackedBVH<T, Meta, K>(files[i], pool);
       for (const auto& p : queryPoints<T>()) {
         REQUIRE_THAT(packedSDFs[i]->signedDistance(p), withinAbsT(single->signedDistance(p), formatMargin<T>()));
       }
@@ -1985,9 +1972,6 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
   Pool       pool(hostMemoryResource());
   const auto mesh = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.stl"), pool);
   REQUIRE(mesh != nullptr);
-
-  // readIntoDCEL never freezes/binds pool itself, but mesh is queried via its no-argument
-  // accessors below (before any SDF wrapper would otherwise do this for us).
 
   BVH::PrimAndBVList<Face, AABB> primsAndBVs;
   for (uint32_t i = 0; i < mesh->numFaces(); i++) {

--- a/Tests/TestBVH.cpp
+++ b/Tests/TestBVH.cpp
@@ -90,14 +90,8 @@ TEMPLATE_TEST_CASE("Dodecahedron: all four file formats parse into an identical,
   const auto meshOBJ = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.obj"), pool);
   const auto meshVTK = Parser::readIntoDCEL<T, Meta>(dataPath("dodecahedron.vtk"), pool);
 
-  // readIntoDCEL never freezes/binds pool itself (it may still be shared with more files -- see
-  // Chap:MemoryModel), but every mesh below is queried directly via its no-argument accessors, so
-  // this test freezes+binds once all four builds are done.
-  pool.freeze();
-  for (const auto& mesh : {meshSTL, meshPLY, meshOBJ, meshVTK}) {
-    mesh->bind(pool);
-  }
-
+  // Every mesh below is queried directly through its own accessors; each attaches to pool on its
+  // first reserve inside readIntoDCEL, so nothing has to be frozen or bound first.
   for (const auto& mesh : {meshSTL, meshPLY, meshOBJ, meshVTK}) {
     REQUIRE(mesh != nullptr);
     REQUIRE(mesh->numVertices() == 20);
@@ -135,8 +129,6 @@ TEMPLATE_TEST_CASE("TreeBVH/PackedBVH: signedDistance agrees with the brute-forc
 
   // readIntoDCEL never freezes/binds pool itself, but mesh is queried via its no-argument
   // accessors below (before any SDF wrapper would otherwise do this for us).
-  pool.freeze();
-  mesh->bind(pool);
 
   using Face = DCEL::FaceT<T, Meta>;
 
@@ -696,14 +688,6 @@ TEMPLATE_TEST_CASE("Parser: multi-file overloads return one result per file, eac
     singles.reserve(files.size());
     for (const auto& file : files) {
       singles.push_back(Parser::readIntoDCEL<T, Meta>(file, pool));
-    }
-
-    pool.freeze();
-    for (const auto& mesh : meshes) {
-      mesh->bind(pool);
-    }
-    for (const auto& single : singles) {
-      single->bind(pool);
     }
 
     for (size_t i = 0; i < files.size(); i++) {
@@ -2004,8 +1988,6 @@ TEMPLATE_TEST_CASE("TreeBVH::deepCopy: independent clone -- distinct nodes, shar
 
   // readIntoDCEL never freezes/binds pool itself, but mesh is queried via its no-argument
   // accessors below (before any SDF wrapper would otherwise do this for us).
-  pool.freeze();
-  mesh->bind(pool);
 
   BVH::PrimAndBVList<Face, AABB> primsAndBVs;
   for (uint32_t i = 0; i < mesh->numFaces(); i++) {

--- a/Tests/TestDCEL.cpp
+++ b/Tests/TestDCEL.cpp
@@ -6,8 +6,10 @@
 #include "TestGPU.hpp"
 
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -34,12 +36,8 @@ loadTetrahedron(Pool& a_pool)
 {
   auto mesh = Parser::readIntoDCEL<T>(g_dataDir + "/tetrahedron.stl", a_pool);
 
-  // readIntoDCEL never freezes/binds a_pool itself (it may still be shared with more files -- see
-  // Chap:MemoryModel), but every call site below queries the returned mesh directly via its
-  // no-argument accessors, so this helper -- unlike the real Parser entry point -- freezes+binds on
-  // its caller's behalf. Each call site below uses its own fresh, single-use Pool.
-  a_pool.freeze();
-  mesh->bind(a_pool);
+  // The mesh is attached to a_pool by its first reserve inside readIntoDCEL and is queryable from
+  // that point on: no freeze, no bind. Each call site below uses its own fresh, single-use Pool.
 
   return mesh;
 }
@@ -75,8 +73,6 @@ buildTetrahedron(Pool& a_pool)
 
   // See loadTetrahedron's comment: every call site below queries the returned mesh via its
   // no-argument accessors, so this test helper freezes+binds a_pool on its caller's behalf.
-  a_pool.freeze();
-  mesh->bind(a_pool);
 
   return mesh;
 }
@@ -370,9 +366,6 @@ TEMPLATE_TEST_CASE("EdgeT: flipNormal negates the normal vector", "[DCEL][Edge]"
   edge.setFace(0);
   mesh.addEdge(pool, edge);
 
-  pool.freeze();
-  mesh.bind(pool);
-
   auto& e = mesh.getEdge(0);
   e.reconcile(mesh);
 
@@ -400,9 +393,6 @@ TEMPLATE_TEST_CASE("EdgeT: computeNormal with a single face returns that face's 
   edge.setFace(0);
   mesh.addEdge(pool, edge);
 
-  pool.freeze();
-  mesh.bind(pool);
-
   REQUIRE(mesh.getEdge(0).computeNormal(mesh) == Vec3T<T>(1, 0, 0));
 }
 
@@ -427,9 +417,6 @@ TEMPLATE_TEST_CASE("EdgeT: computeNormal averages both incident faces' normals",
 
   mesh.addEdge(pool, TestEdge<T>()); // edge under test
   mesh.addEdge(pool, TestEdge<T>()); // its pair edge
-
-  pool.freeze();
-  mesh.bind(pool);
 
   mesh.getEdge(0).setFace(0);
   mesh.getEdge(1).setFace(1);
@@ -460,9 +447,6 @@ TEMPLATE_TEST_CASE("EdgeT: reconcile stores computeNormal's result", "[DCEL][Edg
   edge.setFace(0);
   mesh.addEdge(pool, edge);
 
-  pool.freeze();
-  mesh.bind(pool);
-
   auto& e = mesh.getEdge(0);
   e.reconcile(mesh);
 
@@ -492,9 +476,6 @@ TEMPLATE_TEST_CASE("EdgeT: signedDistance and unsignedDistance2 on a simple segm
   TestFace<T> face;
   face.define(Vec3T<T>(0, 1, 0), UINT32_MAX);
   mesh.addFace(pool, face);
-
-  pool.freeze();
-  mesh.bind(pool);
 
   mesh.getEdge(0).setNextEdge(1);
   mesh.getEdge(0).setFace(0);
@@ -741,9 +722,6 @@ TEMPLATE_TEST_CASE("MeshT: reserveX/addX/getX/numX populate the mesh", "[DCEL][M
   REQUIRE(eIdx == 0);
   REQUIRE(fIdx == 0);
 
-  pool.freeze();
-  mesh.bind(pool);
-
   REQUIRE(mesh.numVertices() == 1);
   REQUIRE(mesh.numEdges() == 1);
   REQUIRE(mesh.numFaces() == 1);
@@ -759,7 +737,7 @@ TEMPLATE_TEST_CASE("MeshT: copy and move are both allowed, and the whole type is
   using T = TestType;
   // Unlike the Pool-owning design this superseded, MeshT holds only plain values (three
   // PODVectors, the search algorithm, and a resolved base pointer) -- copying is a cheap,
-  // always-safe descriptor copy that shares the underlying data (see bind()/deepCopy()'s docs).
+  // always-safe descriptor copy that shares the underlying data (see deepCopy()'s docs).
   static_assert(std::is_copy_constructible_v<TestMesh<T>>);
   static_assert(std::is_copy_assignable_v<TestMesh<T>>);
   static_assert(std::is_move_constructible_v<TestMesh<T>>);
@@ -948,11 +926,6 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy produces an independent mesh with the same g
   auto mesh = buildTetrahedron<T>(srcPool);
   auto copy = mesh->deepCopy(dstPool);
 
-  // deepCopy() never freezes/binds dstPool itself (dstPool may still be shared with more copies --
-  // see Chap:MemoryModel), but every call below queries copy through its no-argument accessors.
-  dstPool.freeze();
-  copy->bind(dstPool);
-
   REQUIRE(copy != nullptr);
   REQUIRE(copy->numVertices() == mesh->numVertices());
   REQUIRE(copy->numEdges() == mesh->numEdges());
@@ -989,12 +962,167 @@ TEMPLATE_TEST_CASE("MeshT: deepCopy preserves a prior flip() instead of silently
 
   auto copy = mesh->deepCopy(dstPool);
 
-  dstPool.freeze();
-  copy->bind(dstPool);
-
   for (uint32_t i = 0; i < mesh->numFaces(); i++) {
     REQUIRE((copy->getFace(i).getNormal() - mesh->getFace(i).getNormal()).length() < T(exactMargin<T>()));
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pool residency: a mesh stays queryable across everything its Pool does
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEMPLATE_TEST_CASE("MeshT: a mesh keeps answering after its Pool grows and moves the block",
+                   "[DCEL][Mesh][PoolResidency]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // Start deliberately tiny so the reserves below are certain to grow the block.
+  Pool pool(hostMemoryResource(), 64);
+
+  auto mesh = buildTetrahedron<T>(pool);
+
+  const Vec3T<T> p(0.1, 0.1, 0.1);
+
+  const void* const baseBeforeGrow = pool.base();
+  const T           before         = mesh->signedDistance(p);
+  const Vec3T<T>    vertexBefore   = mesh->getVertex(0).getPosition();
+
+  // Keep building into the same Pool. Under the old freeze-then-bind contract this was impossible:
+  // querying required a frozen Pool, and reserving into a frozen Pool aborts.
+  auto second = buildTetrahedron<T>(pool);
+
+  REQUIRE(pool.base() != baseBeforeGrow); // the block really did move
+
+  // Same answers, with no rebinding of any kind.
+  REQUIRE_THAT(mesh->signedDistance(p), withinAbsT(before, exactMargin<T>()));
+  REQUIRE(mesh->getVertex(0).getPosition() == vertexBefore);
+  REQUIRE_THAT(second->signedDistance(p), withinAbsT(before, exactMargin<T>()));
+
+  // Both meshes resolve through the same Pool, and know it.
+  REQUIRE(mesh->isAttachedTo(pool));
+  REQUIRE(second->isAttachedTo(pool));
+}
+
+TEMPLATE_TEST_CASE("MeshT: an element survives a growing reserve when carried by value",
+                   "[DCEL][Mesh][PoolResidency]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // The reference-returning accessors hand back an address resolved at the moment of the call, so
+  // a grow invalidates it (see the warning on Pool::reserve). This is the sanctioned way to carry
+  // an element across a reserve: snapshot by value, then write back through a fresh accessor.
+  Pool pool(hostMemoryResource(), 64);
+
+  auto mesh = buildTetrahedron<T>(pool);
+
+  VertexT<T, DefaultMetaData> vertex = mesh->getVertex(0); // by value, deliberately not by reference
+
+  auto other = buildTetrahedron<T>(pool); // may grow, moving the block
+
+  vertex.setPosition(Vec3T<T>(7, 8, 9));
+  mesh->getVertex(0) = vertex; // fresh resolution against the current base
+
+  REQUIRE(mesh->getVertex(0).getPosition() == Vec3T<T>(7, 8, 9));
+
+  // The write landed in this mesh only.
+  REQUIRE(other->getVertex(0).getPosition() != Vec3T<T>(7, 8, 9));
+}
+
+TEMPLATE_TEST_CASE("MeshT: a mesh survives its Pool being moved, including a vector reallocation",
+                   "[DCEL][Mesh][PoolResidency]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // A mesh points at its Pool's control block, not at the Pool object, so relocating the Pool is
+  // invisible to it. The vector case is the sharp one: the source Pool is moved *and destroyed*.
+  std::vector<Pool> pools;
+  pools.reserve(1);
+  pools.emplace_back(hostMemoryResource());
+
+  auto mesh = buildTetrahedron<T>(pools[0]);
+
+  const Vec3T<T> p(0.1, 0.1, 0.1);
+  const T        before = mesh->signedDistance(p);
+
+  while (pools.size() < 16) {
+    pools.emplace_back(hostMemoryResource());
+  }
+
+  REQUIRE_THAT(mesh->signedDistance(p), withinAbsT(before, exactMargin<T>()));
+  REQUIRE(mesh->isAttachedTo(pools[0]));
+
+  // And again after a plain move-construction.
+  Pool moved(std::move(pools[0]));
+
+  REQUIRE_THAT(mesh->signedDistance(p), withinAbsT(before, exactMargin<T>()));
+  REQUIRE(mesh->isAttachedTo(moved));
+}
+
+TEMPLATE_TEST_CASE("MeshT: deepCopy into the same Pool is safe even when it grows",
+                   "[DCEL][Mesh][PoolResidency]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // deepCopy reserves three times from the destination Pool while reading the source. With the
+  // source and destination being the same Pool, those reserves move the very block being read
+  // from -- safe only because every read re-resolves through the control block.
+  Pool pool(hostMemoryResource(), 64);
+
+  auto mesh = buildTetrahedron<T>(pool);
+  auto copy = mesh->deepCopy(pool);
+
+  REQUIRE(copy->numVertices() == mesh->numVertices());
+  REQUIRE(copy->numFaces() == mesh->numFaces());
+
+  const Vec3T<T> p(0.1, 0.1, 0.1);
+  REQUIRE_THAT(copy->signedDistance(p), withinAbsT(mesh->signedDistance(p), formulaMargin<T>()));
+
+  for (uint32_t i = 0; i < mesh->numVertices(); i++) {
+    REQUIRE(copy->getVertex(i).getPosition() == mesh->getVertex(i).getPosition());
+  }
+}
+
+TEMPLATE_TEST_CASE("MeshT: rebasedView onto a host-to-host mirror answers identically",
+                   "[DCEL][Mesh][PoolResidency]",
+                   EBGEOMETRY_TEST_PRECISIONS)
+{
+  using T = TestType;
+
+  // The offset/rebase proof applied to real geometry rather than a synthetic struct, and without a
+  // GPU: mirroring host-to-host produces a byte-identical block at a different address, and the
+  // same descriptor must resolve against it unchanged.
+  Pool pool(hostMemoryResource());
+
+  auto mesh = buildTetrahedron<T>(pool);
+
+  pool.freeze();
+
+  Pool mirrored = Pool::mirror(pool, hostMemoryResource());
+
+  REQUIRE(mirrored.base() != pool.base());
+  REQUIRE(mirrored.mirrorOf() == pool.id());
+
+  const auto view = mesh->rebasedView(mirrored);
+
+  REQUIRE(view.isAttachedTo(mirrored));
+  REQUIRE(view.numVertices() == mesh->numVertices());
+  REQUIRE(view.numFaces() == mesh->numFaces());
+
+  const Vec3T<T> p(0.1, 0.1, 0.1);
+  REQUIRE_THAT(view.signedDistance(p), withinAbsT(mesh->signedDistance(p), exactMargin<T>()));
+
+  for (uint32_t i = 0; i < mesh->numVertices(); i++) {
+    REQUIRE(view.getVertex(i).getPosition() == mesh->getVertex(i).getPosition());
+  }
+
+  // The mirror is an independent copy: corrupting the source must not disturb the view.
+  std::memset(pool.base(), 0, pool.usedBytes());
+
+  REQUIRE_THAT(view.signedDistance(p), withinAbsT(mesh->rebasedView(mirrored).signedDistance(p), exactMargin<T>()));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1412,7 +1540,7 @@ TEMPLATE_TEST_CASE("MeshT/VertexT/EdgeT/FaceT/EdgeIteratorT: device query surfac
 
   const T hostVal = baseTerms + meshSignedDist + windingDist + subtendedDist + flipConsistency;
 
-  const TestMesh<T> deviceView = mesh->boundView(devicePool.base());
+  const TestMesh<T> deviceView = mesh->rebasedView(devicePool);
 
   DeviceBuffer<T> deviceOut;
 

--- a/Tests/TestDCEL.cpp
+++ b/Tests/TestDCEL.cpp
@@ -71,9 +71,6 @@ buildTetrahedron(Pool& a_pool)
   auto mesh = std::make_shared<MeshT<T, DefaultMetaData>>();
   Soup::soupToDCEL(*mesh, a_pool, verts, facets, "tetrahedron-hard"); // reconciles internally
 
-  // See loadTetrahedron's comment: every call site below queries the returned mesh via its
-  // no-argument accessors, so this test helper freezes+binds a_pool on its caller's behalf.
-
   return mesh;
 }
 
@@ -751,12 +748,9 @@ TEMPLATE_TEST_CASE("MeshT: move construction and move assignment transfer owners
 {
   using T = TestType;
 
-  // Two separate pools -- buildTetrahedron freezes its pool before returning (see its doc), so
-  // reusing one pool across two builds would break the second build's reserveX() calls.
-  Pool poolA(hostMemoryResource());
-  Pool poolB(hostMemoryResource());
+  Pool pool(hostMemoryResource());
 
-  auto       moveCtorSrc = buildTetrahedron<T>(poolA);
+  auto       moveCtorSrc = buildTetrahedron<T>(pool);
   const auto v0Position  = moveCtorSrc->getVertex(0).getPosition();
 
   TestMesh<T> moved(std::move(*moveCtorSrc));
@@ -764,7 +758,7 @@ TEMPLATE_TEST_CASE("MeshT: move construction and move assignment transfer owners
   REQUIRE(moved.numFaces() == 4);
   REQUIRE(moved.getVertex(0).getPosition() == v0Position);
 
-  auto        moveAssignSrc = buildTetrahedron<T>(poolB);
+  auto        moveAssignSrc = buildTetrahedron<T>(pool);
   const auto  v0PositionB   = moveAssignSrc->getVertex(0).getPosition();
   TestMesh<T> moveAssignDst;
   moveAssignDst = std::move(*moveAssignSrc);
@@ -1506,7 +1500,7 @@ TEMPLATE_TEST_CASE("MeshT/VertexT/EdgeT/FaceT/EdgeIteratorT: device query surfac
   }
 
   Pool hostPool(hostMemoryResource());
-  auto mesh = buildTetrahedron<T>(hostPool); // freezes+binds hostPool
+  auto mesh = buildTetrahedron<T>(hostPool);
 
   const Vec3T<T> point(2.0, 2.0, 2.0);
 

--- a/Tests/TestOBJ.cpp
+++ b/Tests/TestOBJ.cpp
@@ -130,9 +130,6 @@ TEMPLATE_TEST_CASE("OBJ: convertToDCEL builds a mesh with the correct compressed
   Pool pool(hostMemoryResource());
   auto mesh = obj.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
-  // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
-  // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.
   REQUIRE(mesh->numFaces() == 4);

--- a/Tests/TestOBJ.cpp
+++ b/Tests/TestOBJ.cpp
@@ -132,8 +132,6 @@ TEMPLATE_TEST_CASE("OBJ: convertToDCEL builds a mesh with the correct compressed
 
   // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
   // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-  pool.freeze();
-  mesh->bind(pool);
 
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.

--- a/Tests/TestPLY.cpp
+++ b/Tests/TestPLY.cpp
@@ -160,9 +160,6 @@ TEMPLATE_TEST_CASE("PLY: convertToDCEL builds a mesh with the correct compressed
   Pool pool(hostMemoryResource());
   auto mesh = ply.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
-  // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
-  // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.
   REQUIRE(mesh->numFaces() == 4);

--- a/Tests/TestPLY.cpp
+++ b/Tests/TestPLY.cpp
@@ -162,8 +162,6 @@ TEMPLATE_TEST_CASE("PLY: convertToDCEL builds a mesh with the correct compressed
 
   // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
   // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-  pool.freeze();
-  mesh->bind(pool);
 
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.

--- a/Tests/TestPolygon2D.cpp
+++ b/Tests/TestPolygon2D.cpp
@@ -88,14 +88,11 @@ struct BuiltFace
     }
 
     for (uint32_t i = 0; i < N; i++) {
-      m_mesh.getEdge(m_pool.base(), i).setNextEdge((i + 1) % N);
-      m_mesh.getEdge(m_pool.base(), i).setFace(0);
+      m_mesh.getEdge(i).setNextEdge((i + 1) % N);
+      m_mesh.getEdge(i).setFace(0);
     }
 
     m_mesh.addFace(m_pool, Face(0u)); // half-edge index 0
-
-    m_pool.freeze();
-    m_mesh.bind(m_pool);
 
     m_mesh.getFace(0).reconcile(m_mesh);
   }

--- a/Tests/TestPool.cpp
+++ b/Tests/TestPool.cpp
@@ -187,6 +187,20 @@ TEST_CASE("Pool: mirror of a non-frozen pool aborts", "[Pool][death]")
   }));
 }
 
+TEST_CASE("Pool: reserving from a moved-from pool aborts", "[Pool][death]")
+{
+  // A moved-from pool owns no control block, so there is nowhere to publish a base. This abort is
+  // always-on rather than an EBGEOMETRY_EXPECT (a release build would otherwise dereference null),
+  // but the death-test helper itself only exists under assertions.
+  REQUIRE(abortsUnderAssertions([] {
+    Pool source(hostMemoryResource(), 128);
+    Pool moved(std::move(source));
+
+    PODVector<double> vec;
+    vec.reserveFrom(source, 4); // must abort
+  }));
+}
+
 #endif // EBGEOMETRY_ENABLE_ASSERTIONS
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -242,6 +256,105 @@ TEST_CASE("Pool: move assignment frees the target's old block and steals the sou
 
   for (uint32_t i = 0; i < 4; i++) {
     REQUIRE(vec.at(target.base(), i) == double(i) + 0.5);
+  }
+}
+
+TEST_CASE("Pool: the control block survives a move, including a vector reallocation", "[Pool]")
+{
+  // The reason a pool-resident object stores a PoolControl* rather than a Pool*: moving a Pool must
+  // not disturb anything resolving through it. A std::vector<Pool> reallocation is the sharp case,
+  // since it moves *and then destroys* the source object rather than merely emptying it.
+  std::vector<Pool> pools;
+  pools.reserve(1);
+  pools.emplace_back(hostMemoryResource(), 512);
+
+  const PoolControl* control = pools[0].control();
+  const uint64_t     id      = pools[0].id();
+
+  REQUIRE(control != nullptr);
+  REQUIRE(id != 0);
+
+  PODVector<double> vec;
+  vec.reserveFrom(pools[0], 8);
+
+  for (uint32_t i = 0; i < 8; i++) {
+    vec.push_back(pools[0].base(), double(i) + 0.25);
+  }
+
+  // Force a reallocation: pools[0] is move-constructed into fresh storage, and the original object
+  // is destroyed.
+  while (pools.size() < 16) {
+    pools.emplace_back(hostMemoryResource(), 64);
+  }
+
+  // Same control block, same identity, same data -- resolved without ever touching the (now dead)
+  // original Pool object.
+  REQUIRE(pools[0].control() == control);
+  REQUIRE(pools[0].id() == id);
+
+  for (uint32_t i = 0; i < 8; i++) {
+    REQUIRE(vec.at(control->m_base, i) == double(i) + 0.25);
+  }
+}
+
+TEST_CASE("Pool: a grow republishes the base through the control block", "[Pool]")
+{
+  // The other half of the contract: an object that re-resolves through the control block sees a
+  // grow immediately, with no freeze and no rebinding.
+  Pool pool(hostMemoryResource(), 64);
+
+  const PoolControl* control = pool.control();
+
+  PODVector<double> vec;
+  vec.reserveFrom(pool, 4);
+
+  for (uint32_t i = 0; i < 4; i++) {
+    vec.push_back(pool.base(), double(i) + 0.5);
+  }
+
+  void* const baseBeforeGrow = control->m_base;
+
+  PODVector<double> filler;
+  filler.reserveFrom(pool, 4096); // certain to exceed the 64-byte initial capacity
+
+  REQUIRE(control->m_base != baseBeforeGrow); // the block really did move
+  REQUIRE(pool.control() == control);         // but the control block did not
+
+  for (uint32_t i = 0; i < 4; i++) {
+    REQUIRE(vec.at(control->m_base, i) == double(i) + 0.5);
+  }
+}
+
+TEST_CASE("Pool: identities are unique and mirrorOf names the root of a chain", "[Pool]")
+{
+  Pool a(hostMemoryResource(), 128);
+  Pool b(hostMemoryResource(), 128);
+
+  REQUIRE(a.id() != b.id());
+  REQUIRE(a.mirrorOf() == 0); // not a mirror
+  REQUIRE(b.mirrorOf() == 0);
+
+  PODVector<double> vec;
+  vec.reserveFrom(a, 4);
+
+  for (uint32_t i = 0; i < 4; i++) {
+    vec.push_back(a.base(), double(i));
+  }
+
+  a.freeze();
+
+  const Pool hop1 = Pool::mirror(a, hostMemoryResource());
+  const Pool hop2 = Pool::mirror(hop1, hostMemoryResource());
+
+  // A mirror is its own pool, but every hop names the *root*, so an object built in `a` can still
+  // recognise `hop2` as a faithful copy of its own storage.
+  REQUIRE(hop1.id() != a.id());
+  REQUIRE(hop2.id() != hop1.id());
+  REQUIRE(hop1.mirrorOf() == a.id());
+  REQUIRE(hop2.mirrorOf() == a.id());
+
+  for (uint32_t i = 0; i < 4; i++) {
+    REQUIRE(vec.at(hop2.base(), i) == double(i));
   }
 }
 

--- a/Tests/TestSTL.cpp
+++ b/Tests/TestSTL.cpp
@@ -170,9 +170,6 @@ TEMPLATE_TEST_CASE("Parser::readSTL + convertToDCEL round-trips into a valid, wa
   Pool pool(hostMemoryResource());
   auto mesh = stl.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
-  // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
-  // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4);
   REQUIRE(mesh->numFaces() == 4);

--- a/Tests/TestSTL.cpp
+++ b/Tests/TestSTL.cpp
@@ -172,8 +172,6 @@ TEMPLATE_TEST_CASE("Parser::readSTL + convertToDCEL round-trips into a valid, wa
 
   // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
   // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-  pool.freeze();
-  mesh->bind(pool);
 
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4);

--- a/Tests/TestVTK.cpp
+++ b/Tests/TestVTK.cpp
@@ -160,9 +160,6 @@ TEMPLATE_TEST_CASE("VTK: convertToDCEL builds a mesh with the correct compressed
   Pool pool(hostMemoryResource());
   auto mesh = vtk.template convertToDCEL<DCEL::DefaultMetaData>(pool);
 
-  // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
-  // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.
   REQUIRE(mesh->numFaces() == 4);

--- a/Tests/TestVTK.cpp
+++ b/Tests/TestVTK.cpp
@@ -162,8 +162,6 @@ TEMPLATE_TEST_CASE("VTK: convertToDCEL builds a mesh with the correct compressed
 
   // convertToDCEL never freezes/binds pool itself (it may still be shared with more files -- see
   // Chap:MemoryModel), but mesh is queried below via its no-argument accessors.
-  pool.freeze();
-  mesh->bind(pool);
 
   REQUIRE(mesh != nullptr);
   REQUIRE(mesh->numVertices() == 4); // Compressed down to the 4 unique corners.


### PR DESCRIPTION
# Summary

### Background

`Pool::reserve` can grow the block, which moves it, which invalidates any base an object has cached. Until now that was handled by `freeze()`: seal the pool, then `bind()` each object to the now-stable base.

The cost was that **an object could not be queried until the whole pool was sealed**, so any workflow that keeps building — read ten STLs, deep-copy one, translate a few, read another — collided with a lifecycle decision that was only ever about pointer hygiene. The workarounds were already in the tree: `Examples/MeshSDF` used three pools because `FlatMeshSDF`/`MeshSDF`'s constructors froze, and `Parser::readIntoMesh(files, pool)` was "deliberately not a loop over the single-file overload" for the same reason.

This is step 1 of the roadmap in `PORTING.md`; the design was agreed in `PLAN.md` before any code was written, and the BVH port (step 2) depends on it.

### Solution

A `Pool` now publishes its base through a heap-resident `PoolControl`, and pool-resident objects hold a pointer to *that* rather than to the base itself, re-reading it on every access. A grow is therefore invisible to them, and `freeze()` survives only as the precondition for `mirror()` — a rule that justifies itself ("you cannot copy a block that might still move") rather than a precondition on asking a question.

**Why a control block rather than a `Pool*`.** `MeshT` previously cached the block address, and `Pool`'s move constructor steals that address verbatim, so a mesh survived its pool being moved. Pointing the mesh at the `Pool` object would have silently broken `std::vector<Pool>` reallocation, pools held as class members, and factories returning a pool alongside its geometry — all of which work against the current code, none of which would have drawn a reviewer's eye in the diff. The control block's address does not change when the `Pool` moves, so that property is preserved.

**What this deletes from `DCEL::MeshT`:** `bind()`, `boundView()`, every explicit-base overload (public and protected), and the `deepCopy(srcBase, dstPool)` form. The accessor surface roughly halves.

**The one crossing point** is now `rebasedView(const Pool&)`. It takes the `Pool` rather than a bare base so it can check that the target really is a mirror of the mesh's own pool and is large enough to hold its arrays, and it uses `isDeviceAccessible()` as a **discriminator** rather than an assertion:

- a device-accessible target yields a view holding a plain base address, since a kernel cannot follow a host control block;
- a host target yields a view holding *that* pool's control block, so host-to-host rebasing keeps working and stays growth-immune.

That second branch is what makes a null control block mean "device view" and nothing else, so `base()`'s assertions are exact in both directions rather than best-effort: a non-null control block on device means a host descriptor reached a kernel directly, and a null one on the host means a device view is being dereferenced there. It also keeps the rebase invariant testable on real geometry **without a GPU**, which matters because CI has no device.

**A latent use-after-free is fixed on the way:** `deepCopy(srcBase, dstPool)` documented `dstPool` as possibly being the source's own pool, but cached `srcBase` across three reserves that could move the block out from under it. The new form re-resolves on every read, so it is correct by construction.

Supporting additions: `Pool::id()`/`mirrorOf()`/`control()`, `PODVector::endByte()`, `MeshT::isAttachedTo()`. `mirrorOf()` names the **root** of a mirror chain rather than the immediate source, so staging through pinned memory on the way to a device still validates against the pool the geometry was built in.

### Side-effects

Two properties are no longer enforced by the type system and must be carried by documentation instead. Both are now documented on `Pool::reserve`, on `PODVector`'s class block, on `MeshT`'s reference-returning accessors, and in `MemoryModel.rst`:

- **A resolved address does not survive a `reserve`.** A reference from `getVertex`/`getEdge`/`getFace`, or a `PODSpan` from `bind()`, points into a block that a growing `reserve` deallocates. The freeze state machine previously made this unreachable for users; allowing mid-build queries makes it reachable. The rule is *resolve, use, discard* — carry elements across a `reserve` by value and write them back through a fresh accessor call. Everything returning by value (`signedDistance()`, `getAllVertexCoordinates()`, …) is unaffected.
- **Querying while another thread reserves from the same pool is a data race.** Pools are not internally synchronized; previously the freeze rule made this structurally impossible.

Also note that the "mirror a host descriptor into a kernel" mistake goes from structurally impossible (#140) to possible-but-asserted. The assertions are exact, and every realistic error path is caught at the point of the mistake rather than as a garbage kernel result — but `EBGEOMETRY_EXPECT` compiles out in the release presets, so this is a debug-time guarantee rather than a type-level one.

API changes visible to users: `Soup::reconcilePairEdgesDCEL` loses its now-unused `Pool` parameter; the multi-file `readIntoMesh`/`readIntoPackedBVH` overloads became plain loops over the single-file form; `Examples/MeshSDF` and the AMReX `PaintEB` integration collapse to one pool and drop their freeze/bind calls.

### Alternative solutions

- **Store a `Pool*` and resolve `m_pool->base()`.** Simpler, and was the original plan — rejected because it regresses `Pool` movability as described above, in ways an `EBGEOMETRY_EXPECT` cannot catch (a moved-from pool that has since been destroyed is a read of freed memory, and assertions are off in release).
- **Make `Pool` immovable.** Airtight, but `mirror()` returns by value, and it would stop users putting pools in containers at all.
- **Handle/descriptor split** — a host handle owning the `Pool&` plus a POD descriptor that crosses. Preserves the type-level guarantee, but the cost is not "two types and an API break": every `FaceT`/`EdgeT`/`VertexT` method takes a `const Mesh&`, so a second mesh type means templating the whole DCEL element API. That is the actual reason for accepting the weaker guarantee here.
- **Reserve address space up front so the base never moves.** A guarantee that only holds when someone sized the pool correctly is not a guarantee, and pools get created ad hoc deep inside third-party code.
- **Separate `viewIn` and `deviceView` functions.** Collapsed into one once the host branch was made to follow the target's control block — the accessibility predicate then selects behaviour rather than rejecting it, and no choice is pushed onto the caller.

### Testing

`313` unit tests pass under `debug` and `debug-san` (ASan/UBSan), `319` under `release-test`, and all `11` examples run to completion. Every pre-commit hook passes, including clang-tidy, Doxygen (warnings as errors), and both Sphinx builds.

New cases cover what was previously untestable:

- query an object, force the pool to grow, query again — same answers, no rebinding;
- a mesh surviving its `Pool` being moved, **including a `std::vector<Pool>` reallocation**, which destroys the source object rather than merely emptying it (the case a `Pool*` design fails);
- `deepCopy` into the *same* pool, i.e. the latent use-after-free above;
- snapshot-and-write-back across a grow — the reference path, not just the value path, since a value-only test would pass while the dangling-reference hazard was wide open;
- a `MeshT`-level host-to-host `rebasedView`, which exercises the rebase invariant on real geometry in CI without a GPU;
- `Pool` identity and transitive `mirrorOf` across a two-hop chain, and an abort on reserving from a moved-from pool.

Not verified: the CUDA/HIP `[gpu]` paths were not run on a device for this PR. `MeshT::rebasedView`'s device branch is exercised by `TestDCEL`'s existing `[gpu]` case, which needs a local GPU run before this is merged.

### Reviewer checklist (to be completed by a human)

- [x] The test suite compiles and runs to completion without warnings or errors.
- [x] All relevant new features are documented in the user documentation (Sphinx).
- [x] This contribution does not break existing sections in the user documentation. 
- [x] All relevant APIs are documented in the doxygen documentation.
- [x] Appropriate labels have been assigned to this PR.
- [x] New or revised proper licensing and copyright information is in place.
- [x] A PR review has been run using `@claude review`.
- [x] The continuous integration and testing hooks at GitHub run to completion.
